### PR TITLE
feat(contracts): add initialize(admin) deploy entry point for MarketContract

### DIFF
--- a/contracts/market/src/error.rs
+++ b/contracts/market/src/error.rs
@@ -71,6 +71,12 @@ pub enum ContractError {
     /// Caller is not the admin for this operation
     NotAdmin = 41,
 
+    /// Contract has already been initialized.
+    ///
+    /// `initialize(admin)` may only be called once. Replaying it would allow
+    /// an attacker to hijack the admin slot after initial deploy.
+    AlreadyInitialized = 42,
+
     // ========== Token Errors (50-59) ==========
     /// Token transfer failed (insufficient balance, approval, etc.)
     TokenTransferFailed = 50,

--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -4,6 +4,29 @@ use soroban_sdk::{contractevent, Address, Env, String};
 
 #[contractevent]
 #[derive(Clone, Debug)]
+pub struct ContractInitializedEvent {
+    #[topic]
+    pub admin: Address,
+}
+
+/// Emit an event when the contract is initialized with an admin.
+///
+/// Publishes a [`ContractInitializedEvent`] to the Soroban event stream when
+/// `initialize` is called for the first time. Indexed by `admin` as a topic
+/// so off-chain indexers can confirm who bootstrapped the contract.
+///
+/// # Arguments
+/// * `env` - Contract environment
+/// * `admin` - The address stored as the contract admin
+pub fn emit_contract_initialized(env: &Env, admin: &Address) {
+    ContractInitializedEvent {
+        admin: admin.clone(),
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
 pub struct MarketCreatedEvent {
     #[topic]
     pub market_id: u32,
@@ -192,6 +215,32 @@ mod tests {
         testutils::{Address as _, Events as _},
         Env, IntoVal, Map, String, Symbol, TryIntoVal, Val,
     };
+
+    #[test]
+    fn test_emit_contract_initialized() {
+        let env = Env::default();
+        let contract_id = env.register(MarketContract, ());
+        let admin = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            emit_contract_initialized(&env, &admin);
+        });
+
+        let events = env.events().all();
+        assert_eq!(events.len(), 1);
+
+        let event = events.first().unwrap();
+        let topics = &event.1;
+
+        let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+        assert_eq!(
+            topic0,
+            Symbol::new(&env, "contract_initialized_event")
+        );
+
+        let topic1: Address = topics.get(1).unwrap().into_val(&env);
+        assert_eq!(topic1, admin);
+    }
 
     #[test]
     fn test_emit_market_created() {

--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -7,6 +7,8 @@ use soroban_sdk::{contractevent, Address, Env, String};
 pub struct ContractInitializedEvent {
     #[topic]
     pub admin: Address,
+    /// Ledger timestamp when the contract was bootstrapped.
+    pub initialized_at: u64,
 }
 
 /// Emit an event when the contract is initialized with an admin.
@@ -21,6 +23,7 @@ pub struct ContractInitializedEvent {
 pub fn emit_contract_initialized(env: &Env, admin: &Address) {
     ContractInitializedEvent {
         admin: admin.clone(),
+        initialized_at: env.ledger().timestamp(),
     }
     .publish(env);
 }
@@ -240,6 +243,13 @@ mod tests {
 
         let topic1: Address = topics.get(1).unwrap().into_val(&env);
         assert_eq!(topic1, admin);
+
+        let data: Map<Symbol, Val> = event.2.try_into_val(&env).unwrap();
+        let initialized_at_val: u64 = data
+            .get(Symbol::new(&env, "initialized_at"))
+            .unwrap()
+            .into_val(&env);
+        assert_eq!(initialized_at_val, env.ledger().timestamp());
     }
 
     #[test]

--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -477,10 +477,7 @@ mod tests {
         let topics = &event.1;
 
         let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
-        assert_eq!(
-            topic0,
-            Symbol::new(&env, "contract_initialized_event")
-        );
+        assert_eq!(topic0, Symbol::new(&env, "contract_initialized_event"));
 
         let topic1: Address = topics.get(1).unwrap().into_val(&env);
         assert_eq!(topic1, admin);

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -66,6 +66,20 @@ impl MarketContract {
     /// );
     /// assert_eq!(market_id, 1);
     /// ```
+    /// Bootstrap the contract by setting the admin address.
+    ///
+    /// Must be called once by the admin immediately after deployment.
+    /// Subsequent calls return [`ContractError::AlreadyInitialized`].
+    pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        if storage::has_admin(&env) {
+            return Err(ContractError::AlreadyInitialized);
+        }
+        storage::set_admin(&env, &admin);
+        events::emit_contract_initialized(&env, &admin);
+        Ok(())
+    }
+
     pub fn initialize_market(
         env: Env,
         creator: Address,

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -25,6 +25,48 @@ pub struct MarketContract;
 
 #[contractimpl]
 impl MarketContract {
+    /// One-time contract bootstrap. Must be called exactly once after WASM deploy.
+    ///
+    /// Sets the contract admin, which is required before any market can be created.
+    /// Subsequent calls are rejected with [`ContractError::AlreadyInitialized`] to
+    /// prevent admin hijacking.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban contract environment
+    /// * `admin` - Address that will become the contract admin (must authorize)
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// - [`ContractError::AlreadyInitialized`] – contract was already initialized
+    ///
+    /// # Events
+    /// Emits [`ContractInitializedEvent`] with `admin` as both topic and payload.
+    ///
+    /// # Example
+    /// ```ignore
+    /// client.initialize(&admin);
+    /// // subsequent calls return AlreadyInitialized
+    /// ```
+    pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
+        // 1. Require the admin's authorization (cryptographic proof of ownership)
+        admin.require_auth();
+
+        // 2. Guard against re-initialization — prevent admin hijack on replay
+        if storage::has_admin(&env) {
+            return Err(ContractError::AlreadyInitialized);
+        }
+
+        // 3. Persist the admin address
+        storage::set_admin(&env, &admin);
+
+        // 4. Emit event so indexers and frontends can confirm bootstrap
+        events::emit_contract_initialized(&env, &admin);
+
+        Ok(())
+    }
+
     /// Initialize a new market
     pub fn initialize_market(
         env: Env,

--- a/contracts/market/src/storage.rs
+++ b/contracts/market/src/storage.rs
@@ -55,6 +55,12 @@ pub fn set_admin(env: &Env, admin: &Address) {
     env.storage().persistent().set(&ADMIN_KEY, admin);
 }
 
+/// Returns `true` if the admin slot has been populated (i.e. `initialize` was
+/// already called), `false` on a freshly deployed contract.
+pub fn has_admin(env: &Env) -> bool {
+    env.storage().persistent().has(&ADMIN_KEY)
+}
+
 pub fn get_next_market_id(env: &Env) -> u32 {
     env.storage().persistent().get(&COUNTER_KEY).unwrap_or(0)
 }
@@ -79,7 +85,9 @@ mod test {
         let contract_id = env.register(crate::MarketContract, ());
 
         env.as_contract(&contract_id, || {
+            assert!(!has_admin(&env), "admin slot should be empty before set");
             set_admin(&env, &admin);
+            assert!(has_admin(&env), "admin slot should be populated after set");
             assert_eq!(get_admin(&env), admin);
         });
     }

--- a/contracts/market/src/storage.rs
+++ b/contracts/market/src/storage.rs
@@ -70,7 +70,7 @@ pub fn set_admin(env: &Env, admin: &Address) {
 /// Returns `true` if the admin slot has been populated (i.e. `initialize` was
 /// already called), `false` on a freshly deployed contract.
 pub fn has_admin(env: &Env) -> bool {
-    env.storage().persistent().has(&ADMIN_KEY)
+    env.storage().persistent().has(&StorageKey::Admin)
 }
 
 pub fn get_next_market_id(env: &Env) -> u32 {

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -437,4 +437,70 @@ mod test {
         assert_eq!(market.status, MarketStatus::Resolved);
         assert_eq!(market.result, Some(outcome));
     }
+
+    // ========== initialize tests ==========
+
+    /// Helper that returns a fresh env + contract with NO admin set.
+    fn create_uninitialized_contract<'a>() -> (Env, Address, MarketContractClient<'a>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(MarketContract, ());
+        let client = MarketContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        (env, admin, client)
+    }
+
+    #[test]
+    fn test_initialize_sets_admin_and_emits_event() {
+        let (env, admin, client) = create_uninitialized_contract();
+
+        client.initialize(&admin);
+
+        // Event should carry the admin address as topic
+        let events = env.events().all();
+        assert!(!events.is_empty(), "expected ContractInitialized event");
+        let topic0: soroban_sdk::Symbol = events.last().unwrap().1.get(0).unwrap().into_val(&env);
+        assert_eq!(
+            topic0,
+            soroban_sdk::Symbol::new(&env, "contract_initialized_event")
+        );
+    }
+
+    #[test]
+    fn test_initialize_allows_subsequent_market_creation() {
+        let (env, admin, client) = create_uninitialized_contract();
+
+        // Bootstrap via public API
+        client.initialize(&admin);
+
+        let question = String::from_str(&env, "Will ETH flip BTC?");
+        let end_time = env.ledger().timestamp() + 86400;
+        let oracle_pubkey = BytesN::from_array(&env, &[1u8; 32]);
+        let collateral_token = Address::generate(&env);
+
+        let market_id =
+            client.initialize_market(&admin, &question, &end_time, &oracle_pubkey, &collateral_token);
+        assert_eq!(market_id, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #42)")]
+    fn test_initialize_twice_fails_with_already_initialized() {
+        let (env, admin, client) = create_uninitialized_contract();
+
+        client.initialize(&admin);
+        // Second call must fail with AlreadyInitialized (#42)
+        client.initialize(&admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #42)")]
+    fn test_initialize_second_admin_fails() {
+        let (env, admin, client) = create_uninitialized_contract();
+        let attacker = Address::generate(&env);
+
+        client.initialize(&admin);
+        // An attacker trying to replace the admin must be rejected
+        client.initialize(&attacker);
+    }
 }


### PR DESCRIPTION
Closes #245 

This PR:

- Add ContractError::AlreadyInitialized (#42) to error.rs to guard against re-initialization replay attacks on the admin slot
- Add storage::has_admin() helper that returns true when the ADMIN_KEY persistent slot is populated; used by initialize() to enforce one-time bootstrap semantics
- Add ContractInitializedEvent and emit_contract_initialized() to events.rs so off-chain indexers can confirm which address owns a freshly deployed contract

- Expose MarketContract::initialize(env, admin) in lib.rs:
    1. admin.require_auth()  — cryptographic proof of ownership
    2. Guard: if has_admin() -> Err(AlreadyInitialized)  — prevents hijack
    3. storage::set_admin()  — persists the admin address
    4. emit_contract_initialized()  — publishes the bootstrap event

The new function gives deployers a safe, authorized on-chain path to bootstrap the contract.

- Add tests in test.rs covering:
    * test_initialize_sets_admin_and_emits_event
    * test_initialize_allows_subsequent_market_creation
    * test_initialize_twice_fails_with_already_initialized
    * test_initialize_second_admin_fails

- Extend storage test: test_admin_storage now asserts has_admin() returns false before set_admin() and true after
- Extend events test: test_emit_contract_initialized verifies topic symbol and admin address topic