### PR TITLE
onboarding fixes for expiration, deposit, withdraw docs, and positions errors

### DIFF
--- a/contracts/market/src/deposit.rs
+++ b/contracts/market/src/deposit.rs
@@ -110,6 +110,7 @@ pub fn deposit_collateral(
 mod tests {
     use super::*;
     use crate::types::Market;
+    use soroban_sdk::token::StellarAssetClient;
     use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
 
     fn setup_env() -> Env {
@@ -277,5 +278,37 @@ mod tests {
         });
 
         assert_eq!(result, Err(ContractError::InvalidQuantity));
+    }
+
+    #[test]
+    fn test_deposit_updates_position_collateral() {
+        let env = setup_env();
+        let user = Address::generate(&env);
+        let market_id = 1;
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let collateral_token = token.address();
+        let contract_id = env.register(crate::MarketContract, ());
+
+        let market = create_test_market(&env, market_id, &collateral_token);
+        env.as_contract(&contract_id, || {
+            storage::set_market(&env, market_id, &market);
+        });
+
+        env.mock_all_auths();
+        let token_client = StellarAssetClient::new(&env, &collateral_token);
+        token_client.mint(&user, &10_000);
+
+        let deposit_amount = 5_000i128;
+        let result = env.as_contract(&contract_id, || {
+            deposit_collateral(env.clone(), user.clone(), market_id, deposit_amount)
+        });
+        assert!(result.is_ok());
+
+        let position = env.as_contract(&contract_id, || {
+            storage::get_position(&env, market_id, &user).expect("position should exist")
+        });
+        assert_eq!(position.total_deposited, deposit_amount);
+        assert_eq!(position.locked_collateral, deposit_amount);
     }
 }

--- a/contracts/market/src/positions.rs
+++ b/contracts/market/src/positions.rs
@@ -1,9 +1,17 @@
-use crate::error::ContractError;
 use crate::types::{Market, Position};
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{contracterror, Address, Env};
 
 const BASIS_POINTS: i128 = 10_000;
 pub const STROOPS_PER_USDC: i128 = 10_000_000;
+
+/// Errors returned by position validation and update operations.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum PositionError {
+    /// Proposed YES or NO share change would reduce that side below zero
+    ShareBalanceBelowZero = 1,
+}
 
 /// Calculate required locked collateral based on net position
 ///
@@ -34,17 +42,21 @@ pub fn calculate_locked_collateral(yes_shares: i128, no_shares: i128, market_pri
     }
 }
 
-/// Validate whether a proposed position change is allowed
+/// Validate whether a proposed position change is allowed.
+///
+/// # Errors
+/// Returns [`PositionError::ShareBalanceBelowZero`] when `yes_delta` or
+/// `no_delta` would leave either share balance negative.
 pub fn validate_position_change(
     current_position: &Position,
     yes_delta: i128,
     no_delta: i128,
-) -> Result<(), ContractError> {
+) -> Result<(), PositionError> {
     let new_yes = current_position.yes_shares + yes_delta;
     let new_no = current_position.no_shares + no_delta;
 
     if new_yes < 0 || new_no < 0 {
-        return Err(ContractError::InvalidShareAmount);
+        return Err(PositionError::ShareBalanceBelowZero);
     }
 
     Ok(())
@@ -79,7 +91,7 @@ pub fn can_settle(position: &Position, market: &Market) -> bool {
 /// Updated Position struct
 ///
 /// # Errors
-/// - InvalidShareAmount if deltas would make shares negative
+/// - [`PositionError::ShareBalanceBelowZero`] if deltas would make shares negative
 pub fn update_position(
     env: &Env,
     market_id: u32,
@@ -87,7 +99,7 @@ pub fn update_position(
     yes_delta: i128,
     no_delta: i128,
     market_price: i128,
-) -> Result<Position, ContractError> {
+) -> Result<Position, PositionError> {
     // 1. Load or initialize position
     let mut position =
         crate::storage::get_position(env, market_id, user).unwrap_or_else(|| Position {
@@ -185,8 +197,14 @@ mod tests {
         };
 
         assert!(validate_position_change(&position, 10, -20).is_ok());
-        assert!(validate_position_change(&position, -60, 0).is_err());
-        assert!(validate_position_change(&position, 0, -60).is_err());
+        assert_eq!(
+            validate_position_change(&position, -60, 0),
+            Err(PositionError::ShareBalanceBelowZero)
+        );
+        assert_eq!(
+            validate_position_change(&position, 0, -60),
+            Err(PositionError::ShareBalanceBelowZero)
+        );
     }
 
     #[test]

--- a/contracts/market/src/validation.rs
+++ b/contracts/market/src/validation.rs
@@ -18,6 +18,7 @@ pub fn validate_market_creation(
     }
 
     // End time must be in future (> current_time)
+    // TODO(#71): Reject post-expiration trading with MarketExpired, not only at creation
     if end_time <= current_time {
         return Err(ContractError::InvalidTimestamp);
     }

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -16,24 +16,36 @@ use soroban_sdk::{Address, Env};
 /// Market price used for locked collateral calculation (50/50 = 5000 basis points).
 const MARKET_PRICE_BPS: i128 = 5_000;
 
-/// Withdraw unused collateral from a market
+/// Withdraw unused collateral from a market.
+///
+/// Computes how much collateral is locked by the user's YES/NO shares at the
+/// current 50/50 market price, then allows withdrawing any remaining balance.
 ///
 /// # Arguments
 /// * `env` - Contract environment
-/// * `user` - User withdrawing
+/// * `user` - User withdrawing (must authorize the call)
 /// * `market_id` - Market to withdraw from
-/// * `amount` - Amount to withdraw in stroops
+/// * `amount` - Amount to withdraw in stroops (1 USDC = 10^7 stroops)
 ///
 /// # Returns
-/// Unit (success)
+/// `Ok(())` on success.
 ///
 /// # Errors
-/// - MarketNotFound
-/// - InsufficientCollateral: Trying to withdraw locked collateral
-/// - InvalidQuantity: Amount <= 0
+/// - `MarketNotFound`: The market does not exist
+/// - `MarketNotActive`: The market is resolved or canceled
+/// - `InsufficientCollateral`: `amount` exceeds unlocked collateral
+/// - `InvalidQuantity`: `amount` is zero or negative
+/// - `ArithmeticOverflow`: Subtracting `amount` would overflow
 ///
 /// # Events
-/// Emits CollateralWithdrawn event
+/// Emits `CollateralWithdrawn` with the user, market, amount, and new total.
+///
+/// # Examples
+/// ```
+/// // Withdraw 0.1 USDC (1_000_000 stroops) from an active market when the user
+/// // has at least that much unlocked collateral:
+/// withdraw_unused_collateral(env, user, market_id, 1_000_000)?;
+/// ```
 pub fn withdraw_unused_collateral(
     env: Env,
     user: Address,


### PR DESCRIPTION
# feat(contracts): onboarding fixes for expiration, deposit, withdraw docs, and positions errors

## Summary

- Add a TODO with GitHub issue link near the market expiration validation.
- Introduce a new unit test that exercises successful deposit behavior in the deposit module.
- Improve documentation for the withdraw module’s public API.
- Clarify error semantics in the positions module with a more descriptive error type.

## Changes

### Issue #71 – Add TODO with Issue Link Near Expiration Check

- Added `// TODO(#71): Reject post-expiration trading with MarketExpired, not only at creation` directly above the `end_time <= current_time` check in `validation::validate_market_creation`.

### Issue #72 – Add Unit Test Case for Deposit Module

- In `deposit.rs` tests, added `test_deposit_updates_position_collateral`:
  - Uses `Env::register_stellar_asset_contract_v2` and `StellarAssetClient` to mint test tokens.
  - Calls `deposit_collateral` and asserts that `Position.total_deposited` and `locked_collateral` match the deposited amount for the user/market.

### Issue #73 – Add Doc Comment to Withdraw Module

- Expanded the doc comments for `withdraw_unused_collateral`:
  - Clarified behavior, arguments, and detailed error cases.
  - Added a short `# Examples` block illustrating a typical withdrawal call when the user has unlocked collateral.

### Issue #74 – Improve Error Message in Positions Module

- Added a `PositionError` enum (with `ShareBalanceBelowZero`) in `positions.rs`.
- Updated `validate_position_change` and `update_position` to return `PositionError` instead of the generic `ContractError::InvalidShareAmount`.
- Adjusted tests to assert specifically on `PositionError::ShareBalanceBelowZero`, making failures more self-explanatory.

## Testing

- [x] `cargo fmt --all`
- [x] `cargo clippy -p vatix-market-contract -- -D warnings`
- [x] `cargo test -p vatix-market-contract` (85 tests passing, including `deposit::tests::test_deposit_updates_position_collateral`)

## Related issues

Closes #71  
Closes #72  
Closes #73  
Closes #74