### PR TITLE
Ci/workspace integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,21 +13,21 @@ jobs:
   ci:
     name: Build and Test
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
           targets: wasm32-unknown-unknown
-      
+
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: contracts/market
-      
+          workspaces: . -> target
+
       # Format check enforces consistent code style across the project using rustfmt.
       # Configuration is defined in contracts/market/rustfmt.toml to ensure all
       # contributors format code identically. This prevents style drift and makes
@@ -45,7 +45,7 @@ jobs:
       # See contracts/market/rustfmt.toml for the option reference and planned rules.
       - name: Format check
         run: cd contracts/market && cargo fmt --check
-      
+
       # Echo guard: this step currently runs clippy with `-D warnings` to catch
       # lint issues early, but does not yet enforce a full set of custom lints.
       #
@@ -63,13 +63,23 @@ jobs:
       # real CI actions (credentials, expected outputs, and invocation examples).
       - name: Clippy
         run: cd contracts/market && cargo clippy -- -D warnings
-      
+
       # Runs all unit and integration tests for the market contract via `cargo test`.
       # Tests are defined alongside the contract source under `contracts/market/src/`
       # using Soroban SDK test utilities. A new test should be added for every
       # public contract function to maintain coverage.
       - name: Tests
         run: cd contracts/market && cargo test
+
+      # Runs the workspace-level integration tests located in tests/.
+      # These tests exercise cross-contract behaviour (Market <-> Treasury) and the
+      # full prediction-market lifecycle (create -> deposit -> trade -> resolve -> settle)
+      # using live Soroban testutils environments — no storage mocking.
+      # They are compiled as integration test binaries (not inline unit tests), so
+      # `--tests` targets only files under tests/ and avoids re-running the unit
+      # tests already covered by the step above.
+      - name: Workspace integration tests
+        run: cargo test --workspace --tests
 
       # Restore saved proptest regression cases from previous CI runs so that
       # any previously-found failing inputs are always re-checked.
@@ -95,7 +105,7 @@ jobs:
           name: proptest-regressions
           path: contracts/market/src/.proptest-regressions
           if-no-files-found: ignore
-      
+
       # Compiles the contract to WASM (wasm32-unknown-unknown) — the binary format
       # required by the Stellar Soroban runtime. Mirrors the `make build` target in
       # contracts/market/Makefile; run `cd contracts/market && make build` locally


### PR DESCRIPTION
Problem
The CI pipeline only ran cd contracts/market && cargo test, which exercises the market contract's own inline unit tests. The five workspace-level integration tests under tests/ were silently skipped on every push and pull request — meaning cross-contract flows (Market ↔ Treasury fee routing, full lifecycle settlement, collateral invariants) were never validated in CI.

A secondary issue: the rust-cache step set workspaces: contracts/market, pointing the cache at a workspace member rather than the workspace root. Cargo.lock and the shared target/ directory both live at ., so the cache key was derived from the wrong manifest and cache hits were unreliable, unnecessarily slowing down every CI run.

What Changed
rust-cache workspace path corrected

-          workspaces: contracts/market
+          workspaces: . -> target
Points the dependency cache at the actual Cargo workspace root so the lock-file hash and target/ path are correct for all packages in the workspace.

New CI step — Workspace integration tests

- name: Workspace integration tests
  run: cargo test --workspace --tests
Added immediately after the existing market unit-test step.

--workspace includes the root package (vatix-contract-tests), which owns the tests/ directory.
--tests restricts compilation to integration-test binaries (files under tests/) and does not re-run the inline unit tests already covered by the previous step.
Tests Now Running in CI
File	What it covers
tests/market_test.rs	Market creation, collateral deposit, full protocol loop (deposit → trade → resolve → settle)
tests/positions_test.rs	Share trading via update_position; YES/NO share accounting
tests/settlement_test.rs	Full lifecycle end-to-end: init → create → deposit → buy → resolve → settle
tests/withdraw_treasury_test.rs	Cross-contract fee routing — Market deducts 50 bps and forwards to Treasury on every withdrawal
tests/collateral_invariant_test.rs	Regression and property tests for collateral locking invariants
All five test files already existed with full implementations. No test code was written or modified. No Cargo.toml changes were needed — the workspace root package (vatix-contract-tests) already declared the correct [dev-dependencies]:


vatix-market-contract   = { path = "contracts/market" }
vatix-treasury-contract = { path = "contracts/treasury" }
soroban-sdk             = { workspace = true, features = ["testutils"] }
ed25519-dalek           = "2.2.0"
rand                    = "0.8"
The tests simply were never invoked from CI.

No Regressions
The existing Tests step (cd contracts/market && cargo test) is unchanged and continues to run market unit tests.
The existing Proptest fuzz step is unchanged.
The Frontend job is unaffected.
The new step runs after market unit tests and before proptest, giving fast feedback on integration failures before the slower fuzz suite.
Test Plan
 CI passes on this PR with the new "Workspace integration tests" step green
 All five integration test binaries appear in the step output
 Existing "Tests" and "Proptest fuzz" steps remain unaffected
 No regressions in the frontend job
 
 closes #300 