### PR TITLE
feat(frontend): add aria-label to wallet-context interactive buttons

### DIFF
--- a/apps/web/components/DepositForm.tsx
+++ b/apps/web/components/DepositForm.tsx
@@ -38,6 +38,7 @@ export function DepositForm() {
         <button
           type="submit"
           disabled={isLoading || !amount}
+          aria-label={isLoading ? "Processing deposit" : "Deposit funds"}
           className="w-full rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-600 dark:hover:bg-indigo-500"
         >
           {isLoading ? "Processing..." : "Deposit"}

--- a/apps/web/components/WithdrawForm.tsx
+++ b/apps/web/components/WithdrawForm.tsx
@@ -38,6 +38,7 @@ export function WithdrawForm() {
         <button
           type="submit"
           disabled={isLoading || !amount}
+          aria-label={isLoading ? "Processing withdrawal" : "Withdraw funds"}
           className="w-full rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-600 dark:hover:bg-indigo-500"
         >
           {isLoading ? "Processing..." : "Withdraw"}


### PR DESCRIPTION
Closes #159

## What
Added `aria-label` attributes to the submit buttons in `WithdrawForm` and `DepositForm` components.

## Why
Buttons whose visible text alone may not convey enough context for screen readers need explicit accessible names. The `aria-label` values are dynamic — they reflect the loading state so assistive technology announces the correct action at all times.

## Changes
- `apps/web/components/WithdrawForm.tsx` — added `aria-label` to submit button (`"Withdraw funds"` / `"Processing withdrawal"`)
- `apps/web/components/DepositForm.tsx` — added `aria-label` to submit button (`"Deposit funds"` / `"Processing deposit"`)