### PR TITLE
fix(contracts): return InvalidSignature instead of panicking on bad oracle signatures

### DIFF
--- a/contracts/market/Cargo.toml
+++ b/contracts/market/Cargo.toml
@@ -10,8 +10,11 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
+# default-features = false: drops "std" (incompatible with this contract's
+# #![no_std]/wasm32v1-none target) and "fast"/"zeroize" (unneeded WASM size).
+# Used for oracle signature verification - see contracts/market/src/oracle.rs.
+ed25519-dalek = { version = "2.2.0", default-features = false }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
-ed25519-dalek = "2.2.0"
 rand = "0.8"

--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -381,7 +381,6 @@ pub fn emit_position_settled(
 
 #[contractevent]
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub struct OracleSignatureVerifiedEvent {
     #[topic]
     pub market_id: u32,
@@ -406,7 +405,6 @@ pub struct OracleSignatureVerifiedEvent {
 /// ```ignore
 /// emit_oracle_signature_verified(&env, 1, true, env.ledger().timestamp());
 /// ```
-#[allow(dead_code)]
 pub fn emit_oracle_signature_verified(env: &Env, market_id: u32, outcome: bool, verified_at: u64) {
     OracleSignatureVerifiedEvent {
         market_id,

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -222,6 +222,7 @@ impl MarketContract {
             &signature,
             &market.oracle_pubkey,
         )?;
+        events::emit_oracle_signature_verified(&env, market_id, outcome, env.ledger().timestamp());
 
         // Step 3: Update market (status, outcome, persist)
         market.status = MarketStatus::Resolved;

--- a/contracts/market/src/oracle.rs
+++ b/contracts/market/src/oracle.rs
@@ -7,6 +7,7 @@
 
 use crate::error::ContractError;
 use crate::types::Market;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use soroban_sdk::{Bytes, BytesN, Env};
 
 /// Construct the message that the oracle signs.
@@ -21,17 +22,37 @@ pub fn construct_oracle_message(env: &Env, market_id: u32, outcome: bool) -> Byt
     env.crypto().keccak256(&message).into()
 }
 
+/// Verify an ed25519 signature without panicking on invalid input.
+///
+/// `env.crypto().ed25519_verify` traps the host (an unrecoverable WASM trap,
+/// not a catchable error) when the signature fails to verify, so it cannot
+/// be used here — any failure must surface as a typed [`ContractError`].
+/// Verification is therefore done in pure Rust via `ed25519-dalek`, which
+/// reports failure as a `Result` instead of trapping.
+///
+/// Returns `false` if `pubkey` does not decode to a valid curve point or if
+/// the signature does not verify against `message`.
+fn verify_ed25519_safe(pubkey: &BytesN<32>, message: &BytesN<32>, signature: &BytesN<64>) -> bool {
+    let Ok(verifying_key) = VerifyingKey::from_bytes(&pubkey.to_array()) else {
+        return false;
+    };
+    let signature = Signature::from_bytes(&signature.to_array());
+    verifying_key
+        .verify(&message.to_array(), &signature)
+        .is_ok()
+}
+
 /// Verify that an oracle signature is valid for a market resolution.
 ///
 /// # Errors
 /// - [`ContractError::UnauthorizedOracle`] if `oracle_pubkey` is the zero key.
-/// - Panics if the Ed25519 signature is invalid (SDK limitation — see TODO below).
+/// - [`ContractError::InvalidSignature`] if the signature does not verify
+///   against `construct_oracle_message(env, market_id, outcome)`.
 ///
 /// # Security
-/// Uses Ed25519 signature verification via the Soroban crypto module.
-///
-/// TODO: `ed25519_verify` panics on invalid signatures. Consider `secp256k1_recover`
-/// for proper error handling.
+/// Uses Ed25519 signature verification, performed in pure Rust (see
+/// [`verify_ed25519_safe`]) rather than the host's `ed25519_verify`, so that
+/// an invalid signature returns a typed error instead of trapping the host.
 pub fn verify_oracle_signature(
     env: &Env,
     market_id: u32,
@@ -44,8 +65,9 @@ pub fn verify_oracle_signature(
     }
 
     let message = construct_oracle_message(env, market_id, outcome);
-    env.crypto()
-        .ed25519_verify(oracle_pubkey, &message.into(), signature);
+    if !verify_ed25519_safe(oracle_pubkey, &message, signature) {
+        return Err(ContractError::InvalidSignature);
+    }
 
     Ok(())
 }
@@ -196,16 +218,80 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_verify_invalid_signature() {
         let env = Env::default();
-        verify_oracle_signature(
+        let result = verify_oracle_signature(
             &env,
             123u32,
             true,
             &BytesN::random(&env),
             &BytesN::random(&env),
+        );
+        assert_eq!(result, Err(ContractError::InvalidSignature));
+    }
+
+    /// Generate an ed25519 keypair and sign `construct_oracle_message(market_id, outcome)`.
+    fn generate_keypair_and_sign(
+        env: &Env,
+        market_id: u32,
+        outcome: bool,
+    ) -> (BytesN<32>, BytesN<64>) {
+        use ed25519_dalek::{Signer, SigningKey};
+        use rand::rngs::OsRng;
+
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let message = construct_oracle_message(env, market_id, outcome);
+        let signature = signing_key.sign(message.to_array().as_slice());
+
+        (
+            BytesN::from_array(env, &signing_key.verifying_key().to_bytes()),
+            BytesN::from_array(env, &signature.to_bytes()),
         )
-        .unwrap();
+    }
+
+    #[test]
+    fn test_verify_valid_signature_succeeds() {
+        let env = Env::default();
+        let market_id = 1u32;
+        let outcome = true;
+        let (pubkey, signature) = generate_keypair_and_sign(&env, market_id, outcome);
+
+        let result = verify_oracle_signature(&env, market_id, outcome, &signature, &pubkey);
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn test_verify_signature_wrong_outcome_fails() {
+        let env = Env::default();
+        let market_id = 1u32;
+        let (pubkey, signature) = generate_keypair_and_sign(&env, market_id, true);
+
+        // Signature was produced for outcome=true; verifying against false must fail.
+        let result = verify_oracle_signature(&env, market_id, false, &signature, &pubkey);
+        assert_eq!(result, Err(ContractError::InvalidSignature));
+    }
+
+    #[test]
+    fn test_verify_signature_wrong_market_id_fails() {
+        let env = Env::default();
+        let outcome = true;
+        let (pubkey, signature) = generate_keypair_and_sign(&env, 1u32, outcome);
+
+        // Signature was produced for market_id=1; verifying against 2 must fail.
+        let result = verify_oracle_signature(&env, 2u32, outcome, &signature, &pubkey);
+        assert_eq!(result, Err(ContractError::InvalidSignature));
+    }
+
+    #[test]
+    fn test_verify_signature_from_different_keypair_fails() {
+        let env = Env::default();
+        let market_id = 1u32;
+        let outcome = true;
+        let (_pubkey, signature) = generate_keypair_and_sign(&env, market_id, outcome);
+        let (other_pubkey, _other_signature) = generate_keypair_and_sign(&env, market_id, outcome);
+
+        // Signature was produced by a different keypair than `other_pubkey`.
+        let result = verify_oracle_signature(&env, market_id, outcome, &signature, &other_pubkey);
+        assert_eq!(result, Err(ContractError::InvalidSignature));
     }
 }

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -332,7 +332,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Error(Contract, #20)")]
     fn test_resolve_market_invalid_signature() {
         let (env, admin, client, _contract_id) = create_test_contract();
 
@@ -350,11 +350,45 @@ mod test {
             &collateral_token,
         );
 
-        // Try to resolve with invalid signature - should panic
+        // Bad signature must surface as the typed InvalidSignature error
+        // (#20), not an uncaught host trap.
         let outcome = true;
         let invalid_signature = BytesN::random(&env);
         let market_id_str = String::from_str(&env, "1");
         client.resolve_market(&market_id_str, &outcome, &invalid_signature);
+    }
+
+    #[test]
+    fn test_resolve_market_invalid_signature_leaves_market_active() {
+        let (env, admin, client, contract_id) = create_test_contract();
+
+        let question = String::from_str(&env, "Test market");
+        let end_time = env.ledger().timestamp() + 86400;
+        let oracle_pubkey = BytesN::from_array(&env, &[1u8; 32]);
+        let collateral_token = Address::generate(&env);
+
+        let market_id = client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &collateral_token,
+        );
+
+        let outcome = true;
+        let invalid_signature = BytesN::random(&env);
+        let market_id_str = String::from_str(&env, "1");
+        let result = client.try_resolve_market(&market_id_str, &outcome, &invalid_signature);
+
+        assert_eq!(
+            result,
+            Err(Ok(crate::error::ContractError::InvalidSignature))
+        );
+
+        // Market must be untouched - no partial state mutation on failure.
+        let market = get_market_from_storage(&env, &contract_id, market_id);
+        assert_eq!(market.status, MarketStatus::Active);
+        assert_eq!(market.result, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `verify_oracle_signature` no longer relies on `env.crypto().ed25519_verify()`, which traps the WASM host (an unrecoverable trap, not a catchable `Result`) on an invalid signature. Verification is now done in pure Rust via `ed25519-dalek`, so invalid signatures return `Err(ContractError::InvalidSignature)` (`#20`) instead of crashing the call.
- `ed25519-dalek` was already a dev-dependency (used to generate test signatures); it's now also a normal `[dependencies]` entry with `default-features = false` so it builds under this contract's `#![no_std]` / `wasm32v1-none` target.
- `resolve_market` already propagated errors via `?` before mutating market state, so once `verify_oracle_signature` returns a real `Err`, a bad signature now correctly leaves the market `Active` (no partial state mutation) — added a regression test for this.
- Wired the previously dead `emit_oracle_signature_verified` event: now emitted in `resolve_market` right after a successful verification.
- Replaced both `#[should_panic]` tests (`oracle.rs`, `test.rs`) with assertions on the typed error, and added the test matrix from the issue: wrong outcome, wrong market_id, signature from a different keypair, and the happy path.

## Investigation note

I confirmed by reading the `soroban-sdk` v23 source (`crypto.rs`) that there is no non-panicking ed25519 verify API in the SDK (up to v23.5.3) — `ed25519_verify` discards its result and the host import itself never returns control to the contract on an invalid signature (a genuine WASM trap, not a Rust panic that could be caught). That's why this needed a pure-Rust verification path rather than a wrapper around the host call.

## Test plan

- [x] `cargo test --workspace` — 130 unit tests (contracts/market) + all integration tests under `tests/` pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --target wasm32-unknown-unknown --release` — builds, ~88KB wasm output
- [x] New test matrix: valid sig, random sig, wrong outcome, wrong market_id, different keypair, `resolve_market` invalid-sig leaves market `Active`, `resolve_market` valid-sig resolves market

## Integration notes (per issue)

- Backend oracle signer must produce `keccak256(market_id_be || outcome_byte)`, not a JSON payload — unchanged message format, just confirming alignment per the issue's request.
- Failed resolution (bad signature) now correctly emits no `MarketResolved` event and returns `#20`, rather than an opaque trap.

Fixes #246