### PR TITLE
docs(PositionPanel): add JSDoc comment (#171)

### DIFF
--- a/apps/web/components/PositionPanel.tsx
+++ b/apps/web/components/PositionPanel.tsx
@@ -5,6 +5,20 @@ import { DepositForm } from "./DepositForm";
 import { WithdrawForm } from "./WithdrawForm";
 import { LoadingSkeleton } from "./LoadingSkeleton";
 
+/**
+ * PositionPanel displays the user's open prediction-market positions together
+ * with deposit and withdraw controls.
+ *
+ * Positions are fetched asynchronously on mount. While loading, a skeleton
+ * placeholder is shown. When no positions exist, an empty-state message guides
+ * the user to deposit funds and browse markets.
+ *
+ * @example
+ * ```tsx
+ * // Render the panel on a market detail page
+ * <PositionPanel />
+ * ```
+ */
 export function PositionPanel() {
   const [isLoading, setIsLoading] = useState(true);
   const [positions, setPositions] = useState<any[]>([]);


### PR DESCRIPTION
 Added a JSDoc block to the PositionPanel component in
  apps/web/components/PositionPanel.tsx explaining what the component
  renders, its async loading behaviour, the empty-state fallback, and an
  @example showing how to use it.
  
  closes #171 