### PR TITLE
Wire market update_position to outcome-token mint/burn and add outcome-token contract storage

### DIFF
--- a/contracts/market/Cargo.toml
+++ b/contracts/market/Cargo.toml
@@ -14,6 +14,7 @@ soroban-sdk = { workspace = true }
 # #![no_std]/wasm32v1-none target) and "fast"/"zeroize" (unneeded WASM size).
 # Used for oracle signature verification - see contracts/market/src/oracle.rs.
 ed25519-dalek = { version = "2.2.0", default-features = false }
+vatix-outcome-token-contract = { path = "../outcome-token" }
 
 [features]
 # Enables the oracle_adapter module (trait + Ed25519/Reflector/Pyth stubs).

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -22,6 +22,7 @@ mod validation;
 use crate::error::ContractError;
 use crate::types::{Market, MarketStatus, Position};
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String};
+use vatix_outcome_token_contract::{OutcomeTokenContractClient, types::TokenKind};
 
 #[contract]
 pub struct MarketContract;
@@ -373,9 +374,30 @@ impl MarketContract {
                     positions::PositionError::InvalidMarketPrice => ContractError::InvalidPrice,
                 })?;
 
+        // 5a. Mint or burn outcome tokens for the updated position.
+        if let Some(outcome_token_address) = storage::get_outcome_token_contract(&env) {
+            let token_client = OutcomeTokenContractClient::new(&env, &outcome_token_address);
+            if yes_delta > 0 {
+                token_client.mint(&market_id, &user, &TokenKind::Yes, &yes_delta)?;
+            } else if yes_delta < 0 {
+                token_client.burn(
+                    &market_id,
+                    &user,
+                    &TokenKind::Yes,
+                    &(-yes_delta),
+                )?;
+            }
+
+            if no_delta > 0 {
+                token_client.mint(&market_id, &user, &TokenKind::No, &no_delta)?;
+            } else if no_delta < 0 {
+                token_client.burn(&market_id, &user, &TokenKind::No, &(-no_delta))?;
+            }
+        }
+
         // 6. Persist the updated price so withdraw and other callers see it
         market.price_bps = market_price;
-        storage::set_market(&env, market_id, &market);
+        storage::set_market(&env, market_id, &market)?;
 
         Ok(result)
     }
@@ -436,6 +458,29 @@ impl MarketContract {
         storage::set_treasury(&env, &treasury);
         events::emit_treasury_set(&env, &treasury);
         Ok(())
+    }
+
+    /// Register the deployed outcome-token contract address used by this
+    /// market contract to mint and burn outcome tokens for position updates.
+    ///
+    /// Only the stored admin may call this.
+    pub fn set_outcome_token_contract(
+        env: Env,
+        admin: Address,
+        outcome_token_contract: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        storage::set_outcome_token_contract(&env, &outcome_token_contract);
+        Ok(())
+    }
+
+    /// Return the registered outcome-token contract address, if any.
+    pub fn get_outcome_token_contract(env: Env) -> Option<Address> {
+        storage::get_outcome_token_contract(&env)
     }
 
     /// Return the registered treasury contract address, if any.

--- a/contracts/market/src/storage.rs
+++ b/contracts/market/src/storage.rs
@@ -21,6 +21,9 @@ pub enum StorageKey {
     Admin,
     PendingAdmin,
     MarketCounter,
+    /// Address of the deployed outcome token contract.
+    /// Set by the admin via `set_outcome_token_contract`.
+    OutcomeTokenContract,
     /// Address of the deployed treasury contract.
     /// Set by the admin via `set_treasury`; optional — withdrawal fees are
     /// only routed there when this key is populated and fee_amount > 0.
@@ -139,7 +142,7 @@ pub fn get_next_market_id(env: &Env) -> u32 {
     env.storage()
         .persistent()
         .get(&StorageKey::MarketCounter)
-        .unwrap_or(0))
+        .unwrap_or(0)
 }
 
 pub fn increment_market_id(env: &Env) -> Result<u32, ContractError> {
@@ -151,6 +154,24 @@ pub fn increment_market_id(env: &Env) -> Result<u32, ContractError> {
 }
 
 // --- Treasury Storage ---
+
+pub fn get_outcome_token_contract(env: &Env) -> Option<Address> {
+    env.storage()
+        .instance()
+        .get(&StorageKey::OutcomeTokenContract)
+}
+
+pub fn set_outcome_token_contract(env: &Env, contract: &Address) {
+    env.storage()
+        .instance()
+        .set(&StorageKey::OutcomeTokenContract, contract);
+}
+
+pub fn has_outcome_token_contract(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .has(&StorageKey::OutcomeTokenContract)
+}
 
 pub fn get_treasury(env: &Env) -> Option<Address> {
     env.storage()
@@ -183,19 +204,6 @@ pub fn set_fee_rate_bps(env: &Env, fee_rate_bps: i128) {
     env.storage()
         .persistent()
         .set(&StorageKey::FeeRateBps, &fee_rate_bps);
-}
-
-pub fn get_treasury(env: &Env) -> Option<Address> {
-    env.storage()
-        .persistent()
-        .get(&StorageKey::Treasury)
-}
-
-pub fn set_treasury(env: &Env, treasury: &Option<Address>) {
-    match treasury {
-        Some(addr) => env.storage().persistent().set(&StorageKey::Treasury, addr),
-        None => env.storage().persistent().remove(&StorageKey::Treasury),
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR wires  in the market contract to mint/burn outcome tokens via the registered outcome-token contract. It also adds storage and admin registration for the outcome-token contract address.

Linked issues: Closes #319, Closes #320, Closes #326, Closes #330