### PR TITLE
feat(market): enforce immutability of outcome_count (#411)

### DIFF
--- a/contracts/market/src/deposit.rs
+++ b/contracts/market/src/deposit.rs
@@ -140,6 +140,7 @@ mod tests {
             resolver: None,
             resolved_at: None,
             adapter_type: AdapterType::Ed25519,
+            outcome_count: 2,
         }
     }
 

--- a/contracts/market/src/error.rs
+++ b/contracts/market/src/error.rs
@@ -117,6 +117,12 @@ pub enum ContractError {
     /// Questions must be non-empty and reasonably sized (1-499 characters).
     InvalidQuestion = 33,
 
+    /// Outcome count is not exactly 2.
+    ///
+    /// All markets on this protocol are binary (YES/NO). Any attempt to create
+    /// or overwrite a market with an outcome_count other than 2 is rejected.
+    InvalidOutcomeCount = 34,
+
     // ========== Authorization Errors (40-49) ==========
     /// Caller is not authorized to perform this action.
     ///

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -185,6 +185,7 @@ impl MarketContract {
             resolver: None,
             resolved_at: None,
             adapter_type: crate::types::AdapterType::Ed25519,
+            outcome_count: 2,
         };
 
         // 5. Store market
@@ -686,6 +687,17 @@ impl MarketContract {
     pub fn get_market(env: Env, market_id: u32) -> Result<crate::types::Market, ContractError> {
         storage::get_market(&env, market_id)?
             .ok_or(ContractError::MarketNotFound)
+    }
+
+    /// Return the immutable outcome count for a market (always 2 for binary markets).
+    ///
+    /// # Errors
+    /// - [`ContractError::MarketNotFound`] — no market exists with the given ID.
+    /// - [`ContractError::UpgradeRequired`] — storage version mismatch.
+    pub fn get_outcome_count(env: Env, market_id: u32) -> Result<u32, ContractError> {
+        let market = storage::get_market(&env, market_id)?
+            .ok_or(ContractError::MarketNotFound)?;
+        Ok(market.outcome_count)
     }
 
     /// Cancel an active market, preventing further deposits and withdrawals.

--- a/contracts/market/src/oracle.rs
+++ b/contracts/market/src/oracle.rs
@@ -156,6 +156,7 @@ mod tests {
             resolver: None,
             resolved_at: None,
             adapter_type: AdapterType::Ed25519,
+            outcome_count: 2,
         }
     }
 

--- a/contracts/market/src/positions.rs
+++ b/contracts/market/src/positions.rs
@@ -286,6 +286,7 @@ mod tests {
             resolver: None,
             resolved_at: None,
             adapter_type: AdapterType::Ed25519,
+            outcome_count: 2,
         }
     }
 

--- a/contracts/market/src/settlement.rs
+++ b/contracts/market/src/settlement.rs
@@ -249,6 +249,7 @@ mod tests {
             resolver: None,
             resolved_at: None,
             adapter_type: AdapterType::Ed25519,
+            outcome_count: 2,
         }
     }
 

--- a/contracts/market/src/storage.rs
+++ b/contracts/market/src/storage.rs
@@ -11,7 +11,7 @@ use soroban_sdk::{contracttype, Address, Env};
 /// 3. Call `initialize(admin)` on the fresh deployment — it writes the new version.
 /// 4. The old deployment is now permanently locked behind `UpgradeRequired`;
 ///    any call that touches storage will return that error.
-pub const STORAGE_VERSION: u32 = 2;
+pub const STORAGE_VERSION: u32 = 3;
 
 #[contracttype]
 pub enum StorageKey {
@@ -74,6 +74,7 @@ pub fn get_market(env: &Env, market_id: u32) -> Result<Option<Market>, ContractE
 
 pub fn set_market(env: &Env, market_id: u32, market: &Market) -> Result<(), ContractError> {
     assert_version(env)?;
+    crate::validation::validate_outcome_count(market.outcome_count)?;
     env.storage()
         .persistent()
         .set(&StorageKey::Market(market_id), market);
@@ -316,6 +317,7 @@ mod test {
             resolver: None,
             resolved_at: None,
             adapter_type: AdapterType::Ed25519,
+            outcome_count: 2,
         };
 
         env.as_contract(&contract_id, || {
@@ -385,6 +387,7 @@ mod test {
             resolver: None,
             resolved_at: None,
             adapter_type: AdapterType::Ed25519,
+            outcome_count: 2,
         };
 
         let position = Position {
@@ -518,6 +521,10 @@ mod test {
             created_at: 0,
             collateral_token,
             price_bps: 5_000,
+            resolver: None,
+            resolved_at: None,
+            adapter_type: AdapterType::Ed25519,
+            outcome_count: 2,
         };
 
         env.as_contract(&contract_id, || {

--- a/contracts/market/src/types.rs
+++ b/contracts/market/src/types.rs
@@ -42,6 +42,9 @@ pub struct Market {
     pub resolved_at: Option<u64>,
     /// Oracle adapter type used for resolving this market.
     pub adapter_type: AdapterType,
+    /// Number of possible outcomes for this market. Always 2 (YES/NO) for binary
+    /// prediction markets. Set once at creation and immutable thereafter.
+    pub outcome_count: u32,
 }
 
 /// Tracks the position and shares of a specific user in a market.

--- a/contracts/market/src/validation.rs
+++ b/contracts/market/src/validation.rs
@@ -170,7 +170,7 @@ pub fn parse_market_id(market_id: &String) -> Result<u32, ContractError> {
     Ok(n)
 }
 
-/// Validates a configured withdrawal fee rate (in basis points).
+/// Validates that a configured withdrawal fee rate (in basis points).
 ///
 /// The fee rate must lie within the inclusive 0–10_000 bps range (0%–100%).
 ///
@@ -178,6 +178,20 @@ pub fn parse_market_id(market_id: &String) -> Result<u32, ContractError> {
 /// - `InvalidPrice`: `fee_rate_bps` is outside the 0–10_000 range.
 pub fn validate_fee_rate_bps(fee_rate_bps: i128) -> Result<(), ContractError> {
     validate_market_price(fee_rate_bps)
+}
+
+/// Validates that outcome_count is exactly 2 (binary YES/NO market).
+///
+/// All Vatix markets are binary. This is enforced at creation and re-checked
+/// on every write so the field cannot be silently mutated by callers.
+///
+/// # Errors
+/// - [`ContractError::InvalidOutcomeCount`] – `outcome_count` is not 2.
+pub fn validate_outcome_count(outcome_count: u32) -> Result<(), ContractError> {
+    if outcome_count != 2 {
+        return Err(ContractError::InvalidOutcomeCount);
+    }
+    Ok(())
 }
 
 /// Calculate fee with validation guard

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -198,6 +198,7 @@ mod tests {
             resolver: None,
             resolved_at: None,
             adapter_type: AdapterType::Ed25519,
+            outcome_count: 2,
         }
     }
 


### PR DESCRIPTION
 What was done

### 1. `types.rs` — Added `outcome_count: u32` to `Market` A new `pub outcome_count: u32` field was appended to the `Market` struct with a doc-comment explaining it is always 2 for binary markets and is immutable after creation.

### 2. `error.rs` — Added `InvalidOutcomeCount = 34` A new error variant was introduced in the Validation Errors (30–39) range to give callers a machine-readable rejection reason whenever an `outcome_count` other than 2 is detected. The discriminant 34 follows directly after `InvalidQuestion = 33`.

### 3. `validation.rs` — Added `validate_outcome_count(u32)` A new public validation function enforces that outcome_count == 2, returning `Err(ContractError::InvalidOutcomeCount)` for any other value. This is the single source of truth for the invariant, reusable anywhere.

### 4. `storage.rs` — Guarded `set_market` + bumped `STORAGE_VERSION` to 3 `set_market` now calls `validate_outcome_count(market.outcome_count)` before writing to persistent storage, making it structurally impossible to persist a Market with a non-binary outcome count regardless of how the function is called.
`STORAGE_VERSION` was incremented from 2 to 3 to signal the breaking schema change (new required field on `Market`), which will cause any deployment running the old binary to return `UpgradeRequired` rather than silently deserialising a malformed struct.

### 5. `lib.rs` — Set `outcome_count: 2` in `initialize_market` + getter The `initialize_market` entry point now sets `outcome_count: 2` in the `Market` literal it constructs. A new public `get_outcome_count` method was added so clients can read this value directly without fetching the full `Market` struct.

### 6. All test Market literals updated
Every in-test `Market { ... }` struct literal across `deposit.rs`, `withdraw.rs`, `settlement.rs`, `oracle.rs`, `positions.rs`, and `storage.rs` was updated to include `outcome_count: 2`. The orphaned migration test vector in `storage.rs` (which was also missing `adapter_type`) was fully completed at the same time.

## Files changed
- contracts/market/src/types.rs
- contracts/market/src/error.rs
- contracts/market/src/validation.rs
- contracts/market/src/storage.rs
- contracts/market/src/lib.rs
- contracts/market/src/deposit.rs
- contracts/market/src/withdraw.rs
- contracts/market/src/settlement.rs
- contracts/market/src/oracle.rs
- contracts/market/src/positions.rs




closes #408 
closes #409 
closes #410 
closes  #411 