### PR TITLE
Expose share trading on MarketContract

### DIFF
--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -18,7 +18,7 @@ mod types;
 mod validation;
 
 use crate::error::ContractError;
-use crate::types::{Market, MarketStatus};
+use crate::types::{Market, MarketStatus, Position};
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String};
 
 #[contract]
@@ -220,5 +220,85 @@ impl MarketContract {
         events::emit_market_resolved(&env, market_id, outcome, resolved_at);
 
         Ok(())
+    }
+
+    /// Buy or sell YES/NO shares by applying signed deltas to a user's position.
+    ///
+    /// This is the on-chain entry point for the share-trading logic implemented
+    /// in [`positions::update_position`]. It layers the market- and
+    /// authorization-level checks required before a position may be mutated.
+    ///
+    /// # Arguments
+    /// * `env` - Contract environment
+    /// * `user` - User whose position is updated (must authorize the call)
+    /// * `market_id` - Market identifier
+    /// * `yes_delta` - Change in YES shares (negative to sell)
+    /// * `no_delta` - Change in NO shares (negative to sell)
+    /// * `market_price` - Current market price in basis points (0–10_000) used
+    ///   to value the resulting net position
+    ///
+    /// # Returns
+    /// The updated [`Position`] on success.
+    ///
+    /// # Errors
+    /// - [`ContractError::MarketNotFound`] – market does not exist
+    /// - [`ContractError::MarketNotActive`] – market is resolved or canceled
+    /// - [`ContractError::MarketExpired`] – market has passed its `end_time`
+    /// - [`ContractError::InvalidPrice`] – `market_price` is outside 0–10_000
+    /// - [`ContractError::InsufficientCollateral`] – deposited collateral does
+    ///   not cover the increased locked amount
+    /// - [`ContractError::InvalidShareAmount`] – deltas would push a share
+    ///   balance below zero
+    ///
+    /// # Events
+    /// Emits `PositionUpdated` on success, or `PositionLimitExceeded` when a
+    /// delta would drive a share balance negative.
+    pub fn update_position(
+        env: Env,
+        user: Address,
+        market_id: u32,
+        yes_delta: i128,
+        no_delta: i128,
+        market_price: i128,
+    ) -> Result<Position, ContractError> {
+        // 1. Authorization
+        user.require_auth();
+
+        // 2. Validate market state: must exist, be Active, and not be expired
+        let market = storage::get_market(&env, market_id).ok_or(ContractError::MarketNotFound)?;
+        if market.status != MarketStatus::Active {
+            return Err(ContractError::MarketNotActive);
+        }
+        if env.ledger().timestamp() > market.end_time {
+            return Err(ContractError::MarketExpired);
+        }
+
+        // 3. Validate the market price up front for a clear ContractError
+        validation::validate_market_price(market_price)?;
+
+        // 4. Enforce that deposited collateral covers any increase in the lock.
+        //    Negative-share deltas are left for positions::update_position to
+        //    reject (it also emits a PositionLimitExceeded event).
+        let position = storage::get_position(&env, market_id, &user)
+            .unwrap_or_else(|| Position::new_empty(market_id, user.clone()));
+        let new_yes = position.yes_shares + yes_delta;
+        let new_no = position.no_shares + no_delta;
+        if new_yes >= 0 && new_no >= 0 {
+            let prospective_locked =
+                positions::calculate_locked_collateral(new_yes, new_no, market_price);
+            let lock_increased = prospective_locked > position.locked_collateral;
+            if lock_increased && prospective_locked > position.total_deposited {
+                return Err(ContractError::InsufficientCollateral);
+            }
+        }
+
+        // 5. Apply the share deltas (persists the position and emits an event)
+        positions::update_position(&env, market_id, &user, yes_delta, no_delta, market_price)
+            .map_err(|e| match e {
+                positions::PositionError::ShareBalanceBelowZero => {
+                    ContractError::InvalidShareAmount
+                }
+                positions::PositionError::InvalidMarketPrice => ContractError::InvalidPrice,
+            })
     }
 }

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -542,6 +542,141 @@ mod test {
         client.deposit_collateral(&user, &1, &1000i128);
     }
 
+    // ========== update_position tests ==========
+
+    /// Register a market backed by a real Stellar asset, fund `user`, and
+    /// deposit `deposit` stroops of collateral so trades can be exercised.
+    fn setup_funded_market<'a>(
+        deposit: i128,
+    ) -> (Env, Address, MarketContractClient<'a>, Address, u32) {
+        use soroban_sdk::token::StellarAssetClient;
+
+        let env = Env::default();
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let collateral_token = token.address();
+
+        let contract_id = env.register(MarketContract, ());
+        let client = MarketContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            storage::set_admin(&env, &admin);
+        });
+
+        env.mock_all_auths();
+
+        let question = String::from_str(&env, "Will it rain tomorrow?");
+        let end_time = env.ledger().timestamp() + 86400;
+        let oracle_pubkey = BytesN::from_array(&env, &[1u8; 32]);
+        let market_id = client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &collateral_token,
+        );
+
+        let user = Address::generate(&env);
+        let token_client = StellarAssetClient::new(&env, &collateral_token);
+        token_client.mint(&user, &deposit);
+        client.deposit_collateral(&user, &market_id, &deposit);
+
+        (env, user, client, contract_id, market_id)
+    }
+
+    #[test]
+    fn test_update_position_buys_shares_and_locks_collateral() {
+        use crate::positions::STROOPS_PER_USDC;
+
+        let deposit = 100 * STROOPS_PER_USDC;
+        let (env, user, client, contract_id, market_id) = setup_funded_market(deposit);
+
+        // Buy 100 YES shares at a 60% price -> lock 60 USDC
+        let yes = 100 * STROOPS_PER_USDC;
+        let position = client.update_position(&user, &market_id, &yes, &0i128, &6000i128);
+
+        assert_eq!(position.yes_shares, yes);
+        assert_eq!(position.no_shares, 0);
+        assert_eq!(position.locked_collateral, 60 * STROOPS_PER_USDC);
+
+        // The persisted position matches the returned one
+        let stored = env.as_contract(&contract_id, || {
+            storage::get_position(&env, market_id, &user).expect("position should exist")
+        });
+        assert_eq!(stored.yes_shares, yes);
+        assert_eq!(stored.locked_collateral, 60 * STROOPS_PER_USDC);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn test_update_position_insufficient_collateral() {
+        use crate::positions::STROOPS_PER_USDC;
+
+        // Only 10 USDC deposited, but buying 100 YES at 60% needs 60 USDC locked.
+        let deposit = 10 * STROOPS_PER_USDC;
+        let (_env, user, client, _contract_id, market_id) = setup_funded_market(deposit);
+
+        let yes = 100 * STROOPS_PER_USDC;
+        client.update_position(&user, &market_id, &yes, &0i128, &6000i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #13)")]
+    fn test_update_position_rejects_overselling() {
+        use crate::positions::STROOPS_PER_USDC;
+
+        let deposit = 100 * STROOPS_PER_USDC;
+        let (_env, user, client, _contract_id, market_id) = setup_funded_market(deposit);
+
+        // Selling shares the user does not hold drives the balance below zero.
+        client.update_position(
+            &user,
+            &market_id,
+            &(-50 * STROOPS_PER_USDC),
+            &0i128,
+            &6000i128,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn test_update_position_rejects_resolved_market() {
+        use crate::positions::STROOPS_PER_USDC;
+
+        let deposit = 100 * STROOPS_PER_USDC;
+        let (env, user, client, contract_id, market_id) = setup_funded_market(deposit);
+
+        // Force the market into a resolved state.
+        env.as_contract(&contract_id, || {
+            let mut market = storage::get_market(&env, market_id).unwrap();
+            market.status = MarketStatus::Resolved;
+            market.result = Some(true);
+            storage::set_market(&env, market_id, &market);
+        });
+
+        let yes = 10 * STROOPS_PER_USDC;
+        client.update_position(&user, &market_id, &yes, &0i128, &6000i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #4)")]
+    fn test_update_position_rejects_expired_market() {
+        use crate::positions::STROOPS_PER_USDC;
+
+        let deposit = 100 * STROOPS_PER_USDC;
+        let (env, user, client, contract_id, market_id) = setup_funded_market(deposit);
+
+        // Advance the ledger past the market end_time.
+        let end_time = env.as_contract(&contract_id, || {
+            storage::get_market(&env, market_id).unwrap().end_time
+        });
+        env.ledger().set_timestamp(end_time + 1);
+
+        let yes = 10 * STROOPS_PER_USDC;
+        client.update_position(&user, &market_id, &yes, &0i128, &6000i128);
+    }
+
     // ========== Validation guard tests ==========
 
     #[test]


### PR DESCRIPTION

closes #247 

### Problem
The share-trading logic in `contracts/market/src/positions.rs` was implemented but never exposed on `MarketContract`. Buying and selling YES/NO shares was therefore unreachable on-chain.

### Changes
- Add `pub fn update_position(...)` to `contracts/market/src/lib.rs` as the on-chain entry point for share trading. It wraps the existing `positions::update_position` with the contract-level guards required before a position may be mutated:
  - **Authorization** — `user.require_auth()`.
  - **Market state** — the market must exist, be `Active`, and not be past its `end_time`, returning `MarketNotFound` / `MarketNotActive` / `MarketExpired` respectively.
  - **Price validation** — `market_price` must be within the valid 0–10,000 basis-point range (`InvalidPrice`).
  - **Collateral sufficiency** — when a trade increases the required locked collateral, the user's `total_deposited` must cover it, otherwise `InsufficientCollateral` is returned.
- Errors from the underlying `positions::update_position` are mapped from `PositionError` to `ContractError` (`ShareBalanceBelowZero` → `InvalidShareAmount`, `InvalidMarketPrice` → `InvalidPrice`). Negative-share deltas continue to be rejected by the positions layer, which also emits the `PositionLimitExceeded` event.
- Add client-level integration tests in `contracts/market/src/test.rs` covering: a successful buy that locks the expected collateral and persists the position, insufficient collateral, overselling, a resolved market, and an expired market.

### Testing
- `cargo test -p vatix-market-contract` — 121 passed, 0 failed.
- `cargo fmt --check` — clean.
- `cargo clippy` — no new warnings introduced.
