### PR TITLE
feat(contracts): add two-step admin transfer and ownership rotation

### DIFF
--- a/contracts/market/src/error.rs
+++ b/contracts/market/src/error.rs
@@ -127,6 +127,12 @@ pub enum ContractError {
     /// an attacker to hijack the admin slot after initial deploy.
     AlreadyInitialized = 42,
 
+    /// No pending admin transfer exists.
+    ///
+    /// `accept_admin` was called but `propose_admin` has not been issued yet,
+    /// or the previous proposal was already accepted.
+    NoPendingAdmin = 43,
+
     // ========== Token Errors (50-59) ==========
     /// Token transfer failed (insufficient balance, approval, etc.).
     ///
@@ -164,6 +170,8 @@ mod tests {
         assert_eq!(ContractError::InvalidQuestion as u32, 33);
         assert_eq!(ContractError::Unauthorized as u32, 40);
         assert_eq!(ContractError::NotAdmin as u32, 41);
+        assert_eq!(ContractError::AlreadyInitialized as u32, 42);
+        assert_eq!(ContractError::NoPendingAdmin as u32, 43);
         assert_eq!(ContractError::TokenTransferFailed as u32, 50);
         assert_eq!(ContractError::ArithmeticOverflow as u32, 60);
     }

--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -451,6 +451,44 @@ pub fn emit_fee_calculated(
     .publish(env);
 }
 
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct AdminTransferProposedEvent {
+    #[topic]
+    pub current_admin: Address,
+    #[topic]
+    pub pending_admin: Address,
+    pub proposed_at: u64,
+}
+
+pub fn emit_admin_transfer_proposed(env: &Env, current_admin: &Address, pending_admin: &Address) {
+    AdminTransferProposedEvent {
+        current_admin: current_admin.clone(),
+        pending_admin: pending_admin.clone(),
+        proposed_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct AdminTransferAcceptedEvent {
+    #[topic]
+    pub old_admin: Address,
+    #[topic]
+    pub new_admin: Address,
+    pub accepted_at: u64,
+}
+
+pub fn emit_admin_transfer_accepted(env: &Env, old_admin: &Address, new_admin: &Address) {
+    AdminTransferAcceptedEvent {
+        old_admin: old_admin.clone(),
+        new_admin: new_admin.clone(),
+        accepted_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -80,6 +80,54 @@ impl MarketContract {
         Ok(())
     }
 
+    /// Begin a two-step admin transfer by nominating a new admin address.
+    ///
+    /// Only the current admin may call this. The nominated address becomes the
+    /// pending admin and must confirm the transfer by calling [`accept_admin`].
+    /// Calling this again before acceptance overwrites the previous nomination.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] – contract is not initialized or `current_admin` is not the stored admin
+    pub fn propose_admin(
+        env: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), ContractError> {
+        if !storage::has_admin(&env) {
+            return Err(ContractError::NotAdmin);
+        }
+        let stored_admin = storage::get_admin(&env);
+        if current_admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        current_admin.require_auth();
+        storage::set_pending_admin(&env, &new_admin);
+        events::emit_admin_transfer_proposed(&env, &current_admin, &new_admin);
+        Ok(())
+    }
+
+    /// Complete a two-step admin transfer by accepting a pending nomination.
+    ///
+    /// Must be called by the address that was nominated via [`propose_admin`].
+    /// On success the caller becomes the new admin and the pending nomination
+    /// is cleared.
+    ///
+    /// # Errors
+    /// - [`ContractError::NoPendingAdmin`] – no nomination is outstanding
+    /// - [`ContractError::Unauthorized`] – `new_admin` does not match the pending nomination
+    pub fn accept_admin(env: Env, new_admin: Address) -> Result<(), ContractError> {
+        let pending = storage::get_pending_admin(&env).ok_or(ContractError::NoPendingAdmin)?;
+        if new_admin != pending {
+            return Err(ContractError::Unauthorized);
+        }
+        new_admin.require_auth();
+        let old_admin = storage::get_admin(&env);
+        storage::set_admin(&env, &new_admin);
+        storage::clear_pending_admin(&env);
+        events::emit_admin_transfer_accepted(&env, &old_admin, &new_admin);
+        Ok(())
+    }
+
     pub fn initialize_market(
         env: Env,
         creator: Address,

--- a/contracts/market/src/storage.rs
+++ b/contracts/market/src/storage.rs
@@ -11,6 +11,7 @@ pub enum StorageKey {
     Market(u32),
     Position(u32, Address),
     Admin,
+    PendingAdmin,
     MarketCounter,
 }
 
@@ -71,6 +72,20 @@ pub fn set_admin(env: &Env, admin: &Address) {
 /// already called), `false` on a freshly deployed contract.
 pub fn has_admin(env: &Env) -> bool {
     env.storage().persistent().has(&StorageKey::Admin)
+}
+
+pub fn get_pending_admin(env: &Env) -> Option<Address> {
+    env.storage().persistent().get(&StorageKey::PendingAdmin)
+}
+
+pub fn set_pending_admin(env: &Env, admin: &Address) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::PendingAdmin, admin);
+}
+
+pub fn clear_pending_admin(env: &Env) {
+    env.storage().persistent().remove(&StorageKey::PendingAdmin);
 }
 
 pub fn get_next_market_id(env: &Env) -> u32 {

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -700,4 +700,172 @@ mod test {
             Err(ContractError::InvalidQuantity)
         );
     }
+
+    // ========== propose_admin / accept_admin tests ==========
+
+    #[test]
+    fn test_propose_admin_success() {
+        let (env, admin, client, contract_id) = create_test_contract();
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                storage::get_pending_admin(&env).expect("pending admin should be set"),
+                new_admin
+            );
+        });
+    }
+
+    #[test]
+    fn test_propose_admin_emits_event() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+
+        let events = env.events().all();
+        assert!(events.len() > 0);
+    }
+
+    #[test]
+    fn test_accept_admin_completes_transfer() {
+        let (env, admin, client, contract_id) = create_test_contract();
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+        client.accept_admin(&new_admin);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(storage::get_admin(&env), new_admin);
+            assert!(
+                storage::get_pending_admin(&env).is_none(),
+                "pending admin should be cleared after acceptance"
+            );
+        });
+    }
+
+    #[test]
+    fn test_accept_admin_emits_event() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+        env.events().all(); // clear
+
+        client.accept_admin(&new_admin);
+
+        let events = env.events().all();
+        assert!(events.len() > 0);
+    }
+
+    #[test]
+    fn test_new_admin_can_create_market_after_transfer() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+        client.accept_admin(&new_admin);
+
+        let question = String::from_str(&env, "Will ETH flip BTC?");
+        let end_time = env.ledger().timestamp() + 86400;
+        let oracle_pubkey = BytesN::from_array(&env, &[1u8; 32]);
+        let collateral_token = Address::generate(&env);
+
+        let market_id =
+            client.initialize_market(&new_admin, &question, &end_time, &oracle_pubkey, &collateral_token);
+        assert_eq!(market_id, 1);
+    }
+
+    #[test]
+    fn test_old_admin_cannot_create_market_after_transfer() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+        client.accept_admin(&new_admin);
+
+        let question = String::from_str(&env, "Will ETH flip BTC?");
+        let end_time = env.ledger().timestamp() + 86400;
+        let oracle_pubkey = BytesN::from_array(&env, &[1u8; 32]);
+        let collateral_token = Address::generate(&env);
+
+        let result =
+            client.try_initialize_market(&admin, &question, &end_time, &oracle_pubkey, &collateral_token);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_propose_admin_overwrites_previous_nominee() {
+        let (env, admin, client, contract_id) = create_test_contract();
+        let first_nominee = Address::generate(&env);
+        let second_nominee = Address::generate(&env);
+
+        client.propose_admin(&admin, &first_nominee);
+        client.propose_admin(&admin, &second_nominee);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                storage::get_pending_admin(&env).expect("pending admin should be set"),
+                second_nominee
+            );
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #41)")]
+    fn test_propose_admin_non_admin_fails() {
+        let (env, _admin, client, _contract_id) = create_test_contract();
+        let attacker = Address::generate(&env);
+        let victim = Address::generate(&env);
+
+        client.propose_admin(&attacker, &victim);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #41)")]
+    fn test_propose_admin_when_not_initialized_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(MarketContract, ());
+        let client = MarketContractClient::new(&env, &contract_id);
+
+        let caller = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        client.propose_admin(&caller, &new_admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #43)")]
+    fn test_accept_admin_with_no_pending_fails() {
+        let (env, _admin, client, _contract_id) = create_test_contract();
+        let attacker = Address::generate(&env);
+
+        client.accept_admin(&attacker);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #40)")]
+    fn test_accept_admin_hijack_wrong_address_fails() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let new_admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+        client.accept_admin(&attacker);
+    }
+
+    #[test]
+    fn test_first_nominee_cannot_accept_after_overwrite() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let first_nominee = Address::generate(&env);
+        let second_nominee = Address::generate(&env);
+
+        client.propose_admin(&admin, &first_nominee);
+        client.propose_admin(&admin, &second_nominee);
+
+        let result = client.try_accept_admin(&first_nominee);
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
- Add propose_admin() and accept_admin() two-step pattern
- Reject transfer if contract not initialized
- Update storage.rs with pending_admin key
- Add error variants in error.rs for unauthorized attempts
- Add tests for hijack prevention

Closes #273