### PR TITLE
docs: add TODO with issue link near oracle module

### DIFF
--- a/contracts/market/src/oracle.rs
+++ b/contracts/market/src/oracle.rs
@@ -1,3 +1,10 @@
+// TODO(#139): The oracle module currently uses a simple Ed25519 signature
+// scheme with a single trusted pubkey stored per market. This needs to be
+// replaced with a decentralised oracle integration (e.g. a Reflector or
+// Pyth price-feed adapter) so that market resolution does not rely on a
+// single off-chain signer. Tracked in:
+// https://github.com/Vatix-Protocol/vatix-contract/issues/139
+
 use crate::error::ContractError;
 use crate::types::Market;
 use soroban_sdk::{Bytes, BytesN, Env};


### PR DESCRIPTION
Closes #139


What was changed:
- Prepended a TODO(#139) block comment to oracle.rs explaining that the current single-pubkey Ed25519 scheme is a placeholder and needs to be replaced with a decentralised oracle integration (e.g. Reflector or Pyth price-feed adapter).
- Includes the full GitHub issue URL so future maintainers can jump straight to the tracking issue for context and discussion.
