### PR TITLE
chore(contracts): add TODO with issue link near withdraw module

### DIFF
--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -2,6 +2,10 @@
 //!
 //! Users can withdraw collateral that is not locked by their active positions.
 //! Locked collateral is computed from YES/NO shares using a 50/50 market price.
+//!
+//! TODO(#160): Support dynamic market price for locked collateral calculation
+//! instead of the hardcoded 50/50 price. This will require reading the current
+//! market price from storage once price discovery is implemented.
 
 use crate::error::ContractError;
 use crate::events::{emit_collateral_withdrawn, emit_withdraw_edge_case};


### PR DESCRIPTION
Closes #160

## What
Added a `TODO(#160)` comment to the module-level doc block in `contracts/market/src/withdraw.rs`.

## Why
The withdraw module currently uses a hardcoded 50/50 market price for locked collateral calculation. The TODO flags this limitation with a GitHub issue reference so future contributors know where to pick up the work.

## Changes
- `contracts/market/src/withdraw.rs` — added `TODO(#160)` note explaining the need for dynamic market price support