### PR TITLE
feat: emit AdminTransferred event, add fmt pre-commit hook, fix netwo…

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+# Run cargo fmt --check across the workspace before each commit.
+# To skip (not recommended): git commit --no-verify
+set -e
+
+if ! cargo fmt --check 2>&1; then
+  echo ""
+  echo "pre-commit: cargo fmt check failed."
+  echo "Run 'cargo fmt' to fix formatting, then re-stage and commit."
+  exit 1
+fi

--- a/apps/web/app/markets/page.tsx
+++ b/apps/web/app/markets/page.tsx
@@ -1,6 +1,40 @@
+import { Suspense } from "react";
 import { MarketCard } from "@/components/MarketCard";
-import { MOCK_MARKETS } from "@/lib/markets";
+import { LoadingSkeleton } from "@/components/LoadingSkeleton";
+import { getMarkets, MOCK_MARKETS } from "@/lib/markets";
 import { containerClass } from "@/lib/responsive";
+
+async function MarketList() {
+  const fetched = await getMarkets();
+  const markets = fetched.length > 0 ? fetched : MOCK_MARKETS;
+
+  if (markets.length === 0) {
+    return (
+      <div className="mt-8 rounded-xl border border-slate-200 p-6 text-sm dark:border-slate-700">
+        <p className="font-medium">No markets yet</p>
+        <p className="mt-1 text-slate-600 dark:text-slate-400">
+          Check back soon, or browse the home page for updates.
+        </p>
+        <a
+          href="/"
+          className="mt-4 inline-flex rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500"
+        >
+          Back to home
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="mt-8 grid gap-4 sm:grid-cols-2">
+      {markets.map((market) => (
+        <li key={market.id}>
+          <MarketCard market={market} />
+        </li>
+      ))}
+    </ul>
+  );
+}
 
 export default function MarketsPage() {
   return (
@@ -9,28 +43,9 @@ export default function MarketsPage() {
       <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
         Mock data for UI development — replace with Soroban contract reads.
       </p>
-      {MOCK_MARKETS.length === 0 ? (
-        <div className="mt-8 rounded-xl border border-slate-200 p-6 text-sm dark:border-slate-700">
-          <p className="font-medium">No markets yet</p>
-          <p className="mt-1 text-slate-600 dark:text-slate-400">
-            Check back soon, or browse the home page for updates.
-          </p>
-          <a
-            href="/"
-            className="mt-4 inline-flex rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500"
-          >
-            Back to home
-          </a>
-        </div>
-      ) : (
-        <ul className="mt-8 grid gap-4 sm:grid-cols-2">
-          {MOCK_MARKETS.map((market) => (
-            <li key={market.id}>
-              <MarketCard market={market} />
-            </li>
-          ))}
-        </ul>
-      )}
+      <Suspense fallback={<LoadingSkeleton />}>
+        <MarketList />
+      </Suspense>
     </div>
   );
 }

--- a/apps/web/components/LoadingSkeleton.tsx
+++ b/apps/web/components/LoadingSkeleton.tsx
@@ -2,10 +2,19 @@
 
 export function LoadingSkeleton() {
   return (
-    <div className="space-y-3">
-      {[...Array(3)].map((_, i) => (
-        <div key={i} className="skeleton h-12" />
+    <ul className="mt-8 grid gap-4 sm:grid-cols-2">
+      {[...Array(4)].map((_, i) => (
+        <li key={i} className="animate-pulse rounded-xl border border-slate-200 p-4 dark:border-slate-700">
+          <div className="h-3 w-24 rounded bg-slate-200 dark:bg-slate-800" />
+          <div className="mt-2 h-5 w-full rounded bg-slate-200 dark:bg-slate-800" />
+          <div className="mt-1 h-5 w-3/4 rounded bg-slate-200 dark:bg-slate-800" />
+          <div className="mt-4 flex justify-between">
+            <div className="h-4 w-28 rounded bg-slate-200 dark:bg-slate-800" />
+            <div className="h-4 w-16 rounded bg-slate-200 dark:bg-slate-800" />
+          </div>
+          <div className="mt-3 h-2 rounded-full bg-slate-100 dark:bg-slate-800" />
+        </li>
       ))}
-    </div>
+    </ul>
   );
 }

--- a/apps/web/lib/soroban.ts
+++ b/apps/web/lib/soroban.ts
@@ -6,7 +6,6 @@
 
 import {
   Contract,
-  Networks,
   nativeToScVal,
   SorobanRpc,
   TransactionBuilder,
@@ -20,7 +19,7 @@ export const SOROBAN_RPC_URL =
 
 export const NETWORK_PASSPHRASE =
   process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE ??
-  Networks.TESTNET;
+  "Test SDF Network ; September 2015";
 
 export const HORIZON_URL =
   process.env.NEXT_PUBLIC_HORIZON_URL ??

--- a/contracts/treasury/src/events.rs
+++ b/contracts/treasury/src/events.rs
@@ -89,6 +89,27 @@ pub fn emit_fees_withdrawn(
     .publish(env);
 }
 
+// ── Admin transfer ────────────────────────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct AdminTransferredEvent {
+    #[topic]
+    pub old_admin: Address,
+    #[topic]
+    pub new_admin: Address,
+    pub transferred_at: u64,
+}
+
+pub fn emit_admin_transferred(env: &Env, old_admin: &Address, new_admin: &Address) {
+    AdminTransferredEvent {
+        old_admin: old_admin.clone(),
+        new_admin: new_admin.clone(),
+        transferred_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
 // ── Market contract rotation ──────────────────────────────────────────────────
 
 #[contractevent]

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -169,6 +169,29 @@ impl TreasuryContract {
         Ok(())
     }
 
+    /// Transfer admin rights to a new address immediately.
+    ///
+    /// Only the current admin may call this.
+    pub fn transfer_admin(
+        env: Env,
+        caller: Address,
+        new_admin: Address,
+    ) -> Result<(), TreasuryError> {
+        caller.require_auth();
+
+        if !storage::has_admin(&env) {
+            return Err(TreasuryError::NotInitialized);
+        }
+        let admin = storage::get_admin(&env);
+        if caller != admin {
+            return Err(TreasuryError::Unauthorized);
+        }
+
+        storage::set_admin(&env, &new_admin);
+        events::emit_admin_transferred(&env, &admin, &new_admin);
+        Ok(())
+    }
+
     /// Rotate the registered market contract address (e.g. after an upgrade).
     ///
     /// Only the admin may call this.

--- a/contracts/treasury/src/test.rs
+++ b/contracts/treasury/src/test.rs
@@ -288,3 +288,71 @@ fn old_market_cannot_collect_fee_after_rotation() {
     s.client.collect_fee(&new_market, &s.token, &1u32, &100i128);
     assert_eq!(s.client.get_cumulative_fees(&s.token), 100);
 }
+
+// ── transfer_admin ────────────────────────────────────────────────────────────
+
+#[test]
+fn transfer_admin_updates_admin() {
+    let s = setup();
+    let new_admin = Address::generate(&s.env);
+    s.client.transfer_admin(&s.admin, &new_admin);
+    assert_eq!(s.client.admin(), new_admin);
+}
+
+#[test]
+fn transfer_admin_emits_event() {
+    use soroban_sdk::testutils::Events as _;
+    use soroban_sdk::{IntoVal, Map, Symbol, TryIntoVal, Val};
+
+    let s = setup();
+    let new_admin = Address::generate(&s.env);
+    s.client.transfer_admin(&s.admin, &new_admin);
+
+    let events = s.env.events().all();
+    // Last event is AdminTransferred
+    let ev = events.last().unwrap();
+    let topics = &ev.1;
+    let topic0: Symbol = topics.get(0).unwrap().into_val(&s.env);
+    assert_eq!(topic0, Symbol::new(&s.env, "admin_transferred_event"));
+
+    let data: Map<Symbol, Val> = ev.2.try_into_val(&s.env).unwrap();
+    let old_val: Address = data.get(Symbol::new(&s.env, "old_admin")).unwrap().into_val(&s.env);
+    let new_val: Address = data.get(Symbol::new(&s.env, "new_admin")).unwrap().into_val(&s.env);
+    assert_eq!(old_val, s.admin);
+    assert_eq!(new_val, new_admin);
+}
+
+#[test]
+fn transfer_admin_rejects_non_admin() {
+    let s = setup();
+    let rando = Address::generate(&s.env);
+    let new_admin = Address::generate(&s.env);
+    let err = s
+        .client
+        .try_transfer_admin(&rando, &new_admin)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, TreasuryError::Unauthorized);
+}
+
+#[test]
+fn new_admin_can_withdraw_after_transfer() {
+    let s = setup();
+    let new_admin = Address::generate(&s.env);
+    s.client.transfer_admin(&s.admin, &new_admin);
+
+    // old admin can no longer withdraw
+    fund_treasury(&s, 100_000);
+    s.client.collect_fee(&s.market, &s.token, &1u32, &100_000i128);
+    let recipient = Address::generate(&s.env);
+    let err = s
+        .client
+        .try_withdraw_fees(&s.admin, &s.token, &recipient, &100_000i128)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, TreasuryError::Unauthorized);
+
+    // new admin can withdraw
+    s.client.withdraw_fees(&new_admin, &s.token, &recipient, &100_000i128);
+    assert_eq!(s.client.token_balance(&s.token), 0);
+}


### PR DESCRIPTION
…rk passphrase, add loading skeleton

#392 - treasury: add transfer_admin + AdminTransferredEvent (old_admin, new_admin, transferred_at)
#393 - tooling: add .githooks/pre-commit that runs cargo fmt --check; configure core.hooksPath
#394 - web: remove Networks.TESTNET import in soroban.ts; use consistent string fallback for NEXT_PUBLIC_NETWORK_PASSPHRASE
#395 - web: wrap markets page MarketList in Suspense with LoadingSkeleton fallback; update skeleton to match MarketCard grid layout

closes #392 
closes #393 
closes #394 
closes #395 