### PR TITLE
 Add a no-layout-shift loading skeleton 

### DIFF
--- a/apps/web/app/markets/page.tsx
+++ b/apps/web/app/markets/page.tsx
@@ -8,13 +8,28 @@ export default function MarketsPage() {
       <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
         Mock data for UI development — replace with Soroban contract reads.
       </p>
-      <ul className="mt-8 grid gap-4 sm:grid-cols-2">
-        {MOCK_MARKETS.map((market) => (
-          <li key={market.id}>
-            <MarketCard market={market} />
-          </li>
-        ))}
-      </ul>
+      {MOCK_MARKETS.length === 0 ? (
+        <div className="mt-8 rounded-xl border border-slate-200 p-6 text-sm dark:border-slate-700">
+          <p className="font-medium">No markets yet</p>
+          <p className="mt-1 text-slate-600 dark:text-slate-400">
+            Check back soon, or browse the home page for updates.
+          </p>
+          <a
+            href="/"
+            className="mt-4 inline-flex rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500"
+          >
+            Back to home
+          </a>
+        </div>
+      ) : (
+        <ul className="mt-8 grid gap-4 sm:grid-cols-2">
+          {MOCK_MARKETS.map((market) => (
+            <li key={market.id}>
+              <MarketCard market={market} />
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -15,7 +15,7 @@ export default function HomePage() {
         </p>
         <Link
           href="/markets"
-          className="mt-4 inline-flex rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500"
+          className="mt-4 inline-flex rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
         >
           Browse markets
         </Link>

--- a/apps/web/components/MarketCard.tsx
+++ b/apps/web/components/MarketCard.tsx
@@ -2,38 +2,69 @@ import type { Market } from "@/lib/markets";
 
 interface MarketCardProps {
   market: Market;
+  loading?: boolean;
 }
 
-export function MarketCard({ market }: MarketCardProps) {
+export function MarketCard({ market, loading = false }: MarketCardProps) {
   const yesPct = Math.round(market.yesPrice * 100);
 
   return (
-    <article className="rounded-xl border border-slate-200 p-4 dark:border-slate-700">
+    <article
+      className={`rounded-xl border border-slate-200 p-4 dark:border-slate-700${
+        loading ? " animate-pulse" : ""
+      }`}
+    >
       <p className="text-xs uppercase tracking-wide text-slate-500">
-        {market.status} · ends {market.endsAt}
+        {loading ? (
+          <span className="inline-block h-3 w-40 rounded bg-slate-200 align-middle dark:bg-slate-800" />
+        ) : (
+          <>
+            {market.status} · ends {market.endsAt}
+          </>
+        )}
       </p>
-      <h3 className="mt-2 font-medium leading-snug">{market.question}</h3>
+      <h3 className="mt-2 font-medium leading-snug">
+        {loading ? (
+          <span className="block h-5 w-full rounded bg-slate-200 dark:bg-slate-800" />
+        ) : (
+          market.question
+        )}
+      </h3>
       <div className="mt-4 flex items-end justify-between text-sm">
         <div>
-          <span className="text-emerald-600 dark:text-emerald-400">
-            Yes {yesPct}%
-          </span>
-          <span className="mx-2 text-slate-400">·</span>
-          <span className="text-rose-600 dark:text-rose-400">
-            No {100 - yesPct}%
-          </span>
+          {loading ? (
+            <span className="inline-block h-4 w-28 rounded bg-slate-200 dark:bg-slate-800" />
+          ) : (
+            <>
+              <span className="text-emerald-600 dark:text-emerald-400">
+                Yes {yesPct}%
+              </span>
+              <span className="mx-2 text-slate-400">·</span>
+              <span className="text-rose-600 dark:text-rose-400">
+                No {100 - yesPct}%
+              </span>
+            </>
+          )}
         </div>
-        <span className="text-slate-500">Vol {market.volume}</span>
+        {loading ? (
+          <span className="inline-block h-4 w-16 rounded bg-slate-200 dark:bg-slate-800" />
+        ) : (
+          <span className="text-slate-500">Vol {market.volume}</span>
+        )}
       </div>
       <div className="mt-3 h-2 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
-        <div
-          className="h-full bg-emerald-500"
-          style={{ width: `${yesPct}%` }}
-          role="progressbar"
-          aria-valuenow={yesPct}
-          aria-valuemin={0}
-          aria-valuemax={100}
-        />
+        {loading ? (
+          <div className="h-full w-2/3 bg-slate-200 dark:bg-slate-700" />
+        ) : (
+          <div
+            className="h-full bg-emerald-500"
+            style={{ width: `${yesPct}%` }}
+            role="progressbar"
+            aria-valuenow={yesPct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          />
+        )}
       </div>
     </article>
   );

--- a/apps/web/components/Navbar.tsx
+++ b/apps/web/components/Navbar.tsx
@@ -21,6 +21,7 @@ export function Navbar() {
               type="button"
               onClick={disconnect}
               className="rounded-lg border border-slate-300 px-3 py-1.5 dark:border-slate-600"
+              aria-label="Disconnect wallet"
             >
               {truncateAddress(address)}
             </button>
@@ -30,6 +31,7 @@ export function Navbar() {
               disabled={isConnecting}
               onClick={() => void connect()}
               className="rounded-lg bg-indigo-600 px-3 py-1.5 text-white hover:bg-indigo-500 disabled:opacity-60"
+              aria-label={isConnecting ? "Connecting wallet" : "Connect wallet"}
             >
               {isConnecting ? "Connecting…" : "Connect wallet"}
             </button>


### PR DESCRIPTION
## Summary

- Add a no-layout-shift loading skeleton to `MarketCard` (#38)
- Add an empty state + CTA for the markets list when there are no markets (#39)
- Improve keyboard focus visibility for the HomePage primary CTA (#40)
- Add `aria-label`s to wallet connect/disconnect actions for better accessible naming (#41)

## Test plan

- Visit `/markets` and confirm the empty state renders when the markets list is empty (non-empty list still renders unchanged).
- On the home page, press Tab until “Browse markets” is focused and confirm a visible focus ring appears.
- In the navbar:
  - With no wallet connected, inspect the connect button and confirm it has an accessible name via `aria-label`.
  - With a wallet connected, inspect the disconnect button and confirm it has an accessible name via `aria-label`.
- Render `MarketCard` with `loading={true}` and confirm the skeleton matches the loaded card’s layout (no shift when swapping to real data).

closes #38 
closes #39 
closes #40 
closes #41 