### PR TITLE
feat(market): add validation TODO and fix withdraw test auth issue

### DIFF
--- a/contracts/market/src/validation.rs
+++ b/contracts/market/src/validation.rs
@@ -1,6 +1,7 @@
 use crate::error::ContractError;
 use soroban_sdk::String;
 
+// TODO(#77): Refactor validation helpers for readability
 /// Validates market creation parameters
 pub fn validate_market_creation(
     question: &String,

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -348,6 +348,8 @@ mod tests {
         let collateral_token = token.address();
         let contract_id = env.register(crate::MarketContract, ());
 
+        env.mock_all_auths();
+
         // Fund the contract with collateral (simulates prior deposit)
         let token_client = StellarAssetClient::new(&env, &collateral_token);
         token_client.mint(&contract_id, &200);
@@ -368,8 +370,6 @@ mod tests {
             storage::set_market(&env, market_id, &market);
             storage::set_position(&env, market_id, &user, &position);
         });
-
-        env.mock_all_auths();
 
         let result = env.as_contract(&contract_id, || {
             withdraw_unused_collateral(env.clone(), user.clone(), market_id, 40)


### PR DESCRIPTION
## Context
This PR addresses the onboarding task described in issue #92 to add a TODO with a GitHub issue link near the validation helpers.

## Proposed Changes
- Added a `TODO(#77)` referencing issue #77 near the validation helpers in `contracts/market/src/validation.rs`.
- Fixed a bug in `contracts/market/src/withdraw.rs` unit tests where `env.mock_all_auths()` was set up after `token_client.mint` was already called, causing authentication failure. Moving it to the start of the test allows all 93 unit tests to pass successfully.

## Verification
- Verified all 93 unit tests pass locally (`cargo test`).

Closes #92