### PR TITLE
docs(ci): add comment explaining deploy.sh step (#173)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,1 +1,15 @@
+#!/usr/bin/env bash
+# deploy.sh — echo guard for the Soroban contract deployment step.
+#
+# Purpose: verifies the script is reachable and executable in CI without
+# performing a real on-chain deployment. Safe to run locally or in CI.
+#
+# When a real deployment is needed:
+#   1. Build the WASM:  cargo build --target wasm32-unknown-unknown --release
+#   2. Deploy:          soroban contract deploy --wasm <path> --network testnet --source <account>
+#   3. Capture the returned contract ID for downstream use.
+#
+# Required env vars for a real deployment:
+#   SOROBAN_NETWORK  — target network (e.g. testnet)
+#   SOROBAN_ACCOUNT  — funded account name configured in the Soroban CLI
 echo deploying to testnet...


### PR DESCRIPTION
Added a comment block to scripts/deploy.sh documenting its purpose as an
  echo guard (safe to run in CI without side effects), the steps a real
  deployment would perform, and the required environment variables
  (SOROBAN_NETWORK, SOROBAN_ACCOUNT).
  
  closes #173 