### PR TITLE
feat/outcome-token-contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 default-members = [
   ".",
   "contracts/market",
+  "contracts/outcome-token",
   "contracts/resolution",
 ]
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Core smart contracts powering Vatix prediction markets, written in Rust for the 
 - **Resolution Contract**: Challenge-window lifecycle for oracle resolution candidates
 - **Treasury**: Fee collection and protocol management
 
+## Contract Status
+
+| Contract | Crate | Status | Notes |
+|---|---|---|---|
+| Market | `contracts/market` | ✅ Complete | Trading, deposit, withdraw, settlement |
+| Outcome Token | `contracts/outcome-token` | ✅ Complete | Mint/burn YES/NO tokens; callable only by market contract |
+| Resolution | `contracts/resolution` | ✅ Complete | Challenge-window lifecycle for oracle candidates |
+| Treasury | — | 🔲 Not started | Fee collection and protocol management |
+
 ## Tech Stack
 
 - **Language**: Rust
@@ -87,6 +96,7 @@ pnpm build:web
 ```bash
 # Prerequisites: Rust toolchain, Soroban CLI
 cd contracts/market && cargo build
+cd ../outcome-token && cargo build
 cd ../resolution && cargo build
 ```
 

--- a/contracts/outcome-token/Cargo.toml
+++ b/contracts/outcome-token/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "vatix-outcome-token-contract"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/outcome-token/src/error.rs
+++ b/contracts/outcome-token/src/error.rs
@@ -1,0 +1,13 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    InsufficientBalance = 4,
+    InvalidAmount = 5,
+    Overflow = 6,
+}

--- a/contracts/outcome-token/src/events.rs
+++ b/contracts/outcome-token/src/events.rs
@@ -1,0 +1,62 @@
+use crate::types::TokenKind;
+use soroban_sdk::{contractevent, Address, Env};
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct TokenMintedEvent {
+    #[topic]
+    pub market_id: u32,
+    #[topic]
+    pub user: Address,
+    pub kind: TokenKind,
+    pub amount: i128,
+    pub new_balance: i128,
+}
+
+pub fn emit_token_minted(
+    env: &Env,
+    market_id: u32,
+    user: &Address,
+    kind: TokenKind,
+    amount: i128,
+    new_balance: i128,
+) {
+    TokenMintedEvent {
+        market_id,
+        user: user.clone(),
+        kind,
+        amount,
+        new_balance,
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct TokenBurnedEvent {
+    #[topic]
+    pub market_id: u32,
+    #[topic]
+    pub user: Address,
+    pub kind: TokenKind,
+    pub amount: i128,
+    pub new_balance: i128,
+}
+
+pub fn emit_token_burned(
+    env: &Env,
+    market_id: u32,
+    user: &Address,
+    kind: TokenKind,
+    amount: i128,
+    new_balance: i128,
+) {
+    TokenBurnedEvent {
+        market_id,
+        user: user.clone(),
+        kind,
+        amount,
+        new_balance,
+    }
+    .publish(env);
+}

--- a/contracts/outcome-token/src/lib.rs
+++ b/contracts/outcome-token/src/lib.rs
@@ -1,0 +1,138 @@
+#![no_std]
+
+mod error;
+mod events;
+mod storage;
+pub mod types;
+
+#[cfg(test)]
+mod test;
+
+use crate::error::ContractError;
+use crate::types::{OutcomeTokenConfig, TokenKind};
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct OutcomeTokenContract;
+
+#[contractimpl]
+impl OutcomeTokenContract {
+    /// Bootstrap the contract by registering the admin and the sole market
+    /// contract allowed to call `mint` and `burn`.
+    ///
+    /// Must be called once immediately after deployment. Returns
+    /// [`ContractError::AlreadyInitialized`] on subsequent calls.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        market_contract: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        if storage::has_config(&env) {
+            return Err(ContractError::AlreadyInitialized);
+        }
+        storage::set_config(
+            &env,
+            &OutcomeTokenConfig {
+                admin,
+                market_contract,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn get_config(env: Env) -> OutcomeTokenConfig {
+        storage::get_config(&env)
+    }
+
+    /// Update the market contract address allowed to mint/burn tokens.
+    ///
+    /// Only the stored admin may call this.
+    pub fn set_market_contract(
+        env: Env,
+        admin: Address,
+        market_contract: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        let mut config = storage::get_config(&env);
+        if admin != config.admin {
+            return Err(ContractError::Unauthorized);
+        }
+        config.market_contract = market_contract;
+        storage::set_config(&env, &config);
+        Ok(())
+    }
+
+    /// Mint `amount` tokens of `kind` (Yes or No) for `user` in `market_id`.
+    ///
+    /// Only the registered market contract may call this function.
+    pub fn mint(
+        env: Env,
+        market_id: u32,
+        user: Address,
+        kind: TokenKind,
+        amount: i128,
+    ) -> Result<(), ContractError> {
+        if amount <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+        let config = storage::get_config(&env);
+        config.market_contract.require_auth();
+
+        let balance = storage::get_balance(&env, market_id, &user, &kind);
+        let new_balance = balance
+            .checked_add(amount)
+            .ok_or(ContractError::Overflow)?;
+        storage::set_balance(&env, market_id, &user, &kind, new_balance);
+
+        let supply = storage::get_total_supply(&env, market_id, &kind);
+        let new_supply = supply.checked_add(amount).ok_or(ContractError::Overflow)?;
+        storage::set_total_supply(&env, market_id, &kind, new_supply);
+
+        events::emit_token_minted(&env, market_id, &user, kind, amount, new_balance);
+        Ok(())
+    }
+
+    /// Burn `amount` tokens of `kind` from `user` in `market_id`.
+    ///
+    /// Only the registered market contract may call this function. Returns
+    /// [`ContractError::InsufficientBalance`] if the user holds fewer tokens
+    /// than `amount`.
+    pub fn burn(
+        env: Env,
+        market_id: u32,
+        user: Address,
+        kind: TokenKind,
+        amount: i128,
+    ) -> Result<(), ContractError> {
+        if amount <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+        let config = storage::get_config(&env);
+        config.market_contract.require_auth();
+
+        let balance = storage::get_balance(&env, market_id, &user, &kind);
+        if balance < amount {
+            return Err(ContractError::InsufficientBalance);
+        }
+        let new_balance = balance - amount;
+        storage::set_balance(&env, market_id, &user, &kind, new_balance);
+
+        let supply = storage::get_total_supply(&env, market_id, &kind);
+        let new_supply = supply - amount;
+        storage::set_total_supply(&env, market_id, &kind, new_supply);
+
+        events::emit_token_burned(&env, market_id, &user, kind, amount, new_balance);
+        Ok(())
+    }
+
+    /// Return the token balance for a specific `(market_id, user, kind)` triple.
+    pub fn balance(env: Env, market_id: u32, user: Address, kind: TokenKind) -> i128 {
+        storage::get_balance(&env, market_id, &user, &kind)
+    }
+
+    /// Return the total outstanding supply for a `(market_id, kind)` pair.
+    pub fn total_supply(env: Env, market_id: u32, kind: TokenKind) -> i128 {
+        storage::get_total_supply(&env, market_id, &kind)
+    }
+}

--- a/contracts/outcome-token/src/storage.rs
+++ b/contracts/outcome-token/src/storage.rs
@@ -1,0 +1,53 @@
+use crate::types::{OutcomeTokenConfig, TokenKind};
+use soroban_sdk::{contracttype, Address, Env};
+
+#[contracttype]
+pub enum StorageKey {
+    Config,
+    /// Per-market, per-user, per-side balance.
+    Balance(u32, Address, TokenKind),
+    /// Per-market, per-side total supply.
+    TotalSupply(u32, TokenKind),
+}
+
+pub fn has_config(env: &Env) -> bool {
+    env.storage().persistent().has(&StorageKey::Config)
+}
+
+pub fn get_config(env: &Env) -> OutcomeTokenConfig {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::Config)
+        .expect("outcome-token config not set")
+}
+
+pub fn set_config(env: &Env, config: &OutcomeTokenConfig) {
+    env.storage().persistent().set(&StorageKey::Config, config);
+}
+
+pub fn get_balance(env: &Env, market_id: u32, user: &Address, kind: &TokenKind) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::Balance(market_id, user.clone(), kind.clone()))
+        .unwrap_or(0i128)
+}
+
+pub fn set_balance(env: &Env, market_id: u32, user: &Address, kind: &TokenKind, amount: i128) {
+    env.storage().persistent().set(
+        &StorageKey::Balance(market_id, user.clone(), kind.clone()),
+        &amount,
+    );
+}
+
+pub fn get_total_supply(env: &Env, market_id: u32, kind: &TokenKind) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::TotalSupply(market_id, kind.clone()))
+        .unwrap_or(0i128)
+}
+
+pub fn set_total_supply(env: &Env, market_id: u32, kind: &TokenKind, supply: i128) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::TotalSupply(market_id, kind.clone()), &supply);
+}

--- a/contracts/outcome-token/src/test.rs
+++ b/contracts/outcome-token/src/test.rs
@@ -1,0 +1,181 @@
+use crate::{ContractError, OutcomeTokenContract, OutcomeTokenContractClient};
+use crate::types::TokenKind;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup(env: &Env) -> (OutcomeTokenContractClient<'_>, Address, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(OutcomeTokenContract, ());
+    let client = OutcomeTokenContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let market_contract = Address::generate(env);
+    client.initialize(&admin, &market_contract);
+    (client, admin, market_contract)
+}
+
+// ── initialize ──────────────────────────────────────────────────────────────
+
+#[test]
+fn initialize_stores_config() {
+    let env = Env::default();
+    let (client, admin, market_contract) = setup(&env);
+    let config = client.get_config();
+    assert_eq!(config.admin, admin);
+    assert_eq!(config.market_contract, market_contract);
+}
+
+#[test]
+fn initialize_twice_is_rejected() {
+    let env = Env::default();
+    let (client, admin, market_contract) = setup(&env);
+    assert_eq!(
+        client.try_initialize(&admin, &market_contract),
+        Err(Ok(ContractError::AlreadyInitialized))
+    );
+}
+
+// ── mint ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn mint_increases_balance_and_supply() {
+    let env = Env::default();
+    let (client, _admin, _market) = setup(&env);
+
+    let user = Address::generate(&env);
+    client.mint(&1, &user, &TokenKind::Yes, &500);
+
+    assert_eq!(client.balance(&1, &user, &TokenKind::Yes), 500);
+    assert_eq!(client.total_supply(&1, &TokenKind::Yes), 500);
+    assert_eq!(client.balance(&1, &user, &TokenKind::No), 0);
+}
+
+#[test]
+fn mint_accumulates_across_calls() {
+    let env = Env::default();
+    let (client, _admin, _market) = setup(&env);
+
+    let user = Address::generate(&env);
+    client.mint(&1, &user, &TokenKind::No, &200);
+    client.mint(&1, &user, &TokenKind::No, &300);
+
+    assert_eq!(client.balance(&1, &user, &TokenKind::No), 500);
+    assert_eq!(client.total_supply(&1, &TokenKind::No), 500);
+}
+
+#[test]
+fn mint_zero_amount_is_rejected() {
+    let env = Env::default();
+    let (client, _admin, _market) = setup(&env);
+    let user = Address::generate(&env);
+    assert_eq!(
+        client.try_mint(&1, &user, &TokenKind::Yes, &0),
+        Err(Ok(ContractError::InvalidAmount))
+    );
+}
+
+#[test]
+fn mint_yes_and_no_are_independent() {
+    let env = Env::default();
+    let (client, _admin, _market) = setup(&env);
+    let user = Address::generate(&env);
+
+    client.mint(&1, &user, &TokenKind::Yes, &100);
+    client.mint(&1, &user, &TokenKind::No, &200);
+
+    assert_eq!(client.balance(&1, &user, &TokenKind::Yes), 100);
+    assert_eq!(client.balance(&1, &user, &TokenKind::No), 200);
+    assert_eq!(client.total_supply(&1, &TokenKind::Yes), 100);
+    assert_eq!(client.total_supply(&1, &TokenKind::No), 200);
+}
+
+// ── burn ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn burn_decreases_balance_and_supply() {
+    let env = Env::default();
+    let (client, _admin, _market) = setup(&env);
+    let user = Address::generate(&env);
+
+    client.mint(&1, &user, &TokenKind::Yes, &1000);
+    client.burn(&1, &user, &TokenKind::Yes, &400);
+
+    assert_eq!(client.balance(&1, &user, &TokenKind::Yes), 600);
+    assert_eq!(client.total_supply(&1, &TokenKind::Yes), 600);
+}
+
+#[test]
+fn burn_insufficient_balance_is_rejected() {
+    let env = Env::default();
+    let (client, _admin, _market) = setup(&env);
+    let user = Address::generate(&env);
+
+    client.mint(&1, &user, &TokenKind::No, &100);
+    assert_eq!(
+        client.try_burn(&1, &user, &TokenKind::No, &101),
+        Err(Ok(ContractError::InsufficientBalance))
+    );
+}
+
+#[test]
+fn burn_zero_amount_is_rejected() {
+    let env = Env::default();
+    let (client, _admin, _market) = setup(&env);
+    let user = Address::generate(&env);
+    assert_eq!(
+        client.try_burn(&1, &user, &TokenKind::Yes, &0),
+        Err(Ok(ContractError::InvalidAmount))
+    );
+}
+
+#[test]
+fn burn_full_balance_brings_to_zero() {
+    let env = Env::default();
+    let (client, _admin, _market) = setup(&env);
+    let user = Address::generate(&env);
+
+    client.mint(&2, &user, &TokenKind::Yes, &300);
+    client.burn(&2, &user, &TokenKind::Yes, &300);
+
+    assert_eq!(client.balance(&2, &user, &TokenKind::Yes), 0);
+    assert_eq!(client.total_supply(&2, &TokenKind::Yes), 0);
+}
+
+// ── market isolation ────────────────────────────────────────────────────────
+
+#[test]
+fn balances_are_isolated_across_markets() {
+    let env = Env::default();
+    let (client, _admin, _market) = setup(&env);
+    let user = Address::generate(&env);
+
+    client.mint(&1, &user, &TokenKind::Yes, &100);
+    client.mint(&2, &user, &TokenKind::Yes, &200);
+
+    assert_eq!(client.balance(&1, &user, &TokenKind::Yes), 100);
+    assert_eq!(client.balance(&2, &user, &TokenKind::Yes), 200);
+    assert_eq!(client.total_supply(&1, &TokenKind::Yes), 100);
+    assert_eq!(client.total_supply(&2, &TokenKind::Yes), 200);
+}
+
+// ── set_market_contract ─────────────────────────────────────────────────────
+
+#[test]
+fn admin_can_update_market_contract() {
+    let env = Env::default();
+    let (client, admin, _old_market) = setup(&env);
+    let new_market = Address::generate(&env);
+
+    client.set_market_contract(&admin, &new_market);
+    assert_eq!(client.get_config().market_contract, new_market);
+}
+
+#[test]
+fn non_admin_cannot_update_market_contract() {
+    let env = Env::default();
+    let (client, _admin, _market) = setup(&env);
+    let stranger = Address::generate(&env);
+    let new_market = Address::generate(&env);
+    assert_eq!(
+        client.try_set_market_contract(&stranger, &new_market),
+        Err(Ok(ContractError::Unauthorized))
+    );
+}

--- a/contracts/outcome-token/src/types.rs
+++ b/contracts/outcome-token/src/types.rs
@@ -1,0 +1,16 @@
+use soroban_sdk::{contracttype, Address};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum TokenKind {
+    Yes,
+    No,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct OutcomeTokenConfig {
+    pub admin: Address,
+    /// Only this address may call mint and burn.
+    pub market_contract: Address,
+}


### PR DESCRIPTION
## Summary

  - Add `contracts/outcome-token/` crate to the workspace — mint/burn YES/NO tokens scoped to `(market_id, user)`
  - Auth-gate: only the registered `market_contract` can call `mint` and `burn`, enforced via `require_auth()` at the Soroban layer
  - Admin can rotate the market contract address via `set_market_contract`

  ## Changes

  - `contracts/outcome-token/` — new crate with `error`, `types`, `storage`, `events`, `lib`, and `test` modules
  - `Cargo.toml` — added `contracts/outcome-token` to workspace `default-members`
  - `README.md` — added contract status table and build step for the new crate

  ## Test plan

  - [ ] `initialize` stores config and rejects double-init
  - [ ] `mint` increases per-user balance and total supply; rejects zero amount
  - [ ] YES and NO balances are independent; balances are isolated across markets
  - [ ] `burn` decreases balance and supply; rejects insufficient balance and zero amount
  - [ ] `set_market_contract` succeeds for admin, returns `Unauthorized` for non-admin

closes #265 