### PR TITLE
Title: feat: add proptest fuzz suite for share and collateral math 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,31 @@ jobs:
       # public contract function to maintain coverage.
       - name: Tests
         run: cd contracts/market && cargo test
+
+      # Restore saved proptest regression cases from previous CI runs so that
+      # any previously-found failing inputs are always re-checked.
+      - name: Restore proptest regression corpus
+        uses: actions/cache@v4
+        with:
+          path: contracts/market/src/.proptest-regressions
+          key: proptest-regressions-${{ runner.os }}-${{ hashFiles('contracts/market/src/positions.rs') }}
+          restore-keys: proptest-regressions-${{ runner.os }}-
+
+      # Run the proptest fuzz suite with 2 000 cases per property in CI.
+      # Increase PROPTEST_CASES for deeper coverage in scheduled / nightly runs.
+      # Failing inputs are persisted to .proptest-regressions/ and cached above.
+      - name: Proptest fuzz (share and collateral math)
+        run: cd contracts/market && PROPTEST_CASES=2000 cargo test prop_ -- --nocapture
+
+      # Upload any new regression seeds discovered in this run so they are
+      # available to future runs even when the cache key changes.
+      - name: Upload proptest regressions
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: proptest-regressions
+          path: contracts/market/src/.proptest-regressions
+          if-no-files-found: ignore
       
       # Compiles the contract to WASM (wasm32-unknown-unknown) — the binary format
       # required by the Stellar Soroban runtime. Mirrors the `make build` target in

--- a/contracts/market/Cargo.toml
+++ b/contracts/market/Cargo.toml
@@ -18,3 +18,4 @@ ed25519-dalek = { version = "2.2.0", default-features = false }
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 rand = "0.8"
+proptest = "1"

--- a/contracts/market/src/positions.rs
+++ b/contracts/market/src/positions.rs
@@ -484,3 +484,167 @@ mod tests {
         assert_eq!(pos.locked_collateral, 42 * STROOPS_PER_USDC);
     }
 }
+
+#[cfg(test)]
+mod proptest_tests {
+    use super::*;
+    use crate::types::Position;
+    use proptest::prelude::*;
+    use soroban_sdk::{testutils::Address as TestAddress, Address, Env};
+
+    // Upper bound chosen so that `net * 10_000` never overflows i128.
+    // scale_by_bps does `amount.checked_mul(price_bps).unwrap()`, so any
+    // `amount` up to this value is safe for all valid prices [0, 10_000].
+    const MAX_SAFE_SHARES: i128 = i128::MAX / 10_001;
+
+    fn make_position(env: &Env, yes_shares: i128, no_shares: i128) -> Position {
+        Position {
+            market_id: 0,
+            user: <Address as TestAddress>::generate(env),
+            yes_shares,
+            no_shares,
+            locked_collateral: 0,
+            total_deposited: 0,
+            is_settled: false,
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1_000))]
+
+        /// Locked collateral is always >= 0 for any valid inputs.
+        #[test]
+        fn prop_locked_collateral_never_negative(
+            yes in 0i128..=MAX_SAFE_SHARES,
+            no in 0i128..=MAX_SAFE_SHARES,
+            price in 0i128..=10_000i128,
+        ) {
+            let locked = calculate_locked_collateral(yes, no, price);
+            prop_assert!(
+                locked >= 0,
+                "locked={locked} yes={yes} no={no} price={price}"
+            );
+        }
+
+        /// Equal YES and NO shares always produce zero locked collateral,
+        /// regardless of market price.
+        #[test]
+        fn prop_locked_collateral_hedged_is_zero(
+            shares in 0i128..=MAX_SAFE_SHARES,
+            price in 0i128..=10_000i128,
+        ) {
+            prop_assert_eq!(calculate_locked_collateral(shares, shares, price), 0);
+        }
+
+        /// Locked collateral never exceeds the absolute net position.
+        /// Invariant: locked <= |yes - no|.
+        #[test]
+        fn prop_locked_lte_net_position(
+            yes in 0i128..=MAX_SAFE_SHARES,
+            no in 0i128..=MAX_SAFE_SHARES,
+            price in 0i128..=10_000i128,
+        ) {
+            let locked = calculate_locked_collateral(yes, no, price);
+            let net = (yes - no).abs();
+            prop_assert!(
+                locked <= net,
+                "locked={locked} > net={net}  yes={yes} no={no} price={price}"
+            );
+        }
+
+        /// At price = 5_000 (50 %), long-YES and long-NO of equal net magnitude
+        /// lock the same amount of collateral (symmetry).
+        #[test]
+        fn prop_locked_symmetric_at_midpoint(
+            net in 0i128..=MAX_SAFE_SHARES,
+        ) {
+            let yes_heavy = calculate_locked_collateral(net, 0, 5_000);
+            let no_heavy  = calculate_locked_collateral(0, net, 5_000);
+            prop_assert_eq!(yes_heavy, no_heavy);
+        }
+
+        /// At price = 0 a net-YES position locks nothing; a net-NO position
+        /// locks its full magnitude (cost-to-close at 100 % price).
+        #[test]
+        fn prop_locked_at_zero_price(
+            yes in 0i128..=MAX_SAFE_SHARES,
+            no in 0i128..=MAX_SAFE_SHARES,
+        ) {
+            let locked = calculate_locked_collateral(yes, no, 0);
+            if yes >= no {
+                prop_assert_eq!(locked, 0, "net-YES at price=0 should lock 0");
+            } else {
+                prop_assert_eq!(
+                    locked, no - yes,
+                    "net-NO at price=0 should lock (no-yes)"
+                );
+            }
+        }
+
+        /// At price = 10_000 a net-NO position locks nothing; a net-YES
+        /// position locks its full magnitude.
+        #[test]
+        fn prop_locked_at_full_price(
+            yes in 0i128..=MAX_SAFE_SHARES,
+            no in 0i128..=MAX_SAFE_SHARES,
+        ) {
+            let locked = calculate_locked_collateral(yes, no, 10_000);
+            if no >= yes {
+                prop_assert_eq!(locked, 0, "net-NO at price=10000 should lock 0");
+            } else {
+                prop_assert_eq!(
+                    locked, yes - no,
+                    "net-YES at price=10000 should lock (yes-no)"
+                );
+            }
+        }
+
+        /// validate_position_change returns Err iff the resulting share balance
+        /// would drop below zero on either side.
+        #[test]
+        fn prop_validate_rejects_iff_shares_go_negative(
+            yes_shares in 0i128..=1_000_000i128,
+            no_shares in 0i128..=1_000_000i128,
+            yes_delta in -1_000_000i128..=1_000_000i128,
+            no_delta in -1_000_000i128..=1_000_000i128,
+        ) {
+            let env = Env::default();
+            let pos = make_position(&env, yes_shares, no_shares);
+            let result = validate_position_change(&pos, yes_delta, no_delta);
+            let new_yes = yes_shares + yes_delta;
+            let new_no  = no_shares  + no_delta;
+            if new_yes < 0 || new_no < 0 {
+                prop_assert_eq!(result, Err(PositionError::ShareBalanceBelowZero));
+            } else {
+                prop_assert!(result.is_ok());
+            }
+        }
+
+        /// After a valid position change both share counts are non-negative.
+        #[test]
+        fn prop_valid_position_has_non_negative_shares(
+            yes_shares in 0i128..=1_000_000i128,
+            no_shares in 0i128..=1_000_000i128,
+            yes_delta in -1_000_000i128..=1_000_000i128,
+            no_delta in -1_000_000i128..=1_000_000i128,
+        ) {
+            let env = Env::default();
+            let pos = make_position(&env, yes_shares, no_shares);
+            if validate_position_change(&pos, yes_delta, no_delta).is_ok() {
+                prop_assert!(yes_shares + yes_delta >= 0);
+                prop_assert!(no_shares  + no_delta  >= 0);
+            }
+        }
+
+        /// calculate_net_position is antisymmetric: swapping YES and NO negates it.
+        #[test]
+        fn prop_net_position_antisymmetric(
+            yes in 0i128..=1_000_000_000i128,
+            no in 0i128..=1_000_000_000i128,
+        ) {
+            let net         = calculate_net_position(yes, no);
+            let net_swapped = calculate_net_position(no, yes);
+            prop_assert_eq!(net, -net_swapped);
+        }
+    }
+}

--- a/contracts/outcome-token/src/lib.rs
+++ b/contracts/outcome-token/src/lib.rs
@@ -80,9 +80,7 @@ impl OutcomeTokenContract {
         config.market_contract.require_auth();
 
         let balance = storage::get_balance(&env, market_id, &user, &kind);
-        let new_balance = balance
-            .checked_add(amount)
-            .ok_or(ContractError::Overflow)?;
+        let new_balance = balance.checked_add(amount).ok_or(ContractError::Overflow)?;
         storage::set_balance(&env, market_id, &user, &kind, new_balance);
 
         let supply = storage::get_total_supply(&env, market_id, &kind);

--- a/contracts/outcome-token/src/test.rs
+++ b/contracts/outcome-token/src/test.rs
@@ -1,5 +1,5 @@
-use crate::{ContractError, OutcomeTokenContract, OutcomeTokenContractClient};
 use crate::types::TokenKind;
+use crate::{ContractError, OutcomeTokenContract, OutcomeTokenContractClient};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 fn setup(env: &Env) -> (OutcomeTokenContractClient<'_>, Address, Address) {


### PR DESCRIPTION
Testing


Body:

Problem
Share/collateral math (calculate_locked_collateral, validate_position_change, calculate_net_position) had unit tests for known inputs but no fuzz coverage to catch overflow/underflow edge cases across the full i128 value space.

What this adds. A MAX_SAFE_SHARES cap (i128::MAX / 10_001) documents and enforces the safe operating range for scale_by_bps under fuzzing.

Closes #267