### PR TITLE
web: show tx hash and explorer link after submit

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -21,3 +21,6 @@ NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 
 # Horizon endpoint (for submitting signed transactions)
 NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+
+# Stellar Explorer base URL for transaction links (default: Stellar Expert testnet)
+NEXT_PUBLIC_EXPLORER_URL=https://stellar.expert/explorer/testnet/tx

--- a/apps/web/components/DepositForm.tsx
+++ b/apps/web/components/DepositForm.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useWallet } from "@/context/WalletContext";
 import { invokeContract, MARKET_CONTRACT_ID } from "@/lib/soroban";
 import { amountToScVal, addressToScVal, u32ToScVal } from "@/lib/contract-client";
-import { Address } from "@stellar/stellar-sdk";
+import { TxResult } from "@/components/TxResult";
 
 export function DepositForm() {
   const { address } = useWallet();
@@ -104,11 +104,7 @@ export function DepositForm() {
             {error}
           </p>
         )}
-        {txHash && (
-          <p className="text-sm text-green-600 dark:text-green-400">
-            Deposited! Tx: {txHash.slice(0, 8)}...{txHash.slice(-8)}
-          </p>
-        )}
+        {txHash && <TxResult hash={txHash} label="Deposit" />}
         <button
           type="submit"
           disabled={isLoading || !amount || !address}

--- a/apps/web/components/TxResult.tsx
+++ b/apps/web/components/TxResult.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+/**
+ * Displays a confirmed transaction hash with a link to the Stellar explorer.
+ *
+ * The explorer base URL defaults to Stellar Expert (testnet) and can be
+ * overridden via NEXT_PUBLIC_EXPLORER_URL.
+ */
+
+const EXPLORER_BASE =
+  process.env.NEXT_PUBLIC_EXPLORER_URL ??
+  "https://stellar.expert/explorer/testnet/tx";
+
+interface TxResultProps {
+  /** Full transaction hash returned by the Soroban RPC. */
+  hash: string;
+  /** Optional label shown before the link (defaults to "Transaction"). */
+  label?: string;
+}
+
+export function TxResult({ hash, label = "Transaction" }: TxResultProps) {
+  const explorerUrl = `${EXPLORER_BASE}/${hash}`;
+  const short = `${hash.slice(0, 8)}…${hash.slice(-8)}`;
+
+  return (
+    <p
+      role="status"
+      className="text-sm text-green-600 dark:text-green-400 break-all"
+    >
+      {label} confirmed:{" "}
+      <a
+        href={explorerUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline hover:text-green-500"
+        aria-label={`View transaction ${hash} on Stellar explorer`}
+      >
+        {short}
+      </a>
+    </p>
+  );
+}

--- a/apps/web/components/WithdrawForm.tsx
+++ b/apps/web/components/WithdrawForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useWallet } from "@/context/WalletContext";
 import { invokeContract, MARKET_CONTRACT_ID } from "@/lib/soroban";
 import { amountToScVal, addressToScVal, u32ToScVal } from "@/lib/contract-client";
+import { TxResult } from "@/components/TxResult";
 
 export function WithdrawForm() {
   const { address } = useWallet();
@@ -103,11 +104,7 @@ export function WithdrawForm() {
             {error}
           </p>
         )}
-        {txHash && (
-          <p className="text-sm text-green-600 dark:text-green-400">
-            Withdrawn! Tx: {txHash.slice(0, 8)}...{txHash.slice(-8)}
-          </p>
-        )}
+        {txHash && <TxResult hash={txHash} label="Withdrawal" />}
         <button
           type="submit"
           disabled={isLoading || !amount || !address}


### PR DESCRIPTION
Add TxResult component that renders a confirmed tx hash as a clickable link to Stellar Expert (or the URL configured via NEXT_PUBLIC_EXPLORER_URL).

- apps/web/components/TxResult.tsx: new component
  - Renders role=status paragraph with shortened hash
  - Links to ${EXPLORER_BASE}/${hash} (testnet by default)
  - Optional label prop (defaults to 'Transaction')
  - rel=noopener noreferrer, aria-label for accessibility

- DepositForm.tsx: replace inline hash text with <TxResult label='Deposit' />
- WithdrawForm.tsx: replace inline hash text with <TxResult label='Withdrawal' />
- .env.local.example: document NEXT_PUBLIC_EXPLORER_URL
closes #362 