### PR TITLE
Onboarding/contract improvements

### DIFF
--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -125,6 +125,27 @@ pub fn emit_market_resolved(env: &Env, market_id: u32, outcome: bool, resolved_a
 
 #[contractevent]
 #[derive(Clone, Debug)]
+pub struct PositionLimitExceededEvent {
+    #[topic]
+    pub market_id: u32,
+    #[topic]
+    pub user: Address,
+    /// The share side that would go negative: true = YES, false = NO
+    pub side_yes: bool,
+}
+
+/// Emit an event when a position change is rejected due to share balance going below zero.
+pub fn emit_position_limit_exceeded(env: &Env, market_id: u32, user: &Address, side_yes: bool) {
+    PositionLimitExceededEvent {
+        market_id,
+        user: user.clone(),
+        side_yes,
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub struct PositionUpdatedEvent {
     #[topic]

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -26,7 +26,46 @@ pub struct MarketContract;
 
 #[contractimpl]
 impl MarketContract {
-    /// Initialize a new market
+    /// Create a new prediction market and return its unique identifier.
+    ///
+    /// Only the stored admin may call this function. The market starts in
+    /// [`MarketStatus::Active`] and accepts collateral deposits immediately.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban contract environment
+    /// * `creator` - Admin address that authorizes market creation
+    /// * `question` - Human-readable market question (1–499 characters)
+    /// * `end_time` - Unix timestamp after which trading closes (must be
+    ///   within one year of the current ledger time)
+    /// * `oracle_pubkey` - Ed25519 public key of the oracle that will sign
+    ///   the resolution outcome
+    /// * `collateral_token` - Address of the SAC token used as collateral
+    ///   (e.g. USDC)
+    ///
+    /// # Returns
+    /// The `u32` market ID assigned to the new market (auto-incremented).
+    ///
+    /// # Errors
+    /// - [`ContractError::Unauthorized`] – `creator` is not the admin
+    /// - [`ContractError::InvalidQuestion`] – question is empty or ≥ 500 chars
+    /// - [`ContractError::InvalidTimestamp`] – `end_time` is in the past or
+    ///   more than one year in the future
+    ///
+    /// # Events
+    /// Emits [`MarketCreatedEvent`] with `market_id`, `question`, and
+    /// `end_time` as payload.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let market_id = client.initialize_market(
+    ///     &admin,
+    ///     &String::from_str(&env, "Will BTC reach $100k by end of year?"),
+    ///     &(env.ledger().timestamp() + 86_400),
+    ///     &oracle_pubkey,
+    ///     &usdc_token,
+    /// );
+    /// assert_eq!(market_id, 1);
+    /// ```
     pub fn initialize_market(
         env: Env,
         creator: Address,

--- a/contracts/market/src/positions.rs
+++ b/contracts/market/src/positions.rs
@@ -1,3 +1,4 @@
+use crate::events::emit_position_limit_exceeded;
 use crate::types::{Market, Position};
 use soroban_sdk::{contracterror, Address, Env};
 
@@ -113,7 +114,11 @@ pub fn update_position(
         });
 
     // 2. Validate deltas
-    validate_position_change(&position, yes_delta, no_delta)?;
+    if let Err(e) = validate_position_change(&position, yes_delta, no_delta) {
+        let side_yes = position.yes_shares + yes_delta < 0;
+        emit_position_limit_exceeded(env, market_id, user, side_yes);
+        return Err(e);
+    }
 
     // 3. Apply deltas
     position.yes_shares += yes_delta;
@@ -246,6 +251,38 @@ mod tests {
         };
 
         assert!(!can_settle(&position, &market));
+    }
+
+    #[test]
+    fn test_update_position_limit_exceeded_emits_event() {
+        use soroban_sdk::testutils::Events as _;
+
+        let env = setup_env();
+        let contract_id = env.register(crate::MarketContract, ());
+        let user = sample_user(&env, 3);
+        let market_id = 3;
+
+        let result = env.as_contract(&contract_id, || {
+            // Try to sell 50 YES shares the user doesn't have
+            update_position(&env, market_id, &user, -50, 0, 5000)
+        });
+
+        assert_eq!(result, Err(PositionError::ShareBalanceBelowZero));
+
+        let events = env.events().all();
+        assert_eq!(events.len(), 1);
+
+        let topic0: soroban_sdk::Symbol = events
+            .first()
+            .unwrap()
+            .1
+            .get(0)
+            .unwrap()
+            .into_val(&env);
+        assert_eq!(
+            topic0,
+            soroban_sdk::Symbol::new(&env, "position_limit_exceeded_event")
+        );
     }
 
     #[test]

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -72,6 +72,10 @@ pub fn withdraw_unused_collateral(
         is_settled: false,
     });
 
+    if position.total_deposited == 0 {
+        return Err(ContractError::InsufficientCollateral);
+    }
+
     let required_lock =
         calculate_locked_collateral(position.yes_shares, position.no_shares, MARKET_PRICE_BPS);
     let available = position
@@ -237,6 +241,38 @@ mod tests {
         // Try to withdraw 60 when only 50 is available
         let result = env.as_contract(&contract_id, || {
             withdraw_unused_collateral(env.clone(), user.clone(), market_id, 60)
+        });
+
+        assert_eq!(result, Err(ContractError::InsufficientCollateral));
+    }
+
+    #[test]
+    fn test_withdraw_zero_deposited_rejected() {
+        let env = setup_env();
+        let user = Address::generate(&env);
+        let market_id = 1u32;
+        let collateral_token = Address::generate(&env);
+        let contract_id = env.register(crate::MarketContract, ());
+
+        let market = create_test_market(&env, market_id, &collateral_token);
+        let position = Position {
+            market_id,
+            user: user.clone(),
+            yes_shares: 0,
+            no_shares: 0,
+            locked_collateral: 0,
+            total_deposited: 0,
+            is_settled: false,
+        };
+        env.as_contract(&contract_id, || {
+            storage::set_market(&env, market_id, &market);
+            storage::set_position(&env, market_id, &user, &position);
+        });
+
+        env.mock_all_auths();
+
+        let result = env.as_contract(&contract_id, || {
+            withdraw_unused_collateral(env.clone(), user.clone(), market_id, 1)
         });
 
         assert_eq!(result, Err(ContractError::InsufficientCollateral));

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,3 +1,33 @@
-fn _todo() {
-    todo!()
+use soroban_sdk::{Address, BytesN, Env, String};
+
+/// Failure reasons for the integration test harness.
+#[derive(Debug, PartialEq)]
+pub enum HarnessError {
+    /// Market initialization failed: the contract rejected the provided parameters.
+    /// Check that `end_time` is in the future and `question` is non-empty.
+    MarketInitFailed,
+
+    /// Storage lookup returned None for the given market_id.
+    /// The market was never created or the wrong id was queried.
+    MarketNotFound,
+}
+
+/// Minimal market parameters used across integration tests.
+pub struct MarketParams {
+    pub question: String,
+    pub end_time: u64,
+    pub oracle_pubkey: BytesN<32>,
+    pub collateral_token: Address,
+}
+
+impl MarketParams {
+    /// Build a default valid set of params relative to the current ledger time.
+    pub fn default_valid(env: &Env) -> Self {
+        Self {
+            question: String::from_str(env, "Will BTC reach $100k?"),
+            end_time: env.ledger().timestamp() + 86_400,
+            oracle_pubkey: BytesN::from_array(env, &[1u8; 32]),
+            collateral_token: Address::generate(env),
+        }
+    }
 }


### PR DESCRIPTION
# Onboarding: contract improvements

Four small onboarding tasks, one commit each.

---

## Changes

closes #66 
closes #67 
closes #68 
closes #69 

### 1. `fix(withdraw)` — validation guard for zero-deposit edge case

`withdraw_unused_collateral` previously relied on `checked_sub(...).unwrap_or(0)` to
silently produce `available = 0` when `total_deposited` was zero. The intent was correct
but the path was implicit. An explicit early guard now rejects the call with
`InsufficientCollateral` before any arithmetic runs.

**Files:** `contracts/market/src/withdraw.rs`

- Added guard: `if position.total_deposited == 0 { return Err(ContractError::InsufficientCollateral); }`
- Added `test_withdraw_zero_deposited_rejected` covering the rejection path

---

### 2. `test(helpers)` — clear error variants in integration test harness

`tests/helpers/mod.rs` contained only a `todo!()` stub, giving no signal when a test
setup step failed. Replaced with a typed `HarnessError` enum whose variants carry doc
comments explaining the failure cause, and a `MarketParams` struct with a
`default_valid` constructor to reduce boilerplate across integration tests.

**Files:** `tests/helpers/mod.rs`

- `HarnessError::MarketInitFailed` — explains what to check when init is rejected
- `HarnessError::MarketNotFound` — explains the storage lookup failure
- `MarketParams::default_valid(env)` — reusable baseline for integration test setup

---

### 3. `docs(lib)` — doc comment on `initialize_market`

The public entry point had a single-line comment with no argument, error, or event
documentation. Added a full doc comment aligned with the style used on
`deposit_collateral` and `withdraw_unused_collateral`.

**Files:** `contracts/market/src/lib.rs`

- Documents all six parameters
- Lists all three error variants with descriptions
- Notes the emitted `MarketCreatedEvent`
- Includes an `# Example` block showing typical client usage

---

### 4. `feat(positions)` — emit event when position limit is exceeded

`update_position` returned `ShareBalanceBelowZero` silently. Off-chain indexers and
tests had no observable signal for the rejection. A new `PositionLimitExceededEvent`
is now emitted before the error is returned, carrying `market_id`, `user`, and
`side_yes` (which share side would go negative).

**Files:** `contracts/market/src/events.rs`, `contracts/market/src/positions.rs`

- `PositionLimitExceededEvent` defined in `events.rs` with `emit_position_limit_exceeded`
- `update_position` emits the event before returning the error
- `test_update_position_limit_exceeded_emits_event` asserts the event topic

---

## Checklist

- [x] Invalid withdraw input rejected with explicit guard
- [x] Test covers the zero-deposit rejection
- [x] `HarnessError` variants have clear names and explanatory messages
- [x] `initialize_market` public items fully documented with example
- [x] `PositionLimitExceededEvent` defined in `events.rs`
- [x] Test asserts event emission on position limit breach
- [x] One commit per issue
- [ ] CI passing
