### PR TITLE
feat: tooling and contract improvements 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Format check
         run: cd contracts/market && cargo fmt --check
       
+      # Clippy is Rust's official linter. The `-D warnings` flag promotes every
+      # lint warning to a hard error so no warnings can accumulate silently.
+      # To silence a specific lint where it is intentionally acceptable, add a
+      # targeted `#[allow(lint_name)]` attribute in the source rather than
+      # weakening this flag globally.
       - name: Clippy
         run: cd contracts/market && cargo clippy -- -D warnings
       

--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ pnpm issues:publish   # requires gh auth
 cargo build 
 ```
 
+## Contract Makefile
+
+The `contracts/market/Makefile` provides convenience targets for day-to-day contract work.
+
+| Target  | Description                                          |
+|---------|------------------------------------------------------|
+| `build` | Compile the contract to WASM (`wasm32-unknown-unknown`) and print the output size |
+| `test`  | Run all unit and integration tests (depends on `build`) |
+| `fmt`   | Format all Rust source with `cargo fmt --all`        |
+| `clean` | Remove build artefacts via `cargo clean`             |
+
+```bash
+# From the repo root
+cd contracts/market
+
+make           # default — builds the WASM artefact
+make test      # build then run the full test suite
+make fmt       # auto-format source files
+make clean     # wipe target/ directory
+```
+
 ## Security
 
 Smart contract security is critical. All contracts will undergo:

--- a/contracts/market/rustfmt.toml
+++ b/contracts/market/rustfmt.toml
@@ -1,0 +1,16 @@
+# Echo guard: no formatting rules are enforced yet.
+#
+# A real implementation should define explicit project-wide rustfmt settings
+# here so that all contributors format code identically. Typical rules include:
+#
+#   edition       = "2021"
+#   max_width     = 100
+#   tab_spaces    = 4
+#   newline_style = "Unix"
+#
+# Until explicit rules are committed, `cargo fmt` and `cargo fmt --check`
+# fall back to rustfmt defaults. Add rules incrementally and verify with:
+#
+#   cd contracts/market && cargo fmt --check
+#
+# See the full option reference at https://rust-lang.github.io/rustfmt/

--- a/contracts/market/src/positions.rs
+++ b/contracts/market/src/positions.rs
@@ -1,4 +1,4 @@
-use crate::events::emit_position_limit_exceeded;
+use crate::events::{emit_position_limit_exceeded, emit_position_updated};
 use crate::types::{Market, Position};
 use soroban_sdk::{contracterror, Address, Env};
 
@@ -180,6 +180,16 @@ pub fn update_position(
     // 5. Persist
     crate::storage::set_position(env, market_id, user, &position);
 
+    // 6. Emit event
+    emit_position_updated(
+        env,
+        market_id,
+        user,
+        position.yes_shares,
+        position.no_shares,
+        position.locked_collateral,
+    );
+
     Ok(position)
 }
 
@@ -331,6 +341,37 @@ mod tests {
         assert_eq!(
             topic0,
             soroban_sdk::Symbol::new(&env, "position_limit_exceeded_event")
+        );
+    }
+
+    #[test]
+    fn test_update_position_emits_position_updated_event() {
+        use soroban_sdk::testutils::Events as _;
+        use soroban_sdk::IntoVal;
+
+        let env = setup_env();
+        let contract_id = env.register(crate::MarketContract, ());
+        let user = sample_user(&env, 5);
+        let market_id = 5;
+
+        env.as_contract(&contract_id, || {
+            update_position(&env, market_id, &user, 100 * STROOPS_PER_USDC, 0, 6000)
+                .expect("position update should succeed");
+        });
+
+        let events = env.events().all();
+        assert_eq!(events.len(), 1);
+
+        let topic0: soroban_sdk::Symbol = events
+            .first()
+            .unwrap()
+            .1
+            .get(0)
+            .unwrap()
+            .into_val(&env);
+        assert_eq!(
+            topic0,
+            soroban_sdk::Symbol::new(&env, "position_updated_event")
         );
     }
 

--- a/scripts/issues/README.md
+++ b/scripts/issues/README.md
@@ -39,3 +39,7 @@ pnpm issues:generate -- --publish --delay-ms 500
 | `generated/manifest.json` | summary |
 
 Generated JSON is gitignored; re-run anytime for a fresh local export.
+
+## Tooling config
+
+- **rustfmt** — formatting rules for the market contract live in [`contracts/market/rustfmt.toml`](../../contracts/market/rustfmt.toml). The file currently contains only an echo-guard comment explaining what a real implementation should define; add explicit rules there when formatting conventions are agreed upon.

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,4 +1,7 @@
-use soroban_sdk::{Address, BytesN, Env, String};
+use soroban_sdk::{
+    testutils::Events as _,
+    Address, BytesN, Env, IntoVal, String,
+};
 
 /// Failure reasons for the integration test harness.
 #[derive(Debug, PartialEq)]
@@ -30,4 +33,24 @@ impl MarketParams {
             collateral_token: Address::generate(env),
         }
     }
+}
+
+/// Assert that at least one event was emitted after an action in the harness.
+///
+/// Call this after any contract action to verify the event was published.
+/// The `expected_topic` string is matched against the first topic symbol of
+/// the most recent event.
+pub fn assert_event_emitted(env: &Env, expected_topic: &str) {
+    let events = env.events().all();
+    assert!(
+        !events.is_empty(),
+        "expected at least one event to be emitted"
+    );
+    let last = events.last().unwrap();
+    let topic: soroban_sdk::Symbol = last.1.get(0).unwrap().into_val(env);
+    assert_eq!(
+        topic,
+        soroban_sdk::Symbol::new(env, expected_topic),
+        "event topic mismatch: expected '{expected_topic}'"
+    );
 }


### PR DESCRIPTION
## Summary

This PR resolves four onboarding issues spanning tooling documentation, CI clarity, and contract event emission.

### #100 — Add CI comment explaining clippy lints step

- Added a multi-line YAML comment directly above the `Clippy` step in `.github/workflows/ci.yml`
- Explains that `-D warnings` promotes all lint warnings to hard errors, keeping the codebase clean
- Guides future maintainers to use targeted `#[allow(lint_name)]` attributes in source rather than weakening the global flag

### #99 — Add echo guard comment to rustfmt config

- Created `contracts/market/rustfmt.toml` with an echo-guard comment documenting what a real implementation should define (`edition`, `max_width`, `tab_spaces`, `newline_style`) without enforcing any rules yet
- Added a **Tooling config** section in `scripts/issues/README.md` linking to the new file so contributors know where to add formatting rules when conventions are agreed upon

### #98 — Document usage of contract Makefile

- Added a **Contract Makefile** section to the root `README.md`
- Includes a table covering all four targets (`build`, `test`, `fmt`, `clean`) with descriptions
- Includes example commands showing how to run each target from `contracts/market/`

### #97 — Emit event for action in integration test harness

- Wired `emit_position_updated` into `positions::update_position` (step 6, after persist) so every successful position change publishes a `PositionUpdatedEvent` to the ledger
- Added `test_update_position_emits_position_updated_event` in `contracts/market/src/positions.rs` asserting the event topic symbol is `position_updated_event`
- Extended `tests/helpers/mod.rs` with an `assert_event_emitted` utility that the integration test harness can call after any contract action to verify event publication

## Test plan

- [ ] CI passes: `cargo clippy -- -D warnings` and `cargo fmt --check` succeed
- [ ] `cargo test` in `contracts/market/` passes, including the new `test_update_position_emits_position_updated_event`
- [ ] `contracts/market/rustfmt.toml` is picked up by `cargo fmt`; no formatting changes are forced (echo guard only)
- [ ] README Makefile section renders correctly in GitHub

Closes #100
Closes #99
Closes #98
Closes #97