### PR TITLE
chore(ci): enhance comment explaining deploy.sh step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       # available as repository secrets. When the real implementation lands,
       # this step will build the WASM artefact, invoke `soroban contract deploy`,
       # and capture the returned contract ID for downstream use.
+      #
+      # To run locally: bash scripts/deploy.sh
+      # Real deployment requires SOROBAN_NETWORK and SOROBAN_ACCOUNT env vars.
       - name: Deploy (dry-run guard)
         run: bash scripts/deploy.sh
 


### PR DESCRIPTION
Closes #161

## What
Expanded the comment above the `Deploy (dry-run guard)` step in `.github/workflows/ci.yml`.

## Why
The existing comment described the script's intent but didn't tell maintainers how to run it locally or what environment variables are required for a real deployment. Those details are now documented inline.

## Changes
- `.github/workflows/ci.yml` — added local run instruction and note on required `SOROBAN_NETWORK` / `SOROBAN_ACCOUNT` env vars