### PR TITLE
feat(web): remove MOCK_MARKETS from production pages

### DIFF
--- a/apps/web/app/markets/[id]/page.tsx
+++ b/apps/web/app/markets/[id]/page.tsx
@@ -1,19 +1,19 @@
-import { MOCK_MARKETS } from "@/lib/markets";
 import { findMarketById } from "@/lib/market-helpers";
+import { DepositForm } from "@/components/DepositForm";
 
-export default function MarketDetailPage({
+export default async function MarketDetailPage({
   params,
 }: {
   params: { id: string };
 }) {
-  const market = findMarketById(params.id);
+  const market = await findMarketById(params.id);
 
   if (!market) {
     return (
       <div className="mx-auto max-w-4xl px-4 py-10">
         <h1 className="text-2xl font-semibold">Market not found</h1>
         <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
-          The market you're looking for doesn't exist.
+          The market you&apos;re looking for doesn&apos;t exist.
         </p>
         <a
           href="/markets"
@@ -38,6 +38,9 @@ export default function MarketDetailPage({
         <p>Status: {market.status}</p>
         <p>Ends: {market.endsAt}</p>
         <p>Volume: {market.volume}</p>
+      </div>
+      <div className="mt-8">
+        <DepositForm marketId={market.id} />
       </div>
     </div>
   );

--- a/apps/web/app/markets/page.tsx
+++ b/apps/web/app/markets/page.tsx
@@ -1,12 +1,11 @@
 import { Suspense } from "react";
 import { MarketCard } from "@/components/MarketCard";
 import { LoadingSkeleton } from "@/components/LoadingSkeleton";
-import { getMarkets, MOCK_MARKETS } from "@/lib/markets";
+import { getMarkets } from "@/lib/markets";
 import { containerClass } from "@/lib/responsive";
 
 async function MarketList() {
-  const fetched = await getMarkets();
-  const markets = fetched.length > 0 ? fetched : MOCK_MARKETS;
+  const markets = await getMarkets();
 
   if (markets.length === 0) {
     return (
@@ -40,9 +39,6 @@ export default function MarketsPage() {
   return (
     <div className={`${containerClass()} py-10`}>
       <h1 className="text-2xl font-semibold">All markets</h1>
-      <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
-        Mock data for UI development — replace with Soroban contract reads.
-      </p>
       <Suspense fallback={<LoadingSkeleton />}>
         <MarketList />
       </Suspense>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,10 +1,31 @@
+import { Suspense } from "react";
 import Link from "next/link";
 import { MarketCard } from "@/components/MarketCard";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { LoadingSkeleton } from "@/components/LoadingSkeleton";
 import { PositionPanel } from "@/components/PositionPanel";
-import { MOCK_MARKETS } from "@/lib/markets";
+import { getMarkets } from "@/lib/markets";
 import { containerClass } from "@/lib/responsive";
+
+async function FeaturedMarkets() {
+  const markets = await getMarkets();
+  if (markets.length === 0) {
+    return (
+      <p className="text-sm text-slate-600 dark:text-slate-400">
+        No markets available yet. Check back soon.
+      </p>
+    );
+  }
+  return (
+    <ul className="grid gap-4 sm:grid-cols-2">
+      {markets.slice(0, 2).map((market) => (
+        <li key={market.id}>
+          <MarketCard market={market} />
+        </li>
+      ))}
+    </ul>
+  );
+}
 
 export default function HomePage() {
   return (
@@ -15,7 +36,7 @@ export default function HomePage() {
         </h1>
         <p className="mt-2 max-w-xl text-sm text-slate-600 dark:text-slate-400">
           Trade binary Yes/No outcomes on Stellar. Connect a wallet to deposit
-          and open positions (Soroban integration coming soon).
+          and open positions.
         </p>
         <Link
           href="/markets"
@@ -27,14 +48,9 @@ export default function HomePage() {
 
       <h2 className="mb-4 text-lg font-medium">Featured markets</h2>
       <ErrorBoundary>
-        <LoadingSkeleton />
-        <ul className="grid gap-4 sm:grid-cols-2">
-          {MOCK_MARKETS.slice(0, 2).map((market) => (
-            <li key={market.id}>
-              <MarketCard market={market} />
-            </li>
-          ))}
-        </ul>
+        <Suspense fallback={<LoadingSkeleton />}>
+          <FeaturedMarkets />
+        </Suspense>
       </ErrorBoundary>
 
       <div className="mt-10">

--- a/apps/web/lib/market-helpers.ts
+++ b/apps/web/lib/market-helpers.ts
@@ -1,5 +1,6 @@
-import { MOCK_MARKETS, type Market } from "./markets";
+import { getMarkets, type Market } from "./markets";
 
-export function findMarketById(id: string): Market | undefined {
-  return MOCK_MARKETS.find((market) => market.id === id);
+export async function findMarketById(id: string): Promise<Market | undefined> {
+  const markets = await getMarkets();
+  return markets.find((market) => market.id === id);
 }

--- a/apps/web/lib/markets.ts
+++ b/apps/web/lib/markets.ts
@@ -13,8 +13,8 @@ export interface Market {
 }
 
 /**
- * Fetch markets from the Soroban contract (or indexer).
- * Returns an empty array when the contract ID is not configured.
+ * Fetch markets from the indexer API.
+ * Returns an empty array when the indexer URL is not configured.
  */
 export async function getMarkets(): Promise<Market[]> {
   const { markets } = await fetchContractMarkets();
@@ -28,46 +28,3 @@ export async function getMarkets(): Promise<Market[]> {
     endsAt: m.ends_at,
   }));
 }
-
-/**
- * Fallback static markets used when no contract is configured.
- * Kept for UI development and as a reference data shape.
- */
-export const MOCK_MARKETS: Market[] = [
-  {
-    id: "mkt-1",
-    question: "Will BTC close above $100k on Dec 31, 2026?",
-    yesPrice: 0.62,
-    noPrice: 0.38,
-    volume: "12,400 XLM",
-    status: "open",
-    endsAt: "2026-12-31",
-  },
-  {
-    id: "mkt-2",
-    question: "Will the Fed cut rates before Q3 2026?",
-    yesPrice: 0.41,
-    noPrice: 0.59,
-    volume: "8,200 XLM",
-    status: "open",
-    endsAt: "2026-09-30",
-  },
-  {
-    id: "mkt-3",
-    question: "Will Stellar process 1B+ ops in 2026?",
-    yesPrice: 0.55,
-    noPrice: 0.45,
-    volume: "3,100 XLM",
-    status: "open",
-    endsAt: "2026-12-31",
-  },
-  {
-    id: "mkt-4",
-    question: "Demo market: protocol upgrade passes?",
-    yesPrice: 0.78,
-    noPrice: 0.22,
-    volume: "1,050 XLM",
-    status: "resolved",
-    endsAt: "2025-06-01",
-  },
-];


### PR DESCRIPTION
- markets.ts: drop MOCK_MARKETS export; getMarkets() is the sole API
- market-helpers.ts: findMarketById is now async, fetches live data
- page.tsx: async FeaturedMarkets component, empty-state fallback
- markets/page.tsx: remove MOCK_MARKETS fallback, drop stale comment
- markets/[id]/page.tsx: async server component using findMarketById
closes #359 