### PR TITLE
chore: document CI steps, add loading skeleton spacing, document test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,16 @@ jobs:
         with:
           workspaces: contracts/market
       
-      # Format check enforces consistent code style across the project using rustfmt.
-      # Configuration is defined in contracts/market/rustfmt.toml to ensure all
-      # contributors format code identically. This prevents style drift and makes
-      # code reviews focus on logic rather than formatting.
+      # Format check enforces consistent code style across the project using
+      # `rustfmt`.
+      #
+      # Configuration is defined in `contracts/market/rustfmt.toml`. That file is
+      # intentionally an "echo guard" in this repository (it documents what a
+      # real project-wide config would contain). When maintainers decide on a
+      # concrete style, add the desired options to that file so `cargo fmt`
+      # and `cargo fmt --check` enforce the same rules for everyone. Keeping
+      # formatting locked down in CI prevents style drift and lets reviews
+      # focus on behavior rather than whitespace.
       - name: Format check
         run: cd contracts/market && cargo fmt --check
       
@@ -47,6 +53,9 @@ jobs:
       #     intentionally acceptable, rather than weakening `-D warnings` globally.
       #
       # See scripts/README.md for the full tooling reference.
+      # The scripts README documents the intent of these "echo guard" scripts
+      # and provides guidance for maintainers on how to replace guards with
+      # real CI actions (credentials, expected outputs, and invocation examples).
       - name: Clippy
         run: cd contracts/market && cargo clippy -- -D warnings
       
@@ -83,6 +92,9 @@ jobs:
       #      stored as repository secrets (TESTNET_SOURCE_ACCOUNT, etc.)
       #   3. Log and export the returned contract ID for use in downstream steps
       # See scripts/README.md for the full tooling reference.
+      # The scripts README documents the intent of these "echo guard" scripts
+      # and provides guidance for maintainers on how to replace guards with
+      # real CI actions (credentials, expected outputs, and invocation examples).
       - name: Deploy testnet (guard)
         run: bash scripts/deploy-testnet.sh
 
@@ -94,6 +106,9 @@ jobs:
       #   - Pass CONTRACT_ID (captured from the deploy step) via an environment variable.
       #   - Assert the response matches the expected value to act as a smoke test.
       # See scripts/README.md for the full tooling reference.
+      # The scripts README documents the intent of these "echo guard" scripts
+      # and provides guidance for maintainers on how to replace guards with
+      # real CI actions (credentials, expected outputs, and invocation examples).
       - name: Invoke example (echo guard)
         run: bash scripts/invoke-example.sh
 

--- a/apps/web/components/PositionPanel.tsx
+++ b/apps/web/components/PositionPanel.tsx
@@ -27,7 +27,7 @@ export function PositionPanel() {
 
       <div className="rounded-lg border border-slate-200 p-4 dark:border-slate-700 sm:p-6">
         <h2 className="text-base font-semibold sm:text-lg">Your positions</h2>
-        <div className="mt-4">
+        <div className="mt-4 min-h-[11rem]">
           {isLoading ? (
             <LoadingSkeleton />
           ) : positions.length === 0 ? (

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,3 +1,18 @@
+/// Integration test harness helpers used across the contract integration tests.
+///
+/// This module provides small convenience types and assertions that keep tests
+/// concise and readable. It intentionally lives in `tests/helpers` so test
+/// files can import the helpers with `use crate::helpers::*`.
+///
+/// Example:
+/// ```rust
+/// # use soroban_sdk::Env;
+/// # use tests::helpers::MarketParams;
+/// let env = Env::default();
+/// let params = MarketParams::default_valid(&env);
+/// // Use `params` to initialize the contract under test, then assert events:
+/// // assert_event_emitted(&env, "market_created");
+/// ```
 use soroban_sdk::{
     testutils::Events as _,
     Address, BytesN, Env, IntoVal, String,


### PR DESCRIPTION
Summary of changes:

- CI: expand rustfmt comment to explain the echo-guard config and why formatting is enforced in CI.
- CI: add explicit comment explaining the purpose of scripts/README.md and how to convert guard scripts into real CI steps.
- Frontend: reserve space for the loading skeleton in `PositionPanel` to prevent layout shift when content loads.
- Tests: add module-level doc comment with example to the integration test harness helpers.

Closes #121
Closes #126
Closes #127
Closes #128