### PR TITLE
fix(contracts): reconcile locked_collateral between deposit, update_position, and withdraw

### DIFF
--- a/contracts/market/MIGRATION.md
+++ b/contracts/market/MIGRATION.md
@@ -1,0 +1,51 @@
+# Migration: `Position::locked_collateral` is now share-based only (#262)
+
+## What changed
+
+`Position::locked_collateral` is now exclusively a derived, share-based value
+maintained by `positions::update_position` (via `calculate_locked_collateral`).
+No other code path writes to this field:
+
+- `deposit_collateral` only increments `total_deposited`. It no longer adds
+  the deposit amount to `locked_collateral`.
+- `withdraw_unused_collateral` reads `Position::locked_collateral` directly
+  instead of recomputing a required lock from a hardcoded 50/50 market price.
+
+## Why
+
+Before this change, three code paths computed "locked collateral" three
+different ways:
+
+- `deposit_collateral` set `locked_collateral = locked_collateral + amount`,
+  so a user who deposited but never bought any shares already showed their
+  entire deposit as locked.
+- `update_position` correctly set `locked_collateral` from
+  `calculate_locked_collateral(yes_shares, no_shares, market_price)`.
+- `withdraw_unused_collateral` ignored the stored field entirely and
+  recomputed its own lock using a hardcoded `MARKET_PRICE_BPS = 5_000`,
+  which diverged from the real trade price whenever shares were bought at
+  any price other than 50/50.
+
+## Impact on existing/seeded state and test fixtures
+
+Any `Position` record (on-chain, in a local snapshot, or hand-built in a
+test) that was produced by the old `deposit_collateral` and has
+`locked_collateral == total_deposited` while `yes_shares == 0 && no_shares
+== 0` reflects the old, incorrect accounting. It must be recomputed, not
+copied forward:
+
+- The correct value for such a position is `locked_collateral = 0` (no
+  shares means nothing is locked).
+- Positions that do hold shares should have `locked_collateral` recomputed
+  via `calculate_locked_collateral(yes_shares, no_shares, market_price)` at
+  whatever price the shares were actually bought at — not assumed to be
+  50/50.
+- There were no fixture/snapshot files checked into this repo at the time of
+  this change (`tests/`, `contracts/market/src` contain only inline test
+  data), so no files needed editing. Hand-built `Position { .. }` literals in
+  existing tests already set `locked_collateral` to the share-based value
+  directly and did not need changes. If you maintain seeded state outside
+  this repo (e.g. a local devnet snapshot or fixture data), re-derive
+  `locked_collateral` for every position using the rule above before
+  diffing against post-fix behavior, or the diff will look like a
+  regression when it is actually a correction.

--- a/contracts/market/src/deposit.rs
+++ b/contracts/market/src/deposit.rs
@@ -90,14 +90,17 @@ pub fn deposit_collateral(
         is_settled: false,
     });
 
-    // Add to total_deposited (total collateral user has in this market)
+    // Add to total_deposited (total collateral user has in this market).
+    //
+    // `locked_collateral` is NOT touched here. It represents collateral
+    // required to back the user's current YES/NO shares and is the single
+    // source of truth maintained exclusively by `positions::update_position`
+    // (see `calculate_locked_collateral`). A deposit with no shares held
+    // must leave `locked_collateral` at 0, otherwise `withdraw` (which now
+    // trusts this field directly) would see deposited-but-unused collateral
+    // as locked.
     position.total_deposited = position
         .total_deposited
-        .checked_add(amount)
-        .ok_or(ContractError::ArithmeticOverflow)?;
-    // Add to locked_collateral (available for buying shares until they trade)
-    position.locked_collateral = position
-        .locked_collateral
         .checked_add(amount)
         .ok_or(ContractError::ArithmeticOverflow)?;
 
@@ -314,6 +317,61 @@ mod tests {
             storage::get_position(&env, market_id, &user).expect("position should exist")
         });
         assert_eq!(position.total_deposited, deposit_amount);
-        assert_eq!(position.locked_collateral, deposit_amount);
+        // locked_collateral is share-based and is untouched by deposit; see
+        // `test_deposit_with_zero_shares_keeps_locked_collateral_zero` below.
+        assert_eq!(position.locked_collateral, 0);
+    }
+
+    /// Regression test for #262: a deposit with zero shares held must never
+    /// show any collateral as locked. Before the fix, `deposit_collateral`
+    /// incremented `locked_collateral` by the deposit amount directly,
+    /// making freshly deposited (and entirely unused) collateral look
+    /// "locked" even though the user had not bought any YES/NO shares.
+    #[test]
+    fn test_deposit_with_zero_shares_keeps_locked_collateral_zero() {
+        let env = setup_env();
+        let user = Address::generate(&env);
+        let market_id = 1;
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let collateral_token = token.address();
+        let contract_id = env.register(crate::MarketContract, ());
+
+        let market = create_test_market(&env, market_id, &collateral_token);
+        env.as_contract(&contract_id, || {
+            storage::set_market(&env, market_id, &market);
+        });
+
+        env.mock_all_auths();
+        let token_client = StellarAssetClient::new(&env, &collateral_token);
+        token_client.mint(&user, &10_000);
+
+        let deposit_amount = 5_000i128;
+        let result = env.as_contract(&contract_id, || {
+            deposit_collateral(env.clone(), user.clone(), market_id, deposit_amount)
+        });
+        assert!(result.is_ok());
+
+        let position = env.as_contract(&contract_id, || {
+            storage::get_position(&env, market_id, &user).expect("position should exist")
+        });
+        assert_eq!(position.yes_shares, 0);
+        assert_eq!(position.no_shares, 0);
+        assert_eq!(position.total_deposited, deposit_amount);
+        assert_eq!(position.locked_collateral, 0);
+
+        // A second deposit must keep locked_collateral at 0 while
+        // total_deposited keeps growing.
+        let second_deposit = 1_000i128;
+        let result = env.as_contract(&contract_id, || {
+            deposit_collateral(env.clone(), user.clone(), market_id, second_deposit)
+        });
+        assert!(result.is_ok());
+
+        let position = env.as_contract(&contract_id, || {
+            storage::get_position(&env, market_id, &user).expect("position should exist")
+        });
+        assert_eq!(position.total_deposited, deposit_amount + second_deposit);
+        assert_eq!(position.locked_collateral, 0);
     }
 }

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -1,15 +1,16 @@
 //! Withdraw unused collateral from a market.
 //!
 //! Users can withdraw collateral that is not locked by their active positions.
-//! Locked collateral is computed from YES/NO shares using a 50/50 market price.
-//!
-//! TODO(#160): Support dynamic market price for locked collateral calculation
-//! instead of the hardcoded 50/50 price. This will require reading the current
-//! market price from storage once price discovery is implemented.
+//! `Position::locked_collateral` is the single source of truth for how much
+//! collateral is currently required to back a user's YES/NO shares: it is
+//! computed and persisted exclusively by `positions::update_position` (via
+//! `calculate_locked_collateral`) at the real trade price. Withdraw must
+//! trust that stored value rather than recompute its own lock from a
+//! hardcoded price, otherwise its view of "locked" can diverge from what was
+//! actually locked when shares were bought at a price other than 50/50.
 
 use crate::error::ContractError;
 use crate::events::{emit_collateral_withdrawn, emit_fee_calculated, emit_withdraw_edge_case};
-use crate::positions::calculate_locked_collateral;
 use crate::storage;
 use crate::types::{MarketStatus, Position};
 use crate::validation;
@@ -17,13 +18,11 @@ use crate::validation;
 use soroban_sdk::token::Client as TokenClient;
 use soroban_sdk::{Address, Env};
 
-/// Market price used for locked collateral calculation (50/50 = 5000 basis points).
-const MARKET_PRICE_BPS: i128 = 5_000;
-
 /// Withdraw unused collateral from a market.
 ///
-/// Computes how much collateral is locked by the user's YES/NO shares at the
-/// current 50/50 market price, then allows withdrawing any remaining balance.
+/// Reads the collateral already locked by the user's YES/NO shares from
+/// `Position::locked_collateral` (kept up to date by `update_position`), then
+/// allows withdrawing any remaining balance.
 ///
 /// # Arguments
 /// * `env` - Contract environment
@@ -76,8 +75,7 @@ pub fn withdraw_unused_collateral(
 
     // TODO(#85): fee deduction should be applied here before computing available collateral
     // See: https://github.com/Vatix-Protocol/vatix-contract/issues/85
-    let required_lock =
-        calculate_locked_collateral(position.yes_shares, position.no_shares, MARKET_PRICE_BPS);
+    let required_lock = position.locked_collateral;
 
     // Available collateral is total deposited minus the amount required to back shares.
     let available = if position.total_deposited > required_lock {

--- a/tests/collateral_invariant_test.rs
+++ b/tests/collateral_invariant_test.rs
@@ -1,0 +1,176 @@
+//! Regression and property tests for #262: reconciling `Position::locked_collateral`
+//! between `deposit_collateral`, `update_position`, and `withdraw_unused_collateral`.
+//!
+//! Before the fix:
+//! - `deposit_collateral` incremented `locked_collateral` by the deposit amount,
+//!   so a deposit with zero shares already looked "locked".
+//! - `withdraw_unused_collateral` ignored the stored `locked_collateral` and
+//!   recomputed its own lock from a hardcoded 50/50 price, diverging from
+//!   whatever price `update_position` actually used.
+//!
+//! These tests assert the core invariant `locked_collateral <= total_deposited`
+//! holds across deposit -> update_position -> withdraw sequences, and pin down
+//! the two concrete regressions described above.
+
+#[allow(dead_code)]
+mod helpers;
+
+use helpers::MarketParams;
+
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env};
+use vatix_market_contract::{storage, MarketContract, MarketContractClient};
+
+const STROOPS_PER_USDC: i128 = 10_000_000;
+
+/// Register the contract, create a market backed by a real asset, and fund +
+/// deposit `deposit` stroops for a fresh user.
+///
+/// Returns the env, contract id, market id, and user.
+fn setup_market(deposit: i128) -> (Env, Address, u32, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(MarketContract, ());
+    let client = MarketContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &admin);
+    });
+
+    let token_admin = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(token_admin);
+    let collateral_token = token.address();
+
+    let mut params = MarketParams::default_valid(&env);
+    params.collateral_token = collateral_token.clone();
+
+    let market_id = client.initialize_market(
+        &admin,
+        &params.question,
+        &params.end_time,
+        &params.oracle_pubkey,
+        &params.collateral_token,
+    );
+
+    let user = Address::generate(&env);
+    StellarAssetClient::new(&env, &collateral_token).mint(&user, &deposit);
+    client.deposit_collateral(&user, &market_id, &deposit);
+
+    (env, contract_id, market_id, user)
+}
+
+/// Regression test: a deposit with zero shares held must show zero locked
+/// collateral, not the deposited amount.
+#[test]
+fn deposit_with_zero_shares_has_zero_locked_collateral() {
+    let deposit = 50 * STROOPS_PER_USDC;
+    let (env, contract_id, market_id, user) = setup_market(deposit);
+
+    let position = env.as_contract(&contract_id, || {
+        storage::get_position(&env, market_id, &user).expect("position should exist")
+    });
+
+    assert_eq!(position.yes_shares, 0);
+    assert_eq!(position.no_shares, 0);
+    assert_eq!(position.total_deposited, deposit);
+    assert_eq!(position.locked_collateral, 0);
+}
+
+/// Regression test: withdraw must use the real trade price recorded by
+/// `update_position`, not a hardcoded 50/50 split.
+#[test]
+fn withdraw_uses_real_trade_price_not_hardcoded_fifty_fifty() {
+    let deposit = 100 * STROOPS_PER_USDC;
+    let (env, contract_id, market_id, user) = setup_market(deposit);
+    let client = MarketContractClient::new(&env, &contract_id);
+
+    // Buy 100 YES shares at 60% -> locks 60 USDC (not the 50 USDC a
+    // hardcoded 50/50 calculation would produce).
+    let yes_shares = 100 * STROOPS_PER_USDC;
+    client.update_position(&user, &market_id, &yes_shares, &0i128, &6_000i128);
+
+    let position = env.as_contract(&contract_id, || {
+        storage::get_position(&env, market_id, &user).expect("position should exist")
+    });
+    assert_eq!(position.locked_collateral, 60 * STROOPS_PER_USDC);
+
+    // Under the old hardcoded-50% logic, available would be 100 - 50 = 50,
+    // so withdrawing 45 would have succeeded. The real lock is 60, leaving
+    // only 40 available, so this must now fail.
+    let over_withdraw =
+        client.try_withdraw_unused_collateral(&user, &market_id, &(45 * STROOPS_PER_USDC));
+    assert!(over_withdraw.is_err());
+
+    // Exactly the truly available 40 USDC can be withdrawn.
+    client.withdraw_unused_collateral(&user, &market_id, &(40 * STROOPS_PER_USDC));
+
+    let position = env.as_contract(&contract_id, || {
+        storage::get_position(&env, market_id, &user).expect("position should exist")
+    });
+    assert_eq!(position.total_deposited, 60 * STROOPS_PER_USDC);
+    assert_eq!(position.locked_collateral, 60 * STROOPS_PER_USDC);
+}
+
+/// Property test: across many randomized deposit -> buy -> withdraw
+/// sequences (at random, non-50/50 prices), `locked_collateral` must never
+/// exceed `total_deposited`, and must never go negative.
+#[test]
+fn property_locked_collateral_never_exceeds_total_deposited() {
+    let mut rng = StdRng::seed_from_u64(0x262);
+
+    for trial in 0u32..40 {
+        let deposit_fraction = rng.gen_range(1u64..=500);
+        let deposit_amount = (deposit_fraction as i128) * STROOPS_PER_USDC;
+        let (env, contract_id, market_id, user) = setup_market(deposit_amount);
+        let client = MarketContractClient::new(&env, &contract_id);
+
+        let steps = rng.gen_range(1u32..=10);
+        for _ in 0..steps {
+            let price = rng.gen_range(1u64..=9_999) as i128;
+
+            let position = env.as_contract(&contract_id, || {
+                storage::get_position(&env, market_id, &user).expect("position should exist")
+            });
+
+            match rng.gen_range(0u32..3) {
+                0 => {
+                    // Buy a random amount of YES shares, bounded by total
+                    // deposited so most attempts succeed without overflow.
+                    let pct = rng.gen_range(0u64..=100);
+                    let yes_delta = position.total_deposited * pct as i128 / 100;
+                    let _ =
+                        client.try_update_position(&user, &market_id, &yes_delta, &0i128, &price);
+                }
+                1 => {
+                    let pct = rng.gen_range(0u64..=100);
+                    let no_delta = position.total_deposited * pct as i128 / 100;
+                    let _ =
+                        client.try_update_position(&user, &market_id, &0i128, &no_delta, &price);
+                }
+                _ => {
+                    let pct = rng.gen_range(1u64..=100);
+                    let amount = (position.total_deposited * pct as i128 / 100).max(1);
+                    let _ = client.try_withdraw_unused_collateral(&user, &market_id, &amount);
+                }
+            }
+
+            let position = env.as_contract(&contract_id, || {
+                storage::get_position(&env, market_id, &user).expect("position should exist")
+            });
+
+            assert!(
+                position.locked_collateral <= position.total_deposited,
+                "trial {trial}: invariant violated, locked {} > deposited {}",
+                position.locked_collateral,
+                position.total_deposited
+            );
+            assert!(
+                position.locked_collateral >= 0,
+                "trial {trial}: locked_collateral went negative: {}",
+                position.locked_collateral
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #262.

`Position::locked_collateral` was being written by three different code paths that disagreed with each other:

- `deposit_collateral` incremented `locked_collateral` by the deposit amount, so a fresh deposit with **zero shares** already showed the entire deposit as "locked".
- `update_position` correctly computed it from shares via `calculate_locked_collateral(yes_shares, no_shares, market_price)`.
- `withdraw_unused_collateral` ignored the stored field entirely and recomputed its own lock using a hardcoded `MARKET_PRICE_BPS = 5_000` (50/50), diverging from whatever price shares were actually bought at (the existing tests in `positions.rs` use 6000 bps).

This PR makes `update_position`'s share-based calculation the single source of truth:

- `deposit_collateral` (`deposit.rs`) now only updates `total_deposited`; it no longer touches `locked_collateral`.
- `withdraw_unused_collateral` (`withdraw.rs`) now reads `position.locked_collateral` directly instead of recomputing it from a hardcoded price. The now-unused `MARKET_PRICE_BPS` constant and the `TODO(#160)` comment describing the hardcoded-price problem are removed, since the hardcoded price dependency in withdraw is gone (#160's broader dynamic-pricing scope for `update_position` itself is untouched).
- `positions.rs`/`calculate_locked_collateral` is unchanged — it was already correct and is now the only writer of `locked_collateral`.
- Added `contracts/market/MIGRATION.md` documenting the behavior change for anyone with pre-fix seeded/snapshot `Position` state (none exists in this repo's fixtures today, so no fixture files needed edits).
- Added `tests/collateral_invariant_test.rs` with:
  - a regression test that a deposit with zero shares yields `locked_collateral == 0`,
  - a regression test that withdraw respects the real trade price (60% in the test) rather than 50/50,
  - a randomized property test asserting `locked_collateral <= total_deposited` (and non-negative) across many deposit → buy → withdraw sequences.
- Updated `deposit.rs`'s existing unit test assertion that previously encoded the buggy behavior (`locked_collateral == deposit_amount`), and added a dedicated regression test for the zero-shares case.

## Test plan

- [x] `cargo test --workspace` — 134 tests passing (125 unit + 3 new integration + 6 existing integration)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` on the touched files (`deposit.rs`, `withdraw.rs`) — no new warnings. Note: clippy currently fails on `dev` for unrelated pre-existing lints in `settlement.rs` and `test.rs` (`len_zero`, `module_inception`) introduced by lint changes in newer `stable` toolchains; this PR does not touch those files and does not attempt to fix that pre-existing breakage.