### PR TITLE
 Add settle_position public API with SAC token payout transfer

### DIFF
--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -301,4 +301,31 @@ impl MarketContract {
                 positions::PositionError::InvalidMarketPrice => ContractError::InvalidPrice,
             })
     }
+
+    /// Settle a user's position in a resolved market and pay out their winnings.
+    ///
+    /// Completes the deposit -> resolve -> settle -> receive-funds loop: it
+    /// calculates the payout for the resolved outcome, marks the position
+    /// settled, and transfers the payout in collateral (SAC) tokens from the
+    /// contract to the user.
+    ///
+    /// # Arguments
+    /// * `env` - Contract environment
+    /// * `user` - User settling their position (must authorize the call)
+    /// * `market_id` - Market identifier
+    ///
+    /// # Returns
+    /// The payout amount transferred to the user, in stroops.
+    ///
+    /// # Errors
+    /// - [`ContractError::MarketNotFound`] - the market does not exist
+    /// - [`ContractError::NoPositionFound`] - the user has no position
+    /// - [`ContractError::MarketNotResolved`] - the market is not resolved
+    /// - [`ContractError::PositionAlreadySettled`] - already settled
+    ///
+    /// # Events
+    /// Emits `PositionSettled` with the payout amount.
+    pub fn settle_position(env: Env, user: Address, market_id: u32) -> Result<i128, ContractError> {
+        settlement::settle_position(&env, &user, market_id)
+    }
 }

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -18,7 +18,7 @@ mod types;
 mod validation;
 
 use crate::error::ContractError;
-use crate::types::{Market, MarketStatus};
+use crate::types::{Market, MarketStatus, Position};
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String};
 
 #[contract]
@@ -220,5 +220,85 @@ impl MarketContract {
         events::emit_market_resolved(&env, market_id, outcome, resolved_at);
 
         Ok(())
+    }
+
+    /// Buy or sell YES/NO shares by applying signed deltas to a user's position.
+    ///
+    /// This is the on-chain entry point for the share-trading logic implemented
+    /// in [`positions::update_position`]. It layers the market- and
+    /// authorization-level checks required before a position may be mutated.
+    ///
+    /// # Arguments
+    /// * `env` - Contract environment
+    /// * `user` - User whose position is updated (must authorize the call)
+    /// * `market_id` - Market identifier
+    /// * `yes_delta` - Change in YES shares (negative to sell)
+    /// * `no_delta` - Change in NO shares (negative to sell)
+    /// * `market_price` - Current market price in basis points (0–10_000) used
+    ///   to value the resulting net position
+    ///
+    /// # Returns
+    /// The updated [`Position`] on success.
+    ///
+    /// # Errors
+    /// - [`ContractError::MarketNotFound`] – market does not exist
+    /// - [`ContractError::MarketNotActive`] – market is resolved or canceled
+    /// - [`ContractError::MarketExpired`] – market has passed its `end_time`
+    /// - [`ContractError::InvalidPrice`] – `market_price` is outside 0–10_000
+    /// - [`ContractError::InsufficientCollateral`] – deposited collateral does
+    ///   not cover the increased locked amount
+    /// - [`ContractError::InvalidShareAmount`] – deltas would push a share
+    ///   balance below zero
+    ///
+    /// # Events
+    /// Emits `PositionUpdated` on success, or `PositionLimitExceeded` when a
+    /// delta would drive a share balance negative.
+    pub fn update_position(
+        env: Env,
+        user: Address,
+        market_id: u32,
+        yes_delta: i128,
+        no_delta: i128,
+        market_price: i128,
+    ) -> Result<Position, ContractError> {
+        // 1. Authorization
+        user.require_auth();
+
+        // 2. Validate market state: must exist, be Active, and not be expired
+        let market = storage::get_market(&env, market_id).ok_or(ContractError::MarketNotFound)?;
+        if market.status != MarketStatus::Active {
+            return Err(ContractError::MarketNotActive);
+        }
+        if env.ledger().timestamp() > market.end_time {
+            return Err(ContractError::MarketExpired);
+        }
+
+        // 3. Validate the market price up front for a clear ContractError
+        validation::validate_market_price(market_price)?;
+
+        // 4. Enforce that deposited collateral covers any increase in the lock.
+        //    Negative-share deltas are left for positions::update_position to
+        //    reject (it also emits a PositionLimitExceeded event).
+        let position = storage::get_position(&env, market_id, &user)
+            .unwrap_or_else(|| Position::new_empty(market_id, user.clone()));
+        let new_yes = position.yes_shares + yes_delta;
+        let new_no = position.no_shares + no_delta;
+        if new_yes >= 0 && new_no >= 0 {
+            let prospective_locked =
+                positions::calculate_locked_collateral(new_yes, new_no, market_price);
+            let lock_increased = prospective_locked > position.locked_collateral;
+            if lock_increased && prospective_locked > position.total_deposited {
+                return Err(ContractError::InsufficientCollateral);
+            }
+        }
+
+        // 5. Apply the share deltas (persists the position and emits an event)
+        positions::update_position(&env, market_id, &user, yes_delta, no_delta, market_price)
+            .map_err(|e| match e {
+                positions::PositionError::ShareBalanceBelowZero => {
+                    ContractError::InvalidShareAmount
+                }
+                positions::PositionError::InvalidMarketPrice => ContractError::InvalidPrice,
+            })
     }
 }

--- a/contracts/market/src/settlement.rs
+++ b/contracts/market/src/settlement.rs
@@ -1,6 +1,8 @@
 use crate::error::ContractError;
+use crate::storage;
 use crate::types::{Market, MarketStatus, Position};
-use soroban_sdk::Env;
+use soroban_sdk::token::Client as TokenClient;
+use soroban_sdk::{Address, Env};
 
 /// Calculate payout for a position based on market outcome
 ///
@@ -83,6 +85,57 @@ pub fn execute_settlement(
         payout,
         settled_at,
     );
+
+    Ok(payout)
+}
+
+/// Settle a user's position in a resolved market and transfer their payout.
+///
+/// This is the full settlement entry point that completes the
+/// deposit -> resolve -> settle -> receive-funds loop:
+/// 1. Loads the market and the user's position
+/// 2. Validates eligibility, calculates the payout, and marks the position
+///    settled (via [`execute_settlement`], which also emits `PositionSettled`)
+/// 3. Persists the updated position
+/// 4. Transfers the payout in collateral (SAC) tokens from the contract to the
+///    user
+///
+/// # Arguments
+/// * `env` - Contract environment
+/// * `user` - User settling their position (must authorize the call)
+/// * `market_id` - Market identifier
+///
+/// # Returns
+/// The payout amount transferred to the user, in stroops.
+///
+/// # Errors
+/// - [`ContractError::MarketNotFound`] - the market does not exist
+/// - [`ContractError::NoPositionFound`] - the user has no position in the market
+/// - [`ContractError::MarketNotResolved`] - the market has not been resolved
+/// - [`ContractError::PositionAlreadySettled`] - the position was already settled
+///
+/// # Events
+/// Emits `PositionSettled` with the payout amount.
+pub fn settle_position(env: &Env, user: &Address, market_id: u32) -> Result<i128, ContractError> {
+    user.require_auth();
+
+    let market = storage::get_market(env, market_id).ok_or(ContractError::MarketNotFound)?;
+    let mut position =
+        storage::get_position(env, market_id, user).ok_or(ContractError::NoPositionFound)?;
+
+    // Validates eligibility (Resolved + not already settled), computes the
+    // payout, marks the position settled, and emits the PositionSettled event.
+    let payout = execute_settlement(env, &mut position, &market)?;
+
+    // Persist the settled position before paying out.
+    storage::set_position(env, market_id, user, &position);
+
+    // Transfer the payout in collateral tokens from the contract to the user.
+    if payout > 0 {
+        let contract_address = env.current_contract_address();
+        let token_client = TokenClient::new(env, &market.collateral_token);
+        token_client.transfer(&contract_address, user, &payout);
+    }
 
     Ok(payout)
 }
@@ -281,5 +334,136 @@ mod tests {
     fn test_validate_payout_invalid() {
         assert_eq!(validate_payout(-1), Err(ContractError::InvalidQuantity));
         assert_eq!(validate_payout(-100), Err(ContractError::InvalidQuantity));
+    }
+
+    /// End-to-end settlement through the contract client, asserting that the
+    /// SAC token payout actually reaches the user:
+    /// init -> create market -> deposit -> buy -> resolve -> settle.
+    #[test]
+    fn test_settle_position_transfers_payout_full_flow() {
+        use crate::{MarketContract, MarketContractClient};
+        use ed25519_dalek::{Signer, SigningKey};
+        use rand::rngs::OsRng;
+        use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
+
+        const STROOPS_PER_USDC: i128 = 10_000_000;
+
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(MarketContract, ());
+        let client = MarketContractClient::new(&env, &contract_id);
+
+        // Admin is required before a market can be created.
+        let admin = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            storage::set_admin(&env, &admin);
+        });
+
+        // Real SAC collateral token.
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin);
+        let collateral_token = token.address();
+        let sac = StellarAssetClient::new(&env, &collateral_token);
+        let token_client = TokenClient::new(&env, &collateral_token);
+
+        // Oracle keypair used to sign the resolution of market id 1.
+        let outcome = true;
+        let mut csprng = OsRng;
+        let signing_key = SigningKey::generate(&mut csprng);
+        let oracle_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+
+        // Create the market.
+        let question = String::from_str(&env, "Will the payout land?");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let market_id = client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &collateral_token,
+        );
+
+        // Deposit collateral.
+        let user = Address::generate(&env);
+        let deposit = 100 * STROOPS_PER_USDC;
+        sac.mint(&user, &deposit);
+        client.deposit_collateral(&user, &market_id, &deposit);
+
+        // Buy YES shares so the resolved position has a payout.
+        let yes_shares = 100 * STROOPS_PER_USDC;
+        client.update_position(&user, &market_id, &yes_shares, &0i128, &5_000i128);
+
+        // Resolve the market (YES wins) with a valid oracle signature.
+        let message = crate::oracle::construct_oracle_message(&env, market_id, outcome);
+        let sig_bytes = signing_key.sign(message.to_array().as_slice()).to_bytes();
+        let signature = BytesN::from_array(&env, &sig_bytes);
+        let market_id_str = String::from_str(&env, "1");
+        client.resolve_market(&market_id_str, &outcome, &signature);
+
+        // Before settling, the contract holds the deposit and the user holds nothing.
+        assert_eq!(token_client.balance(&user), 0);
+        assert_eq!(token_client.balance(&contract_id), deposit);
+
+        // Settle: the payout equals the winning YES shares.
+        let payout = client.settle_position(&user, &market_id);
+        assert_eq!(payout, yes_shares);
+
+        // The SAC tokens moved from the contract to the user.
+        assert_eq!(token_client.balance(&user), payout);
+        assert_eq!(token_client.balance(&contract_id), deposit - payout);
+
+        // The position is now marked settled.
+        let position = env.as_contract(&contract_id, || {
+            storage::get_position(&env, market_id, &user).expect("position should exist")
+        });
+        assert!(position.is_settled);
+
+        // Settling a second time is rejected.
+        let second = client.try_settle_position(&user, &market_id);
+        assert!(second.is_err());
+    }
+
+    #[test]
+    fn test_settle_position_rejects_unresolved_market() {
+        use crate::{MarketContract, MarketContractClient};
+        use soroban_sdk::token::StellarAssetClient;
+
+        const STROOPS_PER_USDC: i128 = 10_000_000;
+
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(MarketContract, ());
+        let client = MarketContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            storage::set_admin(&env, &admin);
+        });
+
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin);
+        let collateral_token = token.address();
+
+        let oracle_pubkey = BytesN::from_array(&env, &[1u8; 32]);
+        let question = String::from_str(&env, "Still active?");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let market_id = client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &collateral_token,
+        );
+
+        let user = Address::generate(&env);
+        let deposit = 50 * STROOPS_PER_USDC;
+        StellarAssetClient::new(&env, &collateral_token).mint(&user, &deposit);
+        client.deposit_collateral(&user, &market_id, &deposit);
+
+        // The market is still Active, so settlement must be rejected (#3).
+        let result = client.try_settle_position(&user, &market_id);
+        assert_eq!(result, Err(Ok(ContractError::MarketNotResolved)));
     }
 }

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -542,6 +542,141 @@ mod test {
         client.deposit_collateral(&user, &1, &1000i128);
     }
 
+    // ========== update_position tests ==========
+
+    /// Register a market backed by a real Stellar asset, fund `user`, and
+    /// deposit `deposit` stroops of collateral so trades can be exercised.
+    fn setup_funded_market<'a>(
+        deposit: i128,
+    ) -> (Env, Address, MarketContractClient<'a>, Address, u32) {
+        use soroban_sdk::token::StellarAssetClient;
+
+        let env = Env::default();
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let collateral_token = token.address();
+
+        let contract_id = env.register(MarketContract, ());
+        let client = MarketContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            storage::set_admin(&env, &admin);
+        });
+
+        env.mock_all_auths();
+
+        let question = String::from_str(&env, "Will it rain tomorrow?");
+        let end_time = env.ledger().timestamp() + 86400;
+        let oracle_pubkey = BytesN::from_array(&env, &[1u8; 32]);
+        let market_id = client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &collateral_token,
+        );
+
+        let user = Address::generate(&env);
+        let token_client = StellarAssetClient::new(&env, &collateral_token);
+        token_client.mint(&user, &deposit);
+        client.deposit_collateral(&user, &market_id, &deposit);
+
+        (env, user, client, contract_id, market_id)
+    }
+
+    #[test]
+    fn test_update_position_buys_shares_and_locks_collateral() {
+        use crate::positions::STROOPS_PER_USDC;
+
+        let deposit = 100 * STROOPS_PER_USDC;
+        let (env, user, client, contract_id, market_id) = setup_funded_market(deposit);
+
+        // Buy 100 YES shares at a 60% price -> lock 60 USDC
+        let yes = 100 * STROOPS_PER_USDC;
+        let position = client.update_position(&user, &market_id, &yes, &0i128, &6000i128);
+
+        assert_eq!(position.yes_shares, yes);
+        assert_eq!(position.no_shares, 0);
+        assert_eq!(position.locked_collateral, 60 * STROOPS_PER_USDC);
+
+        // The persisted position matches the returned one
+        let stored = env.as_contract(&contract_id, || {
+            storage::get_position(&env, market_id, &user).expect("position should exist")
+        });
+        assert_eq!(stored.yes_shares, yes);
+        assert_eq!(stored.locked_collateral, 60 * STROOPS_PER_USDC);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn test_update_position_insufficient_collateral() {
+        use crate::positions::STROOPS_PER_USDC;
+
+        // Only 10 USDC deposited, but buying 100 YES at 60% needs 60 USDC locked.
+        let deposit = 10 * STROOPS_PER_USDC;
+        let (_env, user, client, _contract_id, market_id) = setup_funded_market(deposit);
+
+        let yes = 100 * STROOPS_PER_USDC;
+        client.update_position(&user, &market_id, &yes, &0i128, &6000i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #13)")]
+    fn test_update_position_rejects_overselling() {
+        use crate::positions::STROOPS_PER_USDC;
+
+        let deposit = 100 * STROOPS_PER_USDC;
+        let (_env, user, client, _contract_id, market_id) = setup_funded_market(deposit);
+
+        // Selling shares the user does not hold drives the balance below zero.
+        client.update_position(
+            &user,
+            &market_id,
+            &(-50 * STROOPS_PER_USDC),
+            &0i128,
+            &6000i128,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn test_update_position_rejects_resolved_market() {
+        use crate::positions::STROOPS_PER_USDC;
+
+        let deposit = 100 * STROOPS_PER_USDC;
+        let (env, user, client, contract_id, market_id) = setup_funded_market(deposit);
+
+        // Force the market into a resolved state.
+        env.as_contract(&contract_id, || {
+            let mut market = storage::get_market(&env, market_id).unwrap();
+            market.status = MarketStatus::Resolved;
+            market.result = Some(true);
+            storage::set_market(&env, market_id, &market);
+        });
+
+        let yes = 10 * STROOPS_PER_USDC;
+        client.update_position(&user, &market_id, &yes, &0i128, &6000i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #4)")]
+    fn test_update_position_rejects_expired_market() {
+        use crate::positions::STROOPS_PER_USDC;
+
+        let deposit = 100 * STROOPS_PER_USDC;
+        let (env, user, client, contract_id, market_id) = setup_funded_market(deposit);
+
+        // Advance the ledger past the market end_time.
+        let end_time = env.as_contract(&contract_id, || {
+            storage::get_market(&env, market_id).unwrap().end_time
+        });
+        env.ledger().set_timestamp(end_time + 1);
+
+        let yes = 10 * STROOPS_PER_USDC;
+        client.update_position(&user, &market_id, &yes, &0i128, &6000i128);
+    }
+
     // ========== Validation guard tests ==========
 
     #[test]


### PR DESCRIPTION


closes #249

### Problem
`settlement::execute_settlement` marked a position as settled and returned a payout amount but never transferred any SAC tokens, and there was no public entry point to call it. The deposit -> resolve -> settle -> receive-funds loop was therefore incomplete: users could never actually receive their winnings on-chain.

### Changes
- **Added `settlement::settle_position(env, user, market_id)`** as the full settlement entry point. It:
  - requires the user's authorization,
  - loads the market (`MarketNotFound`) and the user's position (`NoPositionFound`),
  - delegates eligibility validation, payout calculation, the settled-flag update, and the `PositionSettled` event to the existing `execute_settlement`,
  - persists the settled position,
  - transfers the payout in collateral (SAC) tokens from the contract to the user via `TokenClient` (only when the payout is positive).
- **Exposed `settle_position` on `MarketContract`** in `lib.rs`, delegating to the settlement module to match the existing `deposit_collateral` / `withdraw_unused_collateral` pattern.
- **Rejection paths** are unchanged in spirit and covered: settling an unresolved market returns `MarketNotResolved`, and settling an already-settled position returns `PositionAlreadySettled`.

### Testing
- `test_settle_position_transfers_payout_full_flow`: drives the full lifecycle through the contract client (init -> create market -> deposit -> buy shares -> resolve with a valid Ed25519 oracle signature -> settle) and asserts the SAC token balances before and after settlement — the user's balance increases by the payout and the contract's decreases by the same amount — that the returned payout equals the winning shares, that the position is marked settled, and that a second settlement is rejected.
- `test_settle_position_rejects_unresolved_market`: settling while the market is still Active returns `MarketNotResolved`.
- `cd contracts/market && cargo test` — 123 passed (121 existing + 2 new).
- `cargo fmt --check` and `cargo clippy -- -D warnings` — clean.
