### PR TITLE
tooling: add echo guard README section and CI build step comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Tests
         run: cd contracts/market && cargo test
       
+      # Compiles the contract to WASM (wasm32-unknown-unknown) — the binary format
+      # required by the Stellar Soroban runtime. Mirrors the `make build` target in
+      # contracts/market/Makefile; run `cd contracts/market && make build` locally
+      # to reproduce this check and see the output WASM size.
       - name: Build
         run: cd contracts/market && cargo build --target wasm32-unknown-unknown
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ bash scripts/deploy.sh
 
 > Requires Soroban CLI and a funded testnet account. Set `SOROBAN_NETWORK` and `SOROBAN_ACCOUNT` env vars before running.
 
+### deploy-testnet.sh (echo guard)
+
+`scripts/deploy-testnet.sh` is an **echo guard** — it prints intent only and does not perform a real deploy. A real implementation should:
+
+1. Build the contract (`cargo build --target wasm32-unknown-unknown --release`)
+2. Deploy via Soroban CLI (`soroban contract deploy --wasm <path> --network testnet --source <account>`)
+3. Capture and log the returned contract ID
+
 ## Development
 ```bash
 # Prerequisites

--- a/scripts/issues/README.md
+++ b/scripts/issues/README.md
@@ -3,7 +3,7 @@
 ## Deployment
 
 - [`deploy.sh`](../deploy.sh) — deploys the compiled contract to the configured network.
-- [`deploy-testnet.sh`](../deploy-testnet.sh) — echo guard; documents what a real testnet deploy should do (build → deploy via Soroban CLI → log contract ID).
+- [`deploy-testnet.sh`](../deploy-testnet.sh) — echo guard; documents what a real testnet deploy should do (build → deploy via Soroban CLI → log contract ID). See the [echo guard note in README.md](../../README.md#deploy-testnetssh-echo-guard) for details.
 - [`invoke-example.sh`](../invoke-example.sh) — example invocation of a deployed contract function.
 
 ---


### PR DESCRIPTION
Documents deploy-testnet.sh as an echo guard in README.md with a note on what a real implementation should do, links it from the scripts README, and adds a comment in ci.yml explaining the contract Makefile build step.

closes #106 
closes #105 