### PR TITLE
fix(empty-state): polish responsive styles to prevent horizontal scroll

### DIFF
--- a/apps/web/components/EmptyState.tsx
+++ b/apps/web/components/EmptyState.tsx
@@ -12,18 +12,18 @@ export function EmptyState({
   onAction,
 }: EmptyStateProps) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-lg border border-slate-200 bg-slate-50 p-8 text-center dark:border-slate-700 dark:bg-slate-900">
-      <h3 className="text-lg font-medium text-slate-900 dark:text-slate-100">
+    <div className="w-full max-w-xl mx-auto flex flex-col items-center justify-center rounded-lg border border-slate-200 bg-slate-50 p-6 sm:p-8 text-center dark:border-slate-700 dark:bg-slate-900">
+      <h3 className="text-base sm:text-lg font-medium text-slate-900 dark:text-slate-100">
         {title}
       </h3>
-      <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+      <p className="mt-2 text-sm sm:text-base text-slate-600 dark:text-slate-400">
         {description}
       </p>
       {actionLabel && onAction && (
         <button
           onClick={onAction}
           aria-label={actionLabel}
-          className="mt-4 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900"
+          className="mt-4 rounded-lg bg-blue-600 px-3 sm:px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 w-full sm:w-auto max-w-xs"
         >
           {actionLabel}
         </button>
@@ -32,7 +32,7 @@ export function EmptyState({
         <a
           href="#"
           aria-label={actionLabel}
-          className="mt-4 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900"
+          className="mt-4 rounded-lg bg-blue-600 px-3 sm:px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 w-full sm:w-auto max-w-xs"
         >
           {actionLabel}
         </a>


### PR DESCRIPTION
Closes #144 
-Add reponsive layout to EmptyState: w-full + max-w-xl, centered (mx-auto) 
- Reduce mobile padding(p-6) and keep p-8 on sm+ 
- Make heading/text reposnive (text-base -> sm:test-lg, paragraph sm:text-base) 
- Make action element full width on mobile and auto onn larger screens (w-full sm:w-auto) with constrained max width. Result: improved appearance at 37px and 1280px and avoids horizontal scroll. Focused change only; no behaviour changes. Test by viewing EmptyState at 375px and 1280px.
