### PR TITLE
feat(market): implement cancel_market admin flow (#263)

### DIFF
--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -240,6 +240,41 @@ pub fn emit_market_resolved(
 
 #[contractevent]
 #[derive(Clone, Debug)]
+pub struct MarketCanceledEvent {
+    #[topic]
+    pub market_id: u32,
+    pub canceler: Address,
+    pub canceled_at: u64,
+}
+
+/// Emit a MarketCanceled event
+///
+/// Publishes a [`MarketCanceledEvent`] to the Soroban event stream when an
+/// admin halts a market before resolution. The event is indexed by `market_id`
+/// as a topic so off-chain indexers can detect canceled markets and surface
+/// collateral-reclaim flows to affected users.
+///
+/// # Arguments
+/// * `env` - Contract environment
+/// * `market_id` - Unique identifier of the canceled market
+/// * `canceler` - Admin address that canceled the market
+/// * `canceled_at` - Unix timestamp (ledger time) when the cancellation occurred
+///
+/// # Example
+/// ```ignore
+/// emit_market_canceled(&env, 1, &admin, env.ledger().timestamp());
+/// ```
+pub fn emit_market_canceled(env: &Env, market_id: u32, canceler: &Address, canceled_at: u64) {
+    MarketCanceledEvent {
+        market_id,
+        canceler: canceler.clone(),
+        canceled_at,
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
 pub struct PositionLimitExceededEvent {
     #[topic]
     pub market_id: u32,
@@ -690,6 +725,44 @@ mod tests {
         assert_eq!(resolver_val, resolver);
         assert_eq!(outcome_val, outcome);
         assert_eq!(resolved_at_val, resolved_at);
+    }
+
+    #[test]
+    fn test_emit_market_canceled() {
+        let env = Env::default();
+        let contract_id = env.register(MarketContract, ());
+
+        let market_id = 1u32;
+        let canceler = Address::generate(&env);
+        let canceled_at = 1234567890u64;
+
+        env.as_contract(&contract_id, || {
+            emit_market_canceled(&env, market_id, &canceler, canceled_at);
+        });
+
+        let events = env.events().all();
+        assert_eq!(events.len(), 1);
+
+        let event = events.first().unwrap();
+        let topics = &event.1;
+
+        let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+        assert_eq!(topic0, Symbol::new(&env, "market_canceled_event"));
+
+        let topic1: u32 = topics.get(1).unwrap().into_val(&env);
+        assert_eq!(topic1, market_id);
+
+        let data: Map<Symbol, Val> = event.2.try_into_val(&env).unwrap();
+        let canceler_val: Address = data
+            .get(Symbol::new(&env, "canceler"))
+            .unwrap()
+            .into_val(&env);
+        let canceled_at_val: u64 = data
+            .get(Symbol::new(&env, "canceled_at"))
+            .unwrap()
+            .into_val(&env);
+        assert_eq!(canceler_val, canceler);
+        assert_eq!(canceled_at_val, canceled_at);
     }
 
     #[test]

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -293,6 +293,120 @@ impl MarketContract {
         Ok(())
     }
 
+    /// Cancel a market before it is resolved, halting all further trading.
+    ///
+    /// Only the stored admin may call this. The market must still be
+    /// [`MarketStatus::Active`]; a resolved market has a final outcome and an
+    /// already-canceled market is rejected to surface the redundant call.
+    /// Once canceled, deposits and position updates are rejected (both already
+    /// require an `Active` status), and affected users may reclaim their
+    /// collateral via [`withdraw_canceled_collateral`].
+    ///
+    /// # Arguments
+    /// * `env` - Contract environment
+    /// * `admin` - Must be the stored admin address (authorizes the call)
+    /// * `market_id` - Identifier of the market to cancel
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] – `admin` is not the stored admin
+    /// - [`ContractError::MarketNotFound`] – the market does not exist
+    /// - [`ContractError::MarketAlreadyResolved`] – the market is already resolved
+    /// - [`ContractError::MarketNotActive`] – the market is already canceled
+    ///
+    /// # Events
+    /// Emits [`MarketCanceledEvent`] with `market_id`, `canceler`, and
+    /// `canceled_at` on success.
+    pub fn cancel_market(
+        env: Env,
+        admin: Address,
+        market_id: u32,
+    ) -> Result<(), ContractError> {
+        // 1. Authorization: only the stored admin may cancel a market.
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+
+        // 2. Load the market and enforce the cancel policy (Active only).
+        let mut market =
+            storage::get_market(&env, market_id)?.ok_or(ContractError::MarketNotFound)?;
+        validation::validate_cancelable(&market.status)?;
+
+        // 3. Transition to Canceled and persist.
+        market.status = MarketStatus::Canceled;
+        storage::set_market(&env, market_id, &market)?;
+
+        // 4. Emit the cancellation event for off-chain indexers.
+        events::emit_market_canceled(&env, market_id, &admin, env.ledger().timestamp());
+
+        Ok(())
+    }
+
+    /// Reclaim deposited collateral from a canceled market.
+    ///
+    /// When a market is canceled before resolution there is no winning outcome,
+    /// so each user is made whole by returning the full collateral they have
+    /// deposited in that market. The user's position balances are zeroed and the
+    /// collateral (SAC) tokens are transferred from the contract back to them.
+    ///
+    /// # Arguments
+    /// * `env` - Contract environment
+    /// * `user` - User reclaiming their collateral (must authorize the call)
+    /// * `market_id` - Identifier of the canceled market
+    ///
+    /// # Returns
+    /// The amount of collateral refunded to the user, in stroops.
+    ///
+    /// # Errors
+    /// - [`ContractError::MarketNotFound`] – the market does not exist
+    /// - [`ContractError::MarketNotActive`] – the market is not canceled, so the
+    ///   reclaim path does not apply
+    /// - [`ContractError::NoPositionFound`] – the user has no position in the market
+    /// - [`ContractError::InsufficientCollateral`] – the user has no collateral to reclaim
+    ///
+    /// # Events
+    /// Emits `CollateralWithdrawn` with the refunded amount and the user's new
+    /// (zero) total.
+    pub fn withdraw_canceled_collateral(
+        env: Env,
+        user: Address,
+        market_id: u32,
+    ) -> Result<i128, ContractError> {
+        // 1. Authorization: only the position owner may reclaim their collateral.
+        user.require_auth();
+
+        // 2. The reclaim path is exclusive to canceled markets.
+        let market =
+            storage::get_market(&env, market_id)?.ok_or(ContractError::MarketNotFound)?;
+        if market.status != MarketStatus::Canceled {
+            return Err(ContractError::MarketNotActive);
+        }
+
+        // 3. Load the user's position and the full deposited balance.
+        let mut position = storage::get_position(&env, market_id, &user)?
+            .ok_or(ContractError::NoPositionFound)?;
+        let refund = position.total_deposited;
+        if refund <= 0 {
+            return Err(ContractError::InsufficientCollateral);
+        }
+
+        // 4. Refund the collateral from the contract back to the user.
+        let contract_address = env.current_contract_address();
+        let token_client = soroban_sdk::token::Client::new(&env, &market.collateral_token);
+        token_client.transfer(&contract_address, &user, &refund);
+
+        // 5. Zero out the position balances now that the collateral has left.
+        position.total_deposited = 0;
+        position.locked_collateral = 0;
+        storage::set_position(&env, market_id, &user, &position)?;
+
+        // 6. Reuse the collateral-withdrawn event so indexers track the refund.
+        events::emit_collateral_withdrawn(&env, &user, market_id, refund, position.total_deposited);
+
+        Ok(refund)
+    }
+
     /// Buy or sell YES/NO shares by applying signed deltas to a user's position.
     ///
     /// This is the on-chain entry point for the share-trading logic implemented

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -907,4 +907,212 @@ mod test {
         let result = client.try_accept_admin(&first_nominee);
         assert!(result.is_err());
     }
+
+    // ========== cancel_market tests ==========
+
+    /// Register a market backed by a real Stellar asset, mint `deposit` to a
+    /// fresh user, and deposit it so cancel and collateral-reclaim flows can be
+    /// exercised end to end.
+    ///
+    /// Returns `(env, admin, user, client, contract_id, market_id, collateral_token)`.
+    fn setup_admin_market_with_deposit<'a>(
+        deposit: i128,
+    ) -> (
+        Env,
+        Address,
+        Address,
+        MarketContractClient<'a>,
+        Address,
+        u32,
+        Address,
+    ) {
+        use soroban_sdk::token::StellarAssetClient;
+
+        let env = Env::default();
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let collateral_token = token.address();
+
+        let contract_id = env.register(MarketContract, ());
+        let client = MarketContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            storage::set_admin(&env, &admin);
+            storage::set_version(&env);
+        });
+
+        env.mock_all_auths();
+
+        let question = String::from_str(&env, "Will it rain tomorrow?");
+        let end_time = env.ledger().timestamp() + 86400;
+        let oracle_pubkey = BytesN::from_array(&env, &[1u8; 32]);
+        let market_id = client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &collateral_token,
+        );
+
+        let user = Address::generate(&env);
+        let token_client = StellarAssetClient::new(&env, &collateral_token);
+        token_client.mint(&user, &deposit);
+        client.deposit_collateral(&user, &market_id, &deposit);
+
+        (
+            env,
+            admin,
+            user,
+            client,
+            contract_id,
+            market_id,
+            collateral_token,
+        )
+    }
+
+    #[test]
+    fn test_cancel_market_success() {
+        let (env, admin, _user, client, contract_id, market_id, _token) =
+            setup_admin_market_with_deposit(1_000);
+
+        client.cancel_market(&admin, &market_id);
+
+        let market = get_market_from_storage(&env, &contract_id, market_id);
+        assert_eq!(market.status, MarketStatus::Canceled);
+    }
+
+    #[test]
+    fn test_cancel_market_emits_event() {
+        let (env, admin, _user, client, _contract_id, market_id, _token) =
+            setup_admin_market_with_deposit(1_000);
+
+        env.events().all(); // clear setup events
+        client.cancel_market(&admin, &market_id);
+
+        let events = env.events().all();
+        assert!(events.len() > 0, "MarketCanceled event should be emitted");
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #41)")]
+    fn test_cancel_market_non_admin_fails() {
+        let (env, _admin, _user, client, _contract_id, market_id, _token) =
+            setup_admin_market_with_deposit(1_000);
+
+        let attacker = Address::generate(&env);
+        client.cancel_market(&attacker, &market_id);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #1)")]
+    fn test_cancel_market_not_found_fails() {
+        let (_env, admin, _user, client, _contract_id, _market_id, _token) =
+            setup_admin_market_with_deposit(1_000);
+
+        client.cancel_market(&admin, &999u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn test_cancel_market_already_resolved_fails() {
+        let (env, admin, _user, client, contract_id, market_id, _token) =
+            setup_admin_market_with_deposit(1_000);
+
+        // Force the market into a resolved state; a final outcome can't be canceled.
+        env.as_contract(&contract_id, || {
+            let mut market = storage::get_market(&env, market_id).unwrap().unwrap();
+            market.status = MarketStatus::Resolved;
+            market.result = Some(true);
+            storage::set_market(&env, market_id, &market).unwrap();
+        });
+
+        client.cancel_market(&admin, &market_id);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn test_cancel_market_already_canceled_fails() {
+        let (_env, admin, _user, client, _contract_id, market_id, _token) =
+            setup_admin_market_with_deposit(1_000);
+
+        client.cancel_market(&admin, &market_id);
+        // A second cancellation is a no-op and must be rejected.
+        client.cancel_market(&admin, &market_id);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn test_deposit_rejected_after_cancel() {
+        use soroban_sdk::token::StellarAssetClient;
+
+        let (env, admin, user, client, _contract_id, market_id, collateral_token) =
+            setup_admin_market_with_deposit(1_000);
+
+        client.cancel_market(&admin, &market_id);
+
+        // A fresh deposit into the canceled market must fail with MarketNotActive.
+        let token_client = StellarAssetClient::new(&env, &collateral_token);
+        token_client.mint(&user, &500);
+        client.deposit_collateral(&user, &market_id, &500);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn test_update_position_rejected_after_cancel() {
+        let (_env, admin, user, client, _contract_id, market_id, _token) =
+            setup_admin_market_with_deposit(1_000);
+
+        client.cancel_market(&admin, &market_id);
+        // Trading is halted once a market is canceled.
+        client.update_position(&user, &market_id, &100i128, &0i128, &5_000i128);
+    }
+
+    #[test]
+    fn test_withdraw_canceled_collateral_refunds_user() {
+        let deposit = 1_000i128;
+        let (env, admin, user, client, contract_id, market_id, collateral_token) =
+            setup_admin_market_with_deposit(deposit);
+
+        client.cancel_market(&admin, &market_id);
+
+        let refunded = client.withdraw_canceled_collateral(&user, &market_id);
+        assert_eq!(refunded, deposit);
+
+        // The user's position is zeroed once the collateral has been returned.
+        let position = env.as_contract(&contract_id, || {
+            storage::get_position(&env, market_id, &user)
+                .unwrap()
+                .expect("position should exist")
+        });
+        assert_eq!(position.total_deposited, 0);
+        assert_eq!(position.locked_collateral, 0);
+
+        // The collateral lands back in the user's wallet.
+        let token_client = soroban_sdk::token::Client::new(&env, &collateral_token);
+        assert_eq!(token_client.balance(&user), deposit);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn test_withdraw_canceled_collateral_rejects_active_market() {
+        let (_env, _admin, user, client, _contract_id, market_id, _token) =
+            setup_admin_market_with_deposit(1_000);
+
+        // Market is still active, so the canceled-reclaim path does not apply.
+        client.withdraw_canceled_collateral(&user, &market_id);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #12)")]
+    fn test_withdraw_canceled_collateral_no_position_fails() {
+        let (env, admin, _user, client, _contract_id, market_id, _token) =
+            setup_admin_market_with_deposit(1_000);
+
+        client.cancel_market(&admin, &market_id);
+
+        // A user who never deposited has no position to reclaim.
+        let stranger = Address::generate(&env);
+        client.withdraw_canceled_collateral(&stranger, &market_id);
+    }
 }

--- a/contracts/market/src/validation.rs
+++ b/contracts/market/src/validation.rs
@@ -1,4 +1,5 @@
 use crate::error::ContractError;
+use crate::types::MarketStatus;
 use soroban_sdk::String;
 
 /// Guard function to validate input before processing.
@@ -119,6 +120,31 @@ pub fn validate_outcome(outcome: bool) -> Result<(), ContractError> {
     // and potential future validation logic
     let _ = outcome; // Acknowledge the parameter
     Ok(())
+}
+
+/// Validates that a market may be administratively canceled.
+///
+/// Cancellation is only permitted while a market is still open, i.e. before it
+/// has been resolved by the oracle. This encodes the cancel policy in one place
+/// so the contract entry point stays declarative.
+///
+/// # Arguments
+/// * `status` - Current [`MarketStatus`] of the market being canceled
+///
+/// # Returns
+/// `Ok(())` when the market is [`MarketStatus::Active`] and can be canceled.
+///
+/// # Errors
+/// - [`ContractError::MarketAlreadyResolved`] – the market is already resolved
+///   and its outcome is final, so it can no longer be canceled.
+/// - [`ContractError::MarketNotActive`] – the market is already canceled; the
+///   operation is a no-op and is rejected to surface the redundant call.
+pub fn validate_cancelable(status: &MarketStatus) -> Result<(), ContractError> {
+    match status {
+        MarketStatus::Active => Ok(()),
+        MarketStatus::Resolved => Err(ContractError::MarketAlreadyResolved),
+        MarketStatus::Canceled => Err(ContractError::MarketNotActive),
+    }
 }
 
 /// Parse a decimal market_id string to u32 (e.g. "1", "42").
@@ -384,6 +410,27 @@ mod tests {
         assert_eq!(
             calculate_fee(i128::MAX, 10000),
             Err(ContractError::ArithmeticOverflow)
+        );
+    }
+
+    #[test]
+    fn test_validate_cancelable_active_ok() {
+        assert!(validate_cancelable(&MarketStatus::Active).is_ok());
+    }
+
+    #[test]
+    fn test_validate_cancelable_resolved_fails() {
+        assert_eq!(
+            validate_cancelable(&MarketStatus::Resolved),
+            Err(ContractError::MarketAlreadyResolved)
+        );
+    }
+
+    #[test]
+    fn test_validate_cancelable_already_canceled_fails() {
+        assert_eq!(
+            validate_cancelable(&MarketStatus::Canceled),
+            Err(ContractError::MarketNotActive)
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes: **#263 — `cancel_market` admin flow for `MarketStatus::Canceled`**.

`MarketStatus::Canceled` existed in `types` but there was no way to halt a market before resolution, and no path for users to recover collateral from a halted market. This PR adds both.

## Changes
- **`cancel_market(admin, market_id)`** (`lib.rs`) — admin-only transition of an `Active` market to `Canceled` before resolution. Rejects:
  - non-admin callers → `NotAdmin` (#41)
  - unknown markets → `MarketNotFound` (#1)
  - already-resolved markets → `MarketAlreadyResolved` (#2)
  - redundant cancels → `MarketNotActive` (#5)
- **`withdraw_canceled_collateral(user, market_id)`** (`lib.rs`) — refunds a user's full deposited collateral from a canceled market, zeroes their position, and transfers the SAC tokens back. Satisfies the "allow collateral withdrawal per policy" requirement without altering the standard active-market withdraw path.
- **`validation::validate_cancelable(status)`** (`validation.rs`) — single home for the cancel policy (Active only).
- **`MarketCanceledEvent` + `emit_market_canceled`** (`events.rs`) — indexed by `market_id` for off-chain indexers.
- Deposits/trades on canceled markets are already rejected by the existing `MarketStatus::Active` gates in `deposit.rs` / `update_position`; tests assert this.

## Acceptance criteria
- [x] Admin-only `cancel_market(market_id)` before resolution
- [x] Reject deposits/trades on canceled markets
- [x] Allow collateral withdrawal per policy
- [x] Emit `MarketCanceled` event
- [x] Tests for cancel → deposit rejected

## Testing / validation
The diff is **100% additive** (+442 lines across `lib.rs`, `validation.rs`, `events.rs`, `test.rs`) and touches no pre-existing code.

15 new tests were added and **all pass**: 6 `cancel_market` cases, cancel→deposit-rejected, cancel→trade-rejected, 3 `withdraw_canceled_collateral` cases, 3 `validate_cancelable` unit tests, and the event test.

> ⚠️ **Reviewer note — base branch does not compile.** The `dev` base currently fails to build due to **pre-existing** errors in `contracts/market/src/storage.rs` (stray paren at the `get_next_market_id` body, duplicate `get_treasury`/`set_treasury`, and missing `StorageKey::FeeRateBps`/`Treasury` variants), plus knock-on errors in `lib.rs`/`withdraw.rs`/`deposit.rs`/`oracle.rs`. These were introduced by an earlier merge and are intentionally left untouched here per scope. As a result CI on this PR will fail to compile until the base is repaired in a separate PR. The #263 feature was verified green by applying those base fixes in a throwaway worktree (all 15 new tests pass; the only other failures are 5 pre-existing `withdraw::tests::test_withdraw_fee_*` tests that contradict the pre-existing withdraw implementation).

## Notes for reviewers
- Cancellation is only valid **before** resolution — a resolved market has a final outcome.
- On cancellation, users are made whole by refunding their full deposit (no winning outcome to settle).
- Recommend landing a base-repair PR for the `storage.rs` merge breakage first, then rebasing this.

Closes #263
