### PR TITLE
feat: implement issues #344, #345, #346, #347

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ The Market Contract emits the following events for off-chain indexing and tracki
 | `market_resolved_event` | `market_id` | `resolver: BytesN<32>`, `outcome: bool`, `resolved_at: u64` | Emitted when a market is resolved with an oracle-signed outcome |
 | `position_settled_event` | `market_id`, `user` | `payout: i128`, `settled_at: u64` | Emitted when a user's position is settled and payout is transferred |
 | `oracle_signature_verified_event` | `market_id` | `outcome: bool`, `verified_at: u64` | Emitted when an oracle signature is verified during resolution |
-| `fee_calculated_event` | `market_id`, `user` | `fee_amount: i128`, `available_after_fee: i128` | Emitted when a fee is calculated during withdrawal |
+| `market_canceled_event` | `market_id` | `canceler: Address`, `canceled_at: u64` | Emitted when an admin cancels an active market |
+| `fee_calculated_event` | `market_id`, `user` | `fee_amount: i128`, `available_after_fee: i128` | Emitted when a non-zero fee is calculated during withdrawal |
 | `validation_failed_event` | `context` | `error_code: u32` | Emitted when validation fails, recording context and error code |
 
 ### Event Indexing

--- a/contracts/market/src/deposit.rs
+++ b/contracts/market/src/deposit.rs
@@ -461,6 +461,36 @@ mod tests {
         assert_eq!(new_total2, first + second);
     }
 
+    // --- #344: market expiry enforcement on deposit ---
+
+    #[test]
+    fn test_deposit_rejected_after_market_expiry() {
+        let env = setup_env();
+        let user = Address::generate(&env);
+        let market_id = 1;
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let collateral_token = token.address();
+        let contract_id = env.register(crate::MarketContract, ());
+
+        // Create market with end_time in the past
+        let mut market = create_test_market(&env, market_id, &collateral_token);
+        market.end_time = 0; // expired
+        env.as_contract(&contract_id, || {
+            storage::set_version(&env);
+            storage::set_market(&env, market_id, &market).unwrap();
+        });
+
+        env.mock_all_auths();
+        let sac = soroban_sdk::token::StellarAssetClient::new(&env, &collateral_token);
+        sac.mint(&user, &20_000);
+
+        let result = env.as_contract(&contract_id, || {
+            deposit_collateral(env.clone(), user.clone(), market_id, 5_000)
+        });
+        assert_eq!(result, Err(ContractError::MarketExpired));
+    }
+
     // --- #374: total_deposited accumulates correctly across multiple deposits ---
 
     #[test]

--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -1040,7 +1040,7 @@ mod tests {
 
         let market_id = 1u32;
         let user = Address::generate(&env);
-        let fee_amount = 0i128;
+        let fee_amount = 500i128; // non-zero fee per #345
         let available_after_fee = 5_000i128;
 
         env.as_contract(&contract_id, || {

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -76,7 +76,10 @@ pub fn withdraw_unused_collateral(
         .total_deposited
         .saturating_sub(position.locked_collateral);
 
-    emit_fee_calculated(&env, market_id, &user, fee_amount, available);
+    // Only emit the fee event when a non-zero fee is actually deducted (#345).
+    if fee_amount > 0 {
+        emit_fee_calculated(&env, market_id, &user, fee_amount, available);
+    }
 
     let total_required = amount
         .checked_add(fee_amount)


### PR DESCRIPTION
##Closes #344 
##Closes #345 
##Closes #346 
##Closes #347 

#344 - Market expiry enforcement on deposit: added unit test
#345 - FeeCalculated event with non-zero amounts: only emit when fee_amount > 0
#346 - MarketCanceled event emission: already implemented, verified
#347 - Canonical event catalog in README: added market_canceled_event entry