### PR TITLE
fix(storage): remove duplicate treasury helpers and add StorageVersion to treasury

### DIFF
--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -612,25 +612,6 @@ pub fn emit_treasury_set(env: &Env, treasury: &Address) {
     .publish(env);
 }
 
-#[contractevent]
-#[derive(Clone, Debug)]
-pub struct MarketCanceledEvent {
-    #[topic]
-    pub market_id: u32,
-    #[topic]
-    pub canceled_by: Address,
-    pub canceled_at: u64,
-}
-
-pub fn emit_market_canceled(env: &Env, market_id: u32, canceled_by: &Address) {
-    MarketCanceledEvent {
-        market_id,
-        canceled_by: canceled_by.clone(),
-        canceled_at: env.ledger().timestamp(),
-    }
-    .publish(env);
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -688,44 +688,4 @@ impl MarketContract {
             .ok_or(ContractError::MarketNotFound)
     }
 
-    /// Cancel an active market, preventing further deposits and withdrawals.
-    ///
-    /// Only the admin may cancel a market. The market must be in `Active` status.
-    ///
-    /// # Arguments
-    /// * `env` - Contract environment
-    /// * `admin` - Must be the stored admin address.
-    /// * `market_id` - The market to cancel.
-    ///
-    /// # Errors
-    /// - [`ContractError::NotAdmin`] — caller is not the stored admin.
-    /// - [`ContractError::MarketNotFound`] — no market with the given ID.
-    /// - [`ContractError::MarketNotActive`] — market is already resolved or canceled.
-    ///
-    /// # Events
-    /// Emits `MarketCanceled` with the market ID and canceling admin.
-    pub fn cancel_market(
-        env: Env,
-        admin: Address,
-        market_id: u32,
-    ) -> Result<(), ContractError> {
-        admin.require_auth();
-        let stored_admin = storage::get_admin(&env)?;
-        if admin != stored_admin {
-            return Err(ContractError::NotAdmin);
-        }
-
-        let mut market =
-            storage::get_market(&env, market_id)?.ok_or(ContractError::MarketNotFound)?;
-
-        if market.status != crate::types::MarketStatus::Active {
-            return Err(ContractError::MarketNotActive);
-        }
-
-        market.status = crate::types::MarketStatus::Canceled;
-        storage::set_market(&env, market_id, &market)?;
-
-        events::emit_market_canceled(&env, market_id, &admin);
-        Ok(())
-    }
 }

--- a/contracts/market/src/storage.rs
+++ b/contracts/market/src/storage.rs
@@ -21,18 +21,13 @@ pub enum StorageKey {
     Admin,
     PendingAdmin,
     MarketCounter,
-    /// Address of the deployed treasury contract.
-    /// Set by the admin via `set_treasury`; optional — withdrawal fees are
-    /// only routed there when this key is populated and fee_amount > 0.
-    Treasury,
-    FeeRateBps,
-    /// Withdrawal fee rate in basis points (0–10_000). Read in the withdraw
-    /// path to compute the protocol fee; defaults to 0 when unset.
-    FeeRateBps,
     /// Address of the deployed treasury contract that protocol fees are routed
     /// to. Optional — fees are only forwarded when this is populated and the
     /// computed fee_amount is greater than zero.
     Treasury,
+    /// Withdrawal fee rate in basis points (0–10_000). Read in the withdraw
+    /// path to compute the protocol fee; defaults to 0 when unset.
+    FeeRateBps,
     /// Address of the deployed outcome-token contract. When set, `update_position`
     /// mints/burns outcome tokens to reflect share balance changes.
     OutcomeTokenContract,
@@ -174,10 +169,30 @@ pub fn get_treasury(env: &Env) -> Option<Address> {
 }
 
 /// Register (or replace) the treasury contract address for protocol fee routing.
-pub fn set_treasury(env: &Env, treasury: &Address) {
+/// Pass `None` to remove the treasury and disable fee routing.
+pub fn set_treasury(env: &Env, treasury: &Option<Address>) {
+    match treasury {
+        Some(addr) => env.storage().persistent().set(&StorageKey::Treasury, addr),
+        None => env.storage().persistent().remove(&StorageKey::Treasury),
+    }
+}
+
+pub fn has_treasury(env: &Env) -> bool {
+    env.storage().persistent().has(&StorageKey::Treasury)
+}
+
+// --- Resolution Contract Storage ---
+
+pub fn get_resolution_contract(env: &Env) -> Option<Address> {
     env.storage()
         .persistent()
-        .set(&StorageKey::Treasury, treasury);
+        .get(&StorageKey::ResolutionContract)
+}
+
+pub fn set_resolution_contract(env: &Env, contract: &Address) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::ResolutionContract, contract);
 }
 
 // --- Outcome Token Storage ---
@@ -207,23 +222,6 @@ pub fn set_fee_rate_bps(env: &Env, fee_rate_bps: i128) {
     env.storage()
         .persistent()
         .set(&StorageKey::FeeRateBps, &fee_rate_bps);
-}
-
-pub fn get_treasury(env: &Env) -> Option<Address> {
-    env.storage()
-        .persistent()
-        .get(&StorageKey::Treasury)
-}
-
-pub fn set_treasury(env: &Env, treasury: &Option<Address>) {
-    match treasury {
-        Some(addr) => env.storage().persistent().set(&StorageKey::Treasury, addr),
-        None => env.storage().persistent().remove(&StorageKey::Treasury),
-    }
-}
-
-pub fn has_treasury(env: &Env) -> bool {
-    env.storage().persistent().has(&StorageKey::Treasury)
 }
 
 #[cfg(test)]
@@ -427,7 +425,6 @@ mod test {
             assert_eq!(m.creator, market.creator);
             assert_eq!(m.created_at, market.created_at);
             assert_eq!(m.collateral_token, market.collateral_token);
-            assert_eq!(m.resolution_price, market.resolution_price);
 
             // --- Position slot is keyed by (market_id, user) ---
             assert!(!has_position(&env, market_id, &user).unwrap());
@@ -518,6 +515,9 @@ mod test {
             created_at: 0,
             collateral_token,
             price_bps: 5_000,
+            resolver: None,
+            resolved_at: None,
+            adapter_type: crate::types::AdapterType::Ed25519,
         };
 
         env.as_contract(&contract_id, || {
@@ -544,6 +544,46 @@ mod test {
                 .persistent()
                 .set(&StorageKey::StorageVersion, &(STORAGE_VERSION + 1));
             assert_eq!(assert_version(&env), Err(ContractError::UpgradeRequired));
+        });
+    }
+
+    // ── Treasury storage helpers ──────────────────────────────────────────────
+
+    #[test]
+    fn test_treasury_storage_set_and_get() {
+        let env = Env::default();
+        let contract_id = env.register(crate::MarketContract, ());
+        let treasury = Address::generate(&env);
+        init_versioned(&env, &contract_id);
+
+        env.as_contract(&contract_id, || {
+            assert!(!has_treasury(&env));
+            assert_eq!(get_treasury(&env), None);
+
+            set_treasury(&env, &Some(treasury.clone()));
+            assert!(has_treasury(&env));
+            assert_eq!(get_treasury(&env), Some(treasury.clone()));
+
+            set_treasury(&env, &None);
+            assert!(!has_treasury(&env));
+            assert_eq!(get_treasury(&env), None);
+        });
+    }
+
+    // ── Resolution contract storage helpers ───────────────────────────────────
+
+    #[test]
+    fn test_resolution_contract_storage_set_and_get() {
+        let env = Env::default();
+        let contract_id = env.register(crate::MarketContract, ());
+        let resolution = Address::generate(&env);
+        init_versioned(&env, &contract_id);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(get_resolution_contract(&env), None);
+
+            set_resolution_contract(&env, &resolution);
+            assert_eq!(get_resolution_contract(&env), Some(resolution.clone()));
         });
     }
 }

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -909,7 +909,7 @@ mod test {
         let (env, admin, client, contract_id) = create_test_contract();
         let treasury = Address::generate(&env);
 
-        client.set_treasury(&admin, &treasury);
+        client.set_treasury_contract(&admin, &treasury);
 
         env.as_contract(&contract_id, || {
             assert_eq!(storage::get_treasury(&env).unwrap(), treasury);
@@ -948,7 +948,7 @@ mod test {
         let stranger = Address::generate(&env);
         let address = Address::generate(&env);
 
-        assert_eq!(client.try_set_treasury(&stranger, &address), Err(Ok(ContractError::NotAdmin)));
+        assert_eq!(client.try_set_treasury_contract(&stranger, &address), Err(Ok(ContractError::NotAdmin)));
         assert_eq!(client.try_set_outcome_token_contract(&stranger, &address), Err(Ok(ContractError::NotAdmin)));
         assert_eq!(client.try_set_resolution_contract(&stranger, &address), Err(Ok(ContractError::NotAdmin)));
     }
@@ -988,9 +988,10 @@ mod test {
         ResolutionContractClient::new(&env, &resolution_addr)
             .propose(&proposer, &market_id, &true, &signature, &evidence, &60);
 
+        let resolver = Address::generate(&env);
         let market_id_str = String::from_str(&env, &market_id.to_string());
         assert_eq!(
-            client.try_resolve_market(&market_id_str, &true, &signature),
+            client.try_resolve_market(&resolver, &market_id_str, &true, &signature),
             Err(Ok(ContractError::ResolutionNotFinalized))
         );
     }

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -726,7 +726,7 @@ mod tests {
             storage::set_market(&env, market_id, &market).unwrap();
             storage::set_position(&env, market_id, &user, &position).unwrap();
             storage::set_fee_rate_bps(&env, 1000); // 10% fee
-            storage::set_treasury(&env, &treasury);
+            storage::set_treasury(&env, &Some(treasury_id.clone()));
         });
 
         let token_client = StellarAssetClient::new(&env, &collateral_token);

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -75,6 +75,7 @@ impl TreasuryContract {
         }
         storage::set_admin(&env, &admin);
         storage::set_authorized_market(&env, &market_contract);
+        storage::set_version(&env);
         events::emit_treasury_initialized(&env, &admin, &market_contract);
         Ok(())
     }

--- a/contracts/treasury/src/storage.rs
+++ b/contracts/treasury/src/storage.rs
@@ -2,10 +2,16 @@
 
 use soroban_sdk::{contracttype, Address, Env};
 
+/// Bump this constant whenever the treasury storage layout changes in a breaking way.
+/// `initialize()` writes this value so that future migrations can detect stale deployments.
+pub const STORAGE_VERSION: u32 = 1;
+
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
 #[contracttype]
 pub enum StorageKey {
+    /// Written by `initialize`; used to detect stale or uninitialized deployments.
+    StorageVersion,
     /// The address that can call `withdraw_fees` and other admin operations.
     Admin,
     /// The single market contract address allowed to call `collect_fee`.
@@ -16,6 +22,18 @@ pub enum StorageKey {
     CumulativeFees(Address),
     /// Global monotone counter: total of all fees ever collected across all tokens.
     TotalCollected,
+}
+
+// ── Version ───────────────────────────────────────────────────────────────────
+
+pub fn set_version(env: &Env) {
+    env.storage()
+        .instance()
+        .set(&StorageKey::StorageVersion, &STORAGE_VERSION);
+}
+
+pub fn get_version(env: &Env) -> Option<u32> {
+    env.storage().instance().get(&StorageKey::StorageVersion)
 }
 
 // ── Admin ─────────────────────────────────────────────────────────────────────

--- a/contracts/treasury/src/test.rs
+++ b/contracts/treasury/src/test.rs
@@ -6,7 +6,7 @@ use soroban_sdk::{
     Address, Env,
 };
 
-use crate::{TreasuryContract, TreasuryContractClient, TreasuryError};
+use crate::{storage, TreasuryContract, TreasuryContractClient, TreasuryError};
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -56,6 +56,27 @@ fn initialize_stores_admin_and_market() {
     assert_eq!(s.client.market_contract(), s.market);
     assert_eq!(s.client.token_balance(&s.token), 0);
     assert_eq!(s.client.get_cumulative_fees(&s.token), 0);
+}
+
+#[test]
+fn initialize_writes_storage_version() {
+    let s = setup();
+    s.env.as_contract(&s.treasury_id, || {
+        assert_eq!(
+            storage::get_version(&s.env),
+            Some(storage::STORAGE_VERSION),
+        );
+    });
+}
+
+#[test]
+fn storage_version_absent_before_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(TreasuryContract, ());
+    env.as_contract(&id, || {
+        assert_eq!(storage::get_version(&env), None);
+    });
 }
 
 #[test]

--- a/tests/treasury_integration_test.rs
+++ b/tests/treasury_integration_test.rs
@@ -46,7 +46,7 @@ fn mock_sac_fee_flows_to_treasury() {
     TreasuryContractClient::new(&env, &treasury_addr).initialize(&admin, &market_addr);
 
     let market = MarketContractClient::new(&env, &market_addr);
-    market.set_treasury(&admin, &treasury_addr);
+    market.set_treasury_contract(&admin, &treasury_addr);
     let treasury = TreasuryContractClient::new(&env, &treasury_addr);
 
     // Mock SAC: use Stellar Asset Contract as the collateral token.
@@ -104,7 +104,7 @@ fn mock_sac_multiple_withdrawals_accumulate() {
     TreasuryContractClient::new(&env, &treasury_addr).initialize(&admin, &market_addr);
 
     let market = MarketContractClient::new(&env, &market_addr);
-    market.set_treasury(&admin, &treasury_addr);
+    market.set_treasury_contract(&admin, &treasury_addr);
     let treasury = TreasuryContractClient::new(&env, &treasury_addr);
 
     let token_admin = Address::generate(&env);
@@ -152,7 +152,7 @@ fn admin_withdraws_mock_sac_fees() {
     TreasuryContractClient::new(&env, &treasury_addr).initialize(&admin, &market_addr);
 
     let market = MarketContractClient::new(&env, &market_addr);
-    market.set_treasury(&admin, &treasury_addr);
+    market.set_treasury_contract(&admin, &treasury_addr);
     let treasury = TreasuryContractClient::new(&env, &treasury_addr);
 
     let token_admin = Address::generate(&env);

--- a/tests/withdraw_treasury_test.rs
+++ b/tests/withdraw_treasury_test.rs
@@ -44,7 +44,7 @@ fn setup_with_treasury() -> (Env, Address, Address, Address, Address) {
     TreasuryContractClient::new(&env, &treasury_addr)
         .initialize(&admin, &market_addr);
 
-    MarketContractClient::new(&env, &market_addr).set_treasury(&admin, &treasury_addr);
+    MarketContractClient::new(&env, &market_addr).set_treasury_contract(&admin, &treasury_addr);
 
     let token_admin = Address::generate(&env);
     let collateral_token = env


### PR DESCRIPTION
THIS PR 

closes #306
closes #307


## Summary

- Removes duplicate `Treasury` and `FeeRateBps` variants from `StorageKey` enum in `contracts/market/src/storage.rs`
- Consolidates the two duplicate `get_treasury`/`set_treasury` function bodies into a single correct implementation (using the `&Option<Address>` signature that all callers require)
- Adds missing `get_resolution_contract` and `set_resolution_contract` storage helpers (referenced in `lib.rs` but absent from `storage.rs`)
- Removes duplicate `cancel_market` in `lib.rs` and duplicate `emit_market_canceled`/`MarketCanceledEvent` in `events.rs` that caused compile errors
- Adds `StorageVersion` key to `contracts/treasury/src/storage.rs` (`STORAGE_VERSION = 1`, `set_version`, `get_version`)
- Calls `storage::set_version(&env)` in `TreasuryContract::initialize` so every fresh deployment records its version

## Changes

| File | Change |
|---|---|
| `contracts/market/src/storage.rs` | Remove duplicate `Treasury`/`FeeRateBps` enum variants; fix `set_treasury` signature; add resolution contract helpers; new tests |
| `contracts/market/src/lib.rs` | Remove duplicate `cancel_market` method |
| `contracts/market/src/events.rs` | Remove duplicate `MarketCanceledEvent` struct and `emit_market_canceled` function |
| `contracts/market/src/test.rs` | Fix `client.set_treasury` → `client.set_treasury_contract`; add missing resolver arg |
| `contracts/market/src/withdraw.rs` | Fix undefined `treasury` variable → `Some(treasury_id.clone())` |
| `contracts/treasury/src/storage.rs` | Add `STORAGE_VERSION`, `StorageVersion` key, `set_version`, `get_version` |
| `contracts/treasury/src/lib.rs` | Call `storage::set_version` in `initialize` |
| `contracts/treasury/src/test.rs` | Add tests for StorageVersion written at initialize |
| `tests/withdraw_treasury_test.rs` | Fix `set_treasury` → `set_treasury_contract` |
| `tests/treasury_integration_test.rs` | Fix `set_treasury` → `set_treasury_contract` |

## Testing

- New unit tests in `contracts/market/src/storage.rs` covering `set_treasury`/`get_treasury`/`has_treasury` with `Option` and `get_resolution_contract`/`set_resolution_contract`
- New unit tests in `contracts/treasury/src/test.rs` verifying `StorageVersion` is written by `initialize` and absent before it
