### PR TITLE
feat: add event emission for withdraw edge case when user has zero co…

### DIFF
--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -33,6 +33,16 @@ pub struct CollateralWithdrawnEvent {
     pub new_total: i128,
 }
 
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct WithdrawEdgeCaseEvent {
+    #[topic]
+    pub user: Address,
+    #[topic]
+    pub market_id: u32,
+    pub amount: i128,
+}
+
 /// Emit event when collateral is deposited
 ///
 /// # Arguments
@@ -94,6 +104,27 @@ pub fn emit_market_created(env: &Env, market_id: u32, question: &String, end_tim
         market_id,
         question: question.clone(),
         end_time,
+    }
+    .publish(env);
+}
+
+/// Emit event for withdraw edge case when user has zero collateral deposited
+///
+/// # Arguments
+/// * env - Soroban environment
+/// * user - User's address
+/// * market_id - Market identifier
+/// * amount - Amount attempted to withdraw in stroops
+pub fn emit_withdraw_edge_case(
+    env: &Env,
+    user: &Address,
+    market_id: u32,
+    amount: i128,
+) {
+    WithdrawEdgeCaseEvent {
+        user: user.clone(),
+        market_id,
+        amount,
     }
     .publish(env);
 }

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -4,7 +4,7 @@
 //! Locked collateral is computed from YES/NO shares using a 50/50 market price.
 
 use crate::error::ContractError;
-use crate::events::emit_collateral_withdrawn;
+use crate::events::{emit_collateral_withdrawn, emit_withdraw_edge_case};
 use crate::positions::calculate_locked_collateral;
 use crate::storage;
 use crate::types::{MarketStatus, Position};
@@ -73,6 +73,7 @@ pub fn withdraw_unused_collateral(
     });
 
     if position.total_deposited == 0 {
+        emit_withdraw_edge_case(&env, &user, market_id, amount);
         return Err(ContractError::InsufficientCollateral);
     }
 
@@ -382,4 +383,51 @@ mod tests {
         });
         assert_eq!(updated.total_deposited, 60);
     }
+
+    #[test]
+    fn test_withdraw_edge_case_emits_event() {
+        use soroban_sdk::testutils::Events;
+
+        let env = setup_env();
+        let user = Address::generate(&env);
+        let market_id = 1u32;
+        let collateral_token = Address::generate(&env);
+        let contract_id = env.register(crate::MarketContract, ());
+
+        let market = create_test_market(&env, market_id, &collateral_token);
+        let position = Position {
+            market_id,
+            user: user.clone(),
+            yes_shares: 0,
+            no_shares: 0,
+            locked_collateral: 0,
+            total_deposited: 0,
+            is_settled: false,
+        };
+        env.as_contract(&contract_id, || {
+            storage::set_market(&env, market_id, &market);
+            storage::set_position(&env, market_id, &user, &position);
+        });
+
+        env.mock_all_auths();
+
+        let result = env.as_contract(&contract_id, || {
+            withdraw_unused_collateral(env.clone(), user.clone(), market_id, 100)
+        });
+
+        assert_eq!(result, Err(ContractError::InsufficientCollateral));
+
+        let events = env.events().all();
+        let withdraw_edge_case_events: Vec<_> = events
+            .iter()
+            .filter(|(event, _)| {
+                // Check for WithdrawEdgeCaseEvent
+                event.topics.len() == 2
+                    && event.contract_id == contract_id
+            })
+            .collect();
+
+        assert_eq!(withdraw_edge_case_events.len(), 1);
+    }
 }
+


### PR DESCRIPTION
closed #83
# Emit Event for Action in Withdraw Edge Case

## Summary

Emit `WithdrawEdgeCaseEvent` when a user attempts to withdraw with zero collateral deposited in a market. This improves contract observability and enables better monitoring of edge case scenarios.

## Changes

### New Event Definition

- **File**: `contracts/market/src/events.rs`
- **Type**: `WithdrawEdgeCaseEvent`
- **Fields**:
  - `user` (topic) - User attempting withdrawal
  - `market_id` (topic) - Market identifier
  - `amount` - Amount attempted to withdraw

### Event Emission

- **File**: `contracts/market/src/withdraw.rs`
- **Location**: `withdraw_unused_collateral()` function
- **Trigger**: When `position.total_deposited == 0` (edge case)
- **Behavior**: Event is emitted before returning `InsufficientCollateral` error

### Test Coverage

- **File**: `contracts/market/src/withdraw.rs`
- **Test**: `test_withdraw_edge_case_emits_event()`
- **Validation**: Confirms event emission and error handling

## Rationale

This event enables:

1. **Monitoring**: Track edge cases where users attempt to withdraw from positions with zero collateral
2. **Debugging**: Easier identification of unexpected user behavior patterns
3. **Analytics**: Collect data on contract usage patterns
4. **Alerting**: Set up notifications for unusual withdrawal attempts

## Acceptance Criteria ✅

- [x] Event defined in `events.rs`
- [x] Test asserts event emission

## Testing

The implementation includes a dedicated test that:

1. Creates a position with zero collateral deposited
2. Attempts to withdraw funds
3. Verifies `WithdrawEdgeCaseEvent` is emitted
4. Confirms `InsufficientCollateral` error is returned

## Files Changed

- `contracts/market/src/events.rs` - Added event definition and emitter function
- `contracts/market/src/withdraw.rs` - Added event emission and test coverage

## Related Issues

Resolves onboarding task: "[contracts] Emit event for action in withdraw edge case"

## Breaking Changes

None. This is a purely additive change that adds event emission without modifying existing function signatures or behavior.

## Notes

- Event follows the same pattern as existing events (`CollateralDepositedEvent`, `CollateralWithdrawnEvent`)
- Uses the standard Soroban `#[contractevent]` macro
- Topics are set for `user` and `market_id` to enable efficient event filtering
