### PR TITLE
Add resolution challenge lifecycle contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 default-members = [
   ".",
   "contracts/market",
+  "contracts/resolution",
 ]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Core smart contracts powering Vatix prediction markets, written in Rust for the 
 
 - **Market Contract**: Market creation, trading, and settlement logic
 - **Outcome Token**: Fungible tokens representing market outcomes
-- **Resolution Contract**: Oracle-based outcome resolution
+- **Resolution Contract**: Challenge-window lifecycle for oracle resolution candidates
 - **Treasury**: Fee collection and protocol management
 
 ## Tech Stack
@@ -31,6 +31,17 @@ Core smart contracts powering Vatix prediction markets, written in Rust for the 
 - Oracle-based resolution
 - Fee distribution
 - Market expiration and settlement
+
+## Resolution Lifecycle
+
+The Market Contract still owns the final `resolve_market(market_id, outcome, signature)` state transition. The separate Resolution Contract adds the missing on-chain challenge window that mirrors the backend `ResolutionCandidate` flow:
+
+1. `propose(proposer, market_id, outcome, signature, evidence_uri, challenge_window_seconds)` stores a signed candidate and publishes its `challenge_deadline`.
+2. `challenge(challenger, candidate_id, challenge_uri)` can be called until the deadline. A challenged candidate cannot be finalized.
+3. `finalize(finalizer, candidate_id)` succeeds only after the challenge window closes and returns the candidate payload.
+4. The backend or registered factory then submits the finalized candidate to `MarketContract::resolve_market`, using the stored outcome and oracle signature.
+
+`contracts/resolution` is intentionally a lifecycle and registration layer, not a replacement settlement engine. `initialize(admin, factory, market_contract)` registers the factory/market relationship so off-chain services can discover which resolution contract guards a market deployment.
 
 ## Event Catalog
 
@@ -76,6 +87,7 @@ pnpm build:web
 ```bash
 # Prerequisites: Rust toolchain, Soroban CLI
 cd contracts/market && cargo build
+cd ../resolution && cargo build
 ```
 
 ### Contributor issues

--- a/contracts/resolution/Cargo.toml
+++ b/contracts/resolution/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "vatix-resolution-contract"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/resolution/src/error.rs
+++ b/contracts/resolution/src/error.rs
@@ -1,0 +1,19 @@
+use soroban_sdk::contracterror;
+
+/// Error codes for the Vatix resolution candidate contract.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    CandidateNotFound = 1,
+    CandidateAlreadyExists = 2,
+    CandidateAlreadyChallenged = 3,
+    CandidateAlreadyFinalized = 4,
+    ChallengeWindowOpen = 5,
+    ChallengeWindowClosed = 6,
+    InvalidChallengeWindow = 7,
+    InvalidEvidenceUri = 8,
+    Unauthorized = 40,
+    NotAdmin = 41,
+    AlreadyInitialized = 42,
+}

--- a/contracts/resolution/src/events.rs
+++ b/contracts/resolution/src/events.rs
@@ -1,0 +1,94 @@
+use soroban_sdk::{contractevent, Address, Env, String};
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct ResolutionRegisteredEvent {
+    #[topic]
+    pub factory: Address,
+    pub market_contract: Address,
+    pub registered_at: u64,
+}
+
+pub fn emit_resolution_registered(env: &Env, factory: &Address, market_contract: &Address) {
+    ResolutionRegisteredEvent {
+        factory: factory.clone(),
+        market_contract: market_contract.clone(),
+        registered_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct CandidateProposedEvent {
+    #[topic]
+    pub candidate_id: u32,
+    #[topic]
+    pub market_id: u32,
+    pub outcome: bool,
+    pub proposer: Address,
+    pub evidence_uri: String,
+    pub challenge_deadline: u64,
+}
+
+pub fn emit_candidate_proposed(env: &Env, candidate: &crate::types::ResolutionCandidate) {
+    CandidateProposedEvent {
+        candidate_id: candidate.id,
+        market_id: candidate.market_id,
+        outcome: candidate.outcome,
+        proposer: candidate.proposer.clone(),
+        evidence_uri: candidate.evidence_uri.clone(),
+        challenge_deadline: candidate.challenge_deadline,
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct CandidateChallengedEvent {
+    #[topic]
+    pub candidate_id: u32,
+    #[topic]
+    pub market_id: u32,
+    pub challenger: Address,
+    pub challenge_uri: String,
+    pub challenged_at: u64,
+}
+
+pub fn emit_candidate_challenged(
+    env: &Env,
+    candidate_id: u32,
+    market_id: u32,
+    challenger: &Address,
+    challenge_uri: &String,
+) {
+    CandidateChallengedEvent {
+        candidate_id,
+        market_id,
+        challenger: challenger.clone(),
+        challenge_uri: challenge_uri.clone(),
+        challenged_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct CandidateFinalizedEvent {
+    #[topic]
+    pub candidate_id: u32,
+    #[topic]
+    pub market_id: u32,
+    pub outcome: bool,
+    pub finalized_at: u64,
+}
+
+pub fn emit_candidate_finalized(env: &Env, candidate: &crate::types::ResolutionCandidate) {
+    CandidateFinalizedEvent {
+        candidate_id: candidate.id,
+        market_id: candidate.market_id,
+        outcome: candidate.outcome,
+        finalized_at: candidate.finalized_at.unwrap_or(env.ledger().timestamp()),
+    }
+    .publish(env);
+}

--- a/contracts/resolution/src/lib.rs
+++ b/contracts/resolution/src/lib.rs
@@ -1,0 +1,223 @@
+#![no_std]
+
+mod error;
+mod events;
+mod storage;
+pub mod types;
+
+#[cfg(test)]
+mod test;
+
+use crate::error::ContractError;
+use crate::types::{CandidateStatus, ResolutionCandidate, ResolutionConfig};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String};
+
+const MIN_CHALLENGE_WINDOW_SECONDS: u64 = 60;
+const MAX_CHALLENGE_WINDOW_SECONDS: u64 = 14 * 24 * 60 * 60;
+const MAX_URI_BYTES: u32 = 512;
+
+#[contract]
+pub struct ResolutionContract;
+
+#[contractimpl]
+impl ResolutionContract {
+    /// Register the resolution lifecycle contract with its factory and market.
+    ///
+    /// The factory can index this contract as the challenge-window companion
+    /// for `market_contract`. Final settlement still happens through the
+    /// market contract's `resolve_market` function after a candidate finalizes.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        factory: Address,
+        market_contract: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        if storage::has_config(&env) {
+            return Err(ContractError::AlreadyInitialized);
+        }
+
+        storage::set_config(
+            &env,
+            &ResolutionConfig {
+                admin,
+                factory: factory.clone(),
+                market_contract: market_contract.clone(),
+            },
+        );
+        events::emit_resolution_registered(&env, &factory, &market_contract);
+        Ok(())
+    }
+
+    pub fn get_config(env: Env) -> ResolutionConfig {
+        storage::get_config(&env)
+    }
+
+    /// Update the registered factory address.
+    pub fn set_factory(env: Env, admin: Address, factory: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        let mut config = storage::get_config(&env);
+        require_admin(&admin, &config)?;
+        config.factory = factory.clone();
+        storage::set_config(&env, &config);
+        events::emit_resolution_registered(&env, &factory, &config.market_contract);
+        Ok(())
+    }
+
+    /// Update the market contract address that finalized candidates target.
+    pub fn set_market_contract(
+        env: Env,
+        admin: Address,
+        market_contract: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        let mut config = storage::get_config(&env);
+        require_admin(&admin, &config)?;
+        config.market_contract = market_contract.clone();
+        storage::set_config(&env, &config);
+        events::emit_resolution_registered(&env, &config.factory, &market_contract);
+        Ok(())
+    }
+
+    /// Propose a signed resolution candidate for a market.
+    ///
+    /// The returned candidate is the on-chain anchor for the backend
+    /// `ResolutionCandidate`: off-chain services may display the same
+    /// `challenge_deadline` and evidence URI while listening for challenge and
+    /// finalize events.
+    pub fn propose(
+        env: Env,
+        proposer: Address,
+        market_id: u32,
+        outcome: bool,
+        signature: BytesN<64>,
+        evidence_uri: String,
+        challenge_window_seconds: u64,
+    ) -> Result<u32, ContractError> {
+        proposer.require_auth();
+        storage::get_config(&env);
+        validate_uri(&evidence_uri)?;
+        validate_challenge_window(challenge_window_seconds)?;
+        if storage::get_candidate_id_for_market(&env, market_id).is_some() {
+            return Err(ContractError::CandidateAlreadyExists);
+        }
+
+        let proposed_at = env.ledger().timestamp();
+        let candidate = ResolutionCandidate {
+            id: storage::increment_candidate_id(&env),
+            market_id,
+            outcome,
+            signature,
+            proposer,
+            evidence_uri,
+            proposed_at,
+            challenge_deadline: proposed_at + challenge_window_seconds,
+            status: CandidateStatus::Proposed,
+            challenged_by: None,
+            challenge_uri: None,
+            finalized_at: None,
+        };
+
+        storage::set_candidate(&env, &candidate);
+        events::emit_candidate_proposed(&env, &candidate);
+        Ok(candidate.id)
+    }
+
+    /// Challenge a candidate while its challenge window is still open.
+    pub fn challenge(
+        env: Env,
+        challenger: Address,
+        candidate_id: u32,
+        challenge_uri: String,
+    ) -> Result<(), ContractError> {
+        challenger.require_auth();
+        validate_uri(&challenge_uri)?;
+
+        let mut candidate =
+            storage::get_candidate(&env, candidate_id).ok_or(ContractError::CandidateNotFound)?;
+        if candidate.status == CandidateStatus::Finalized {
+            return Err(ContractError::CandidateAlreadyFinalized);
+        }
+        if candidate.status == CandidateStatus::Challenged {
+            return Err(ContractError::CandidateAlreadyChallenged);
+        }
+        if env.ledger().timestamp() > candidate.challenge_deadline {
+            return Err(ContractError::ChallengeWindowClosed);
+        }
+
+        candidate.status = CandidateStatus::Challenged;
+        candidate.challenged_by = Some(challenger.clone());
+        candidate.challenge_uri = Some(challenge_uri.clone());
+        storage::set_candidate(&env, &candidate);
+        events::emit_candidate_challenged(
+            &env,
+            candidate_id,
+            candidate.market_id,
+            &challenger,
+            &challenge_uri,
+        );
+        Ok(())
+    }
+
+    /// Finalize an unchallenged candidate after its challenge window closes.
+    ///
+    /// This does not call `resolve_market` directly. It returns the signed
+    /// candidate payload so the backend/factory can submit
+    /// `market.resolve_market(market_id, outcome, signature)` as the final
+    /// market-state transition.
+    pub fn finalize(
+        env: Env,
+        finalizer: Address,
+        candidate_id: u32,
+    ) -> Result<ResolutionCandidate, ContractError> {
+        finalizer.require_auth();
+        let mut candidate =
+            storage::get_candidate(&env, candidate_id).ok_or(ContractError::CandidateNotFound)?;
+
+        if candidate.status == CandidateStatus::Finalized {
+            return Err(ContractError::CandidateAlreadyFinalized);
+        }
+        if candidate.status == CandidateStatus::Challenged {
+            return Err(ContractError::CandidateAlreadyChallenged);
+        }
+        if env.ledger().timestamp() <= candidate.challenge_deadline {
+            return Err(ContractError::ChallengeWindowOpen);
+        }
+
+        candidate.status = CandidateStatus::Finalized;
+        candidate.finalized_at = Some(env.ledger().timestamp());
+        storage::set_candidate(&env, &candidate);
+        events::emit_candidate_finalized(&env, &candidate);
+        Ok(candidate)
+    }
+
+    pub fn get_candidate(env: Env, candidate_id: u32) -> Option<ResolutionCandidate> {
+        storage::get_candidate(&env, candidate_id)
+    }
+
+    pub fn get_candidate_id_for_market(env: Env, market_id: u32) -> Option<u32> {
+        storage::get_candidate_id_for_market(&env, market_id)
+    }
+}
+
+fn require_admin(admin: &Address, config: &ResolutionConfig) -> Result<(), ContractError> {
+    if admin != &config.admin {
+        return Err(ContractError::NotAdmin);
+    }
+    Ok(())
+}
+
+fn validate_challenge_window(seconds: u64) -> Result<(), ContractError> {
+    if !(MIN_CHALLENGE_WINDOW_SECONDS..=MAX_CHALLENGE_WINDOW_SECONDS).contains(&seconds) {
+        return Err(ContractError::InvalidChallengeWindow);
+    }
+    Ok(())
+}
+
+fn validate_uri(uri: &String) -> Result<(), ContractError> {
+    let len = uri.len();
+    if len == 0 || len > MAX_URI_BYTES {
+        return Err(ContractError::InvalidEvidenceUri);
+    }
+    Ok(())
+}

--- a/contracts/resolution/src/storage.rs
+++ b/contracts/resolution/src/storage.rs
@@ -1,0 +1,60 @@
+use crate::types::{ResolutionCandidate, ResolutionConfig};
+use soroban_sdk::{contracttype, Env};
+
+#[contracttype]
+pub enum StorageKey {
+    Config,
+    CandidateCounter,
+    Candidate(u32),
+    CandidateByMarket(u32),
+}
+
+pub fn has_config(env: &Env) -> bool {
+    env.storage().persistent().has(&StorageKey::Config)
+}
+
+pub fn get_config(env: &Env) -> ResolutionConfig {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::Config)
+        .expect("Resolution config not set")
+}
+
+pub fn set_config(env: &Env, config: &ResolutionConfig) {
+    env.storage().persistent().set(&StorageKey::Config, config);
+}
+
+pub fn increment_candidate_id(env: &Env) -> u32 {
+    let next = env
+        .storage()
+        .persistent()
+        .get(&StorageKey::CandidateCounter)
+        .unwrap_or(0u32)
+        + 1;
+    env.storage()
+        .persistent()
+        .set(&StorageKey::CandidateCounter, &next);
+    next
+}
+
+pub fn get_candidate(env: &Env, candidate_id: u32) -> Option<ResolutionCandidate> {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::Candidate(candidate_id))
+}
+
+pub fn set_candidate(env: &Env, candidate: &ResolutionCandidate) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::Candidate(candidate.id), candidate);
+    env.storage().persistent().set(
+        &StorageKey::CandidateByMarket(candidate.market_id),
+        &candidate.id,
+    );
+}
+
+pub fn get_candidate_id_for_market(env: &Env, market_id: u32) -> Option<u32> {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::CandidateByMarket(market_id))
+}

--- a/contracts/resolution/src/test.rs
+++ b/contracts/resolution/src/test.rs
@@ -1,0 +1,136 @@
+use crate::{ContractError, ResolutionContract, ResolutionContractClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, BytesN, Env, String,
+};
+
+fn setup(env: &Env) -> (ResolutionContractClient<'_>, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(ResolutionContract, ());
+    let client = ResolutionContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let factory = Address::generate(env);
+    let market_contract = Address::generate(env);
+    client.initialize(&admin, &factory, &market_contract);
+    (client, admin)
+}
+
+fn signature(env: &Env) -> BytesN<64> {
+    BytesN::from_array(env, &[7u8; 64])
+}
+
+fn evidence(env: &Env) -> String {
+    String::from_str(env, "ipfs://resolution-evidence")
+}
+
+fn set_time(env: &Env, timestamp: u64) {
+    env.ledger().with_mut(|ledger| {
+        ledger.timestamp = timestamp;
+    });
+}
+
+#[test]
+fn propose_stores_candidate_with_challenge_deadline() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let candidate_id = client.propose(
+        &proposer,
+        &42,
+        &true,
+        &signature(&env),
+        &evidence(&env),
+        &300,
+    );
+
+    assert_eq!(candidate_id, 1);
+    let candidate = client.get_candidate(&candidate_id).unwrap();
+    assert_eq!(candidate.market_id, 42);
+    assert_eq!(candidate.outcome, true);
+    assert_eq!(candidate.challenge_deadline, 1_300);
+    assert_eq!(client.get_candidate_id_for_market(&42), Some(candidate_id));
+}
+
+#[test]
+fn challenge_marks_candidate_and_blocks_finalize() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let candidate_id = client.propose(
+        &proposer,
+        &1,
+        &false,
+        &signature(&env),
+        &evidence(&env),
+        &300,
+    );
+
+    let challenger = Address::generate(&env);
+    let challenge_uri = String::from_str(&env, "ipfs://challenge");
+    client.challenge(&challenger, &candidate_id, &challenge_uri);
+    set_time(&env, 1_400);
+
+    let finalizer = Address::generate(&env);
+    let result = client.try_finalize(&finalizer, &candidate_id);
+    assert_eq!(result, Err(Ok(ContractError::CandidateAlreadyChallenged)));
+}
+
+#[test]
+fn finalize_requires_closed_challenge_window() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let candidate_id = client.propose(
+        &proposer,
+        &1,
+        &true,
+        &signature(&env),
+        &evidence(&env),
+        &300,
+    );
+
+    let finalizer = Address::generate(&env);
+    assert_eq!(
+        client.try_finalize(&finalizer, &candidate_id),
+        Err(Ok(ContractError::ChallengeWindowOpen))
+    );
+
+    set_time(&env, 1_301);
+    let candidate = client.finalize(&finalizer, &candidate_id);
+    assert_eq!(candidate.status, crate::types::CandidateStatus::Finalized);
+    assert_eq!(candidate.finalized_at, Some(1_301));
+}
+
+#[test]
+fn challenge_after_deadline_is_rejected() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let candidate_id = client.propose(&proposer, &1, &true, &signature(&env), &evidence(&env), &60);
+
+    set_time(&env, 1_061);
+    let challenger = Address::generate(&env);
+    let challenge_uri = String::from_str(&env, "ipfs://late-challenge");
+    assert_eq!(
+        client.try_challenge(&challenger, &candidate_id, &challenge_uri),
+        Err(Ok(ContractError::ChallengeWindowClosed))
+    );
+}
+
+#[test]
+fn admin_can_update_factory_registration() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    let new_factory = Address::generate(&env);
+    client.set_factory(&admin, &new_factory);
+    assert_eq!(client.get_config().factory, new_factory);
+}

--- a/contracts/resolution/src/types.rs
+++ b/contracts/resolution/src/types.rs
@@ -1,0 +1,39 @@
+use soroban_sdk::{contracttype, Address, BytesN, String};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum CandidateStatus {
+    Proposed,
+    Challenged,
+    Finalized,
+}
+
+/// On-chain mirror of the backend `ResolutionCandidate` concept.
+///
+/// The backend may keep richer metadata, but the fields here are the minimum
+/// needed to make a proposed outcome challengeable before it is handed to the
+/// market contract's `resolve_market` entry point.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct ResolutionCandidate {
+    pub id: u32,
+    pub market_id: u32,
+    pub outcome: bool,
+    pub signature: BytesN<64>,
+    pub proposer: Address,
+    pub evidence_uri: String,
+    pub proposed_at: u64,
+    pub challenge_deadline: u64,
+    pub status: CandidateStatus,
+    pub challenged_by: Option<Address>,
+    pub challenge_uri: Option<String>,
+    pub finalized_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct ResolutionConfig {
+    pub admin: Address,
+    pub factory: Address,
+    pub market_contract: Address,
+}


### PR DESCRIPTION
Adds a new contracts/resolution Soroban crate that implements the missing on-chain lifecycle for resolution candidates before markets are finalized.

The market contract still owns the final resolve_market(market_id, outcome, signature) transition. This new resolution contract acts as the challenge-window layer around that final step, matching the backend ResolutionCandidate concept.

Changes

Added contracts/resolution crate
Implemented propose -> challenge -> finalize lifecycle
Added on-chain ResolutionCandidate storage with:
market id
proposed outcome
oracle signature
evidence URI
challenge deadline
challenged/finalized status
Added factory and market contract registration via initialize(admin, factory, market_contract)
Added admin update functions for registered factory and market contract
Added resolution lifecycle events
Added focused unit tests for proposal, challenge, deadline, finalization, and registration behavior
Registered contracts/resolution in workspace default members
Documented the relationship between the Resolution Contract and MarketContract::resolve_market in README.md
Validation

cargo test -p vatix-resolution-contract
cargo test --workspace
cargo clippy -p vatix-resolution-contract -- -D warnings
All checks pass.

closes #266 