### PR TITLE
feat: add admin parameter validation for initialize (#370)

### DIFF
--- a/contracts/market/src/error.rs
+++ b/contracts/market/src/error.rs
@@ -123,6 +123,12 @@ pub enum ContractError {
     /// or overwrite a market with an outcome_count other than 2 is rejected.
     InvalidOutcomeCount = 34,
 
+    /// Admin address is invalid (e.g., contract address or zero address).
+    ///
+    /// The admin must be a valid user account address, not a contract address
+    /// or any special/reserved address.
+    InvalidAdmin = 35,
+
     // ========== Authorization Errors (40-49) ==========
     /// Caller is not authorized to perform this action.
     ///

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -76,14 +76,46 @@ impl MarketContract {
     ///
     /// Must be called once by the admin immediately after deployment.
     /// Subsequent calls return [`ContractError::AlreadyInitialized`].
+    ///
+    /// # Arguments
+    /// * `env` - Contract environment
+    /// * `admin` - Admin address (must be a user account, not a contract)
+    ///
+    /// # Returns
+    /// `Ok(())` on successful initialization
+    ///
+    /// # Errors
+    /// - [`ContractError::AlreadyInitialized`] – contract was previously initialized
+    /// - [`ContractError::InvalidAdmin`] – admin address is a contract or otherwise invalid
+    ///
+    /// # Security
+    /// - Requires authorization from the admin address
+    /// - Can only be called once per deployment
+    /// - Validates admin is a user account, not a contract
+    ///
+    /// # Example
+    /// ```ignore
+    /// client.initialize(&admin_address)?;
+    /// ```
     pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
+        // 1. Validate admin address before authorization to fail fast
+        validation::validate_admin_address(&admin)?;
+        
+        // 2. Require authorization from the admin
         admin.require_auth();
+        
+        // 3. Check if already initialized
         if storage::has_admin(&env) {
             return Err(ContractError::AlreadyInitialized);
         }
+        
+        // 4. Set admin and version
         storage::set_admin(&env, &admin);
         storage::set_version(&env);
+        
+        // 5. Emit initialization event
         events::emit_contract_initialized(&env, &admin);
+        
         Ok(())
     }
 
@@ -93,23 +125,40 @@ impl MarketContract {
     /// pending admin and must confirm the transfer by calling [`accept_admin`].
     /// Calling this again before acceptance overwrites the previous nomination.
     ///
+    /// # Arguments
+    /// * `env` - Contract environment
+    /// * `current_admin` - Current admin authorizing the transfer
+    /// * `new_admin` - Address to nominate as pending admin (must be a user account)
+    ///
     /// # Errors
     /// - [`ContractError::NotAdmin`] – contract is not initialized or `current_admin` is not the stored admin
+    /// - [`ContractError::InvalidAdmin`] – `new_admin` is a contract or otherwise invalid
     pub fn propose_admin(
         env: Env,
         current_admin: Address,
         new_admin: Address,
     ) -> Result<(), ContractError> {
+        // 1. Validate new admin address
+        validation::validate_admin_address(&new_admin)?;
+        
+        // 2. Check contract is initialized
         if !storage::has_admin(&env) {
             return Err(ContractError::NotAdmin);
         }
+        
+        // 3. Verify current admin
         let stored_admin = storage::get_admin(&env)?;
         if current_admin != stored_admin {
             return Err(ContractError::NotAdmin);
         }
+        
+        // 4. Require authorization
         current_admin.require_auth();
+        
+        // 5. Set pending admin and emit event
         storage::set_pending_admin(&env, &new_admin);
         events::emit_admin_transfer_proposed(&env, &current_admin, &new_admin);
+        
         Ok(())
     }
 

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -77,6 +77,110 @@ mod test {
     }
 
     // Rest of tests remain the same...
+    // ========== Initialize Function Tests ==========
+    
+    #[test]
+    fn test_initialize_with_valid_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let contract_id = env.register(MarketContract, ());
+        let client = MarketContractClient::new(&env, &contract_id);
+        
+        let admin = Address::generate(&env);
+        
+        // Initialize should succeed with a valid account address
+        let result = client.initialize(&admin);
+        assert!(result.is_ok());
+        
+        // Verify admin was set
+        let stored_admin = env.as_contract(&contract_id, || {
+            storage::get_admin(&env).expect("Admin should be set")
+        });
+        assert_eq!(stored_admin, admin);
+    }
+    
+    #[test]
+    #[should_panic(expected = "Error(Contract, #35)")]
+    fn test_initialize_with_contract_address_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let contract_id = env.register(MarketContract, ());
+        let client = MarketContractClient::new(&env, &contract_id);
+        
+        // Try to use another contract address as admin (should fail)
+        let other_contract = env.register(MarketContract, ());
+        
+        // This should fail with InvalidAdmin error (#35)
+        client.initialize(&other_contract);
+    }
+    
+    #[test]
+    #[should_panic(expected = "Error(Contract, #42)")]
+    fn test_initialize_twice_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let contract_id = env.register(MarketContract, ());
+        let client = MarketContractClient::new(&env, &contract_id);
+        
+        let admin = Address::generate(&env);
+        
+        // First initialization should succeed
+        client.initialize(&admin);
+        
+        // Second initialization should fail with AlreadyInitialized (#42)
+        let another_admin = Address::generate(&env);
+        client.initialize(&another_admin);
+    }
+    
+    #[test]
+    fn test_initialize_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let contract_id = env.register(MarketContract, ());
+        let client = MarketContractClient::new(&env, &contract_id);
+        
+        let admin = Address::generate(&env);
+        
+        client.initialize(&admin);
+        
+        // Verify event was emitted
+        let events = env.events().all();
+        assert!(events.len() > 0);
+        
+        // Check for contract_initialized_event
+        let event_found = events.iter().any(|e| {
+            e.topics.iter().any(|t| {
+                t.to_string().contains("contract_initialized")
+            })
+        });
+        assert!(event_found, "contract_initialized_event should be emitted");
+    }
+    
+    #[test]
+    fn test_initialize_sets_version() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let contract_id = env.register(MarketContract, ());
+        let client = MarketContractClient::new(&env, &contract_id);
+        
+        let admin = Address::generate(&env);
+        
+        client.initialize(&admin);
+        
+        // Verify storage version was set
+        env.as_contract(&contract_id, || {
+            let result = storage::assert_version(&env);
+            assert!(result.is_ok(), "Storage version should be set correctly");
+        });
+    }
+
+    // ========== Initialize Market Function Tests ==========
+    
     #[test]
     fn test_initialize_market_success() {
         let (env, admin, client, contract_id) = create_test_contract();
@@ -775,6 +879,18 @@ mod test {
 
         let events = env.events().all();
         assert!(events.len() > 0);
+    }
+    
+    #[test]
+    #[should_panic(expected = "Error(Contract, #35)")]
+    fn test_propose_admin_with_contract_address_fails() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        
+        // Try to propose a contract address as admin
+        let contract_admin = env.register(MarketContract, ());
+        
+        // This should fail with InvalidAdmin error (#35)
+        client.propose_admin(&admin, &contract_admin);
     }
 
     #[test]

--- a/contracts/market/src/validation.rs
+++ b/contracts/market/src/validation.rs
@@ -1,6 +1,41 @@
 use crate::error::ContractError;
 use crate::types::MarketStatus;
-use soroban_sdk::String;
+use soroban_sdk::{Address, String};
+
+/// Validates that an admin address is suitable for contract administration.
+///
+/// The admin address must be a valid user account. This function rejects:
+/// - Contract addresses (to prevent circular dependencies or governance attacks)
+///
+/// # Arguments
+/// * `admin` - Address to validate as admin
+///
+/// # Returns
+/// `Ok(())` if the address is valid for use as admin
+///
+/// # Errors
+/// - [`ContractError::InvalidAdmin`] – address is a contract or otherwise unsuitable
+///
+/// # Security Notes
+/// Contract addresses as admin could lead to:
+/// - Circular dependency issues
+/// - Complex governance attack vectors
+/// - Unintended behavior if contract is upgraded or self-destructs
+///
+/// # Example
+/// ```ignore
+/// validation::validate_admin_address(&admin)?;
+/// ```
+pub fn validate_admin_address(admin: &Address) -> Result<(), ContractError> {
+    // Reject contract addresses - admin should be an account
+    // In Soroban, this check ensures we're not setting a contract as admin
+    // which could lead to complex governance issues
+    if admin.to_string().starts_with("C") {
+        return Err(ContractError::InvalidAdmin);
+    }
+    
+    Ok(())
+}
 
 /// Guard function to validate input before processing.
 ///
@@ -455,6 +490,25 @@ mod tests {
         assert_eq!(
             validate_cancelable(&MarketStatus::Canceled),
             Err(ContractError::MarketNotActive)
+        );
+    }
+
+    #[test]
+    fn test_validate_admin_address_account_ok() {
+        let env = soroban_sdk::Env::default();
+        // Generate a user account address (starts with 'G')
+        let admin = Address::generate(&env);
+        assert!(validate_admin_address(&admin).is_ok());
+    }
+
+    #[test]
+    fn test_validate_admin_address_contract_fails() {
+        let env = soroban_sdk::Env::default();
+        // Register a contract to get a contract address (starts with 'C')
+        let contract_id = env.register(crate::MarketContract, ());
+        assert_eq!(
+            validate_admin_address(&contract_id),
+            Err(ContractError::InvalidAdmin)
         );
     }
 }


### PR DESCRIPTION
- Added InvalidAdmin error (code #35) for invalid admin addresses
- Added validate_admin_address() function to reject contract addresses as admin
- Updated initialize() to validate admin parameter before setting
- Updated propose_admin() to validate new admin parameter
- Enhanced documentation for admin validation and security implications
- Added 5 new tests for initialize function validation
- Added 1 test for propose_admin with invalid admin
- All validation follows existing patterns in validation.rs

Security improvements:
- Prevents contract addresses from being set as admin
- Avoids circular dependencies and governance attack vectors
- Validates admin addresses before authorization for fail-fast behavior

Tests added:
- test_initialize_with_valid_admin
- test_initialize_with_contract_address_fails
- test_initialize_twice_fails
- test_initialize_emits_event
- test_initialize_sets_version
- test_propose_admin_with_contract_address_fails
- test_validate_admin_address_account_ok (unit)
- test_validate_admin_address_contract_fails (unit)

closes #370 