### PR TITLE
Onboarding/contract tasks

### DIFF
--- a/contracts/market/src/error.rs
+++ b/contracts/market/src/error.rs
@@ -19,7 +19,8 @@ pub enum ContractError {
     /// Attempted to resolve a market that has already been resolved
     MarketAlreadyResolved = 2,
 
-    /// Attempted to settle positions before market resolution
+    /// Settlement was attempted but the market has not been resolved yet;
+    /// wait for the oracle to submit a valid resolution before settling
     MarketNotResolved = 3,
 
     /// Market has passed its end_time and is no longer active for trading
@@ -32,7 +33,8 @@ pub enum ContractError {
     /// User does not have enough collateral locked to perform this operation
     InsufficientCollateral = 10,
 
-    /// Attempted to settle a position that has already been settled
+    /// Settlement was attempted on a position that has already been paid out;
+    /// each position can only be settled once
     PositionAlreadySettled = 11,
 
     /// No position exists for this user in this market

--- a/contracts/market/src/oracle.rs
+++ b/contracts/market/src/oracle.rs
@@ -58,6 +58,11 @@ pub fn verify_oracle_signature(
     signature: &BytesN<64>,
     oracle_pubkey: &BytesN<32>,
 ) -> Result<(), ContractError> {
+    // Reject the all-zero pubkey — it is not a valid Ed25519 public key
+    if oracle_pubkey == &BytesN::from_array(env, &[0u8; 32]) {
+        return Err(ContractError::UnauthorizedOracle);
+    }
+
     // 1. Construct message to verify (market_id + outcome)
     let message = construct_oracle_message(env, market_id, outcome);
 
@@ -217,6 +222,19 @@ mod tests {
         let result = validate_oracle_authorization(&market, &wrong_pubkey);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), ContractError::UnauthorizedOracle);
+    }
+
+    #[test]
+    fn test_verify_signature_rejects_zero_pubkey() {
+        let env = Env::default();
+        let market_id = 1u32;
+        let outcome = true;
+        let zero_pubkey = BytesN::from_array(&env, &[0u8; 32]);
+        let signature = BytesN::from_array(&env, &[0u8; 64]);
+
+        let result =
+            verify_oracle_signature(&env, market_id, outcome, &signature, &zero_pubkey);
+        assert_eq!(result, Err(ContractError::UnauthorizedOracle));
     }
 
     #[test]

--- a/contracts/market/src/positions.rs
+++ b/contracts/market/src/positions.rs
@@ -13,12 +13,27 @@ pub enum PositionError {
     ShareBalanceBelowZero = 1,
 }
 
-/// Calculate required locked collateral based on net position
+/// Calculate required locked collateral based on net position.
 ///
-/// Logic:
-/// - Net YES  => lock net_yes * price
-/// - Net NO   => lock net_no * (1 - price)
-/// - Hedged   => lock 0
+/// # Arguments
+/// * `yes_shares` - Number of YES shares held
+/// * `no_shares` - Number of NO shares held
+/// * `market_price` - Current market price in basis points (0–10_000)
+///
+/// # Returns
+/// Collateral that must remain locked, in the same unit as the share values.
+///
+/// # Logic
+/// - Net YES  => lock `net_yes * price / 10_000`
+/// - Net NO   => lock `net_no * (10_000 - price) / 10_000`
+/// - Hedged   => lock `0`
+///
+/// # Example
+/// ```
+/// // 100 YES shares at a 60% price => 60 units locked
+/// let locked = calculate_locked_collateral(100, 0, 6_000);
+/// assert_eq!(locked, 60);
+/// ```
 pub fn calculate_locked_collateral(yes_shares: i128, no_shares: i128, market_price: i128) -> i128 {
     if yes_shares == no_shares {
         return 0;
@@ -62,16 +77,38 @@ pub fn validate_position_change(
     Ok(())
 }
 
-/// Calculate net position from YES and NO shares
+/// Calculate net position from YES and NO shares.
 ///
-/// Positive  => net long YES
-/// Negative  => net long NO
-/// Zero      => hedged
+/// # Arguments
+/// * `yes_shares` - Number of YES shares held
+/// * `no_shares` - Number of NO shares held
+///
+/// # Returns
+/// Positive value => net long YES, negative => net long NO, zero => hedged.
+///
+/// # Example
+/// ```
+/// assert_eq!(calculate_net_position(100, 30), 70);  // net long YES
+/// assert_eq!(calculate_net_position(30, 100), -70); // net long NO
+/// ```
 pub fn calculate_net_position(yes_shares: i128, no_shares: i128) -> i128 {
     yes_shares - no_shares
 }
 
-/// Check if a position is eligible for settlement
+/// Check if a position is eligible for settlement.
+///
+/// Returns `true` only when the market is `Resolved` and the position has not
+/// already been settled.
+///
+/// # Arguments
+/// * `position` - The user's position to check
+/// * `market` - The market the position belongs to
+///
+/// # Example
+/// ```
+/// // Returns false if position.is_settled == true, even on a resolved market.
+/// assert!(!can_settle(&settled_position, &resolved_market));
+/// ```
 pub fn can_settle(position: &Position, market: &Market) -> bool {
     use crate::types::MarketStatus;
     matches!(market.status, MarketStatus::Resolved) && !position.is_settled

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -298,4 +298,51 @@ mod tests {
         });
         assert_eq!(result, Err(ContractError::InsufficientCollateral));
     }
+
+    #[test]
+    fn test_withdraw_success_updates_position_and_transfers() {
+        use soroban_sdk::token::StellarAssetClient;
+
+        let env = setup_env();
+        let user = Address::generate(&env);
+        let market_id = 1u32;
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let collateral_token = token.address();
+        let contract_id = env.register(crate::MarketContract, ());
+
+        // Fund the contract with collateral (simulates prior deposit)
+        let token_client = StellarAssetClient::new(&env, &collateral_token);
+        token_client.mint(&contract_id, &200);
+
+        let market = create_test_market(&env, market_id, &collateral_token);
+        // No shares held -> required_lock = 0, available = total_deposited = 100
+        let position = Position {
+            market_id,
+            user: user.clone(),
+            yes_shares: 0,
+            no_shares: 0,
+            locked_collateral: 0,
+            total_deposited: 100,
+            is_settled: false,
+        };
+
+        env.as_contract(&contract_id, || {
+            storage::set_market(&env, market_id, &market);
+            storage::set_position(&env, market_id, &user, &position);
+        });
+
+        env.mock_all_auths();
+
+        let result = env.as_contract(&contract_id, || {
+            withdraw_unused_collateral(env.clone(), user.clone(), market_id, 40)
+        });
+        assert!(result.is_ok());
+
+        // Position total_deposited reduced by withdrawn amount
+        let updated = env.as_contract(&contract_id, || {
+            storage::get_position(&env, market_id, &user).expect("position should exist")
+        });
+        assert_eq!(updated.total_deposited, 60);
+    }
 }


### PR DESCRIPTION
# Onboarding contract tasks

Four small, focused improvements to `contracts/market` covering testing, documentation, error clarity, and input validation.

---

## Changes

closes #58 
closes #59 
closes #60 
closes #61 

### `test(withdraw)` — add happy-path test for `withdraw_unused_collateral`

The existing tests in `withdraw.rs` only covered error paths. Added `test_withdraw_success_updates_position_and_transfers` which:
- Mints tokens to the contract (simulating a prior deposit)
- Calls `withdraw_unused_collateral` with a valid amount against a position with no locked shares
- Asserts the call succeeds and `total_deposited` is reduced by the withdrawn amount

### `docs(positions)` — add doc comments to public items

Three public functions in `positions.rs` had missing or incomplete documentation:
- `calculate_locked_collateral` — added `# Arguments`, `# Returns`, and `# Example`
- `calculate_net_position` — added full doc comment with `# Arguments`, `# Returns`, and `# Example`
- `can_settle` — added full doc comment with `# Arguments` and `# Example`

### `fix(settlement)` — improve error messages for settlement variants

Two `ContractError` variants used by the settlement module had descriptions that just restated the variant name. Updated in `error.rs`:
- `MarketNotResolved` — now explains the market must be resolved by the oracle first
- `PositionAlreadySettled` — now explains each position can only be settled once

### `feat(oracle)` — reject all-zero pubkey in `verify_oracle_signature`

An all-zero `BytesN<32>` is not a valid Ed25519 public key. Without a guard, it would reach the crypto call and panic. Added an early return of `UnauthorizedOracle` when the pubkey is all zeros, and added `test_verify_signature_rejects_zero_pubkey` to cover the rejection.

---

## Checklist

- [x] Tests in `contracts/market`
- [x] Public items in `positions` documented with examples
- [x] Settlement error messages explain the failure
- [x] Oracle rejects invalid input with a test covering the rejection
- [ ] `cargo test` passes (no Rust toolchain in this environment — CI will validate)
