### PR TITLE
chore(ci): enhance comment explaining rustfmt config step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
       # Configuration is defined in contracts/market/rustfmt.toml to ensure all
       # contributors format code identically. This prevents style drift and makes
       # code reviews focus on logic rather than formatting.
+      #
+      # The `--check` flag makes rustfmt exit with a non-zero status if any file
+      # would be reformatted, failing the CI run without modifying files.
+      # To auto-fix locally before pushing, run: cd contracts/market && cargo fmt
       - name: Format check
         run: cd contracts/market && cargo fmt --check
       


### PR DESCRIPTION
Closes #164

## What
Expanded the comment above the `Format check` step in `.github/workflows/ci.yml`.

## Why
The existing comment explained *what* the step does but not *how* `--check` works or how contributors can fix failures locally. Future maintainers now have that context inline.

## Changes
- `.github/workflows/ci.yml` — added two lines explaining the `--check` flag behaviour and the local fix command (`cargo fmt`)