### PR TITLE
web: add Freighter connect error handling

### DIFF
--- a/apps/web/components/Navbar.tsx
+++ b/apps/web/components/Navbar.tsx
@@ -11,7 +11,7 @@ import { WalletConnectButton } from "./WalletConnectButton";
  * When the user has no wallet connected, shows a friendly prompt to connect.
  */
 export function Navbar() {
-  const { address, isConnecting, connect, disconnect } = useWallet();
+  const { address, isConnecting, connectError, connect, disconnect } = useWallet();
 
   return (
     <header className="border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950">
@@ -31,6 +31,7 @@ export function Navbar() {
           <WalletConnectButton
             address={address}
             isConnecting={isConnecting}
+            connectError={connectError}
             onConnect={connect}
             onDisconnect={disconnect}
           />

--- a/apps/web/components/WalletConnectButton.tsx
+++ b/apps/web/components/WalletConnectButton.tsx
@@ -5,6 +5,7 @@
  * <WalletConnectButton
  *   address={address}
  *   isConnecting={isConnecting}
+ *   connectError={connectError}
  *   onConnect={connect}
  *   onDisconnect={disconnect}
  * />
@@ -17,6 +18,9 @@ export interface WalletConnectButtonProps {
   /** Whether a wallet connection is in progress. */
   isConnecting: boolean;
 
+  /** Error message from the last failed connect() attempt, or null. */
+  connectError?: string | null;
+
   /** Callback function to initiate wallet connection. */
   onConnect: () => void | Promise<void>;
 
@@ -26,12 +30,13 @@ export interface WalletConnectButtonProps {
 
 /**
  * A button component that displays wallet connection status and triggers
- * connect/disconnect actions. Shows "Connect wallet" when disconnected,
- * displays the truncated address when connected, or "Connecting…" during connection.
+ * connect/disconnect actions. Shows an inline error message below the button
+ * when a connection attempt fails (e.g., extension not installed, user rejected).
  */
 export function WalletConnectButton({
   address,
   isConnecting,
+  connectError,
   onConnect,
   onDisconnect,
 }: WalletConnectButtonProps) {
@@ -49,15 +54,25 @@ export function WalletConnectButton({
   }
 
   return (
-    <button
-      type="button"
-      disabled={isConnecting}
-      onClick={() => void onConnect()}
-      className="rounded-lg bg-indigo-600 px-3 py-1.5 text-white hover:bg-indigo-500 disabled:opacity-60"
-      aria-label={isConnecting ? "Connecting wallet" : "Connect wallet"}
-    >
-      {isConnecting ? "Connecting…" : "Connect wallet"}
-    </button>
+    <div className="flex flex-col items-start gap-1">
+      <button
+        type="button"
+        disabled={isConnecting}
+        onClick={() => void onConnect()}
+        className="rounded-lg bg-indigo-600 px-3 py-1.5 text-white hover:bg-indigo-500 disabled:opacity-60"
+        aria-label={isConnecting ? "Connecting wallet" : "Connect wallet"}
+      >
+        {isConnecting ? "Connecting…" : "Connect wallet"}
+      </button>
+      {connectError && (
+        <p
+          role="alert"
+          className="max-w-xs text-xs text-red-600 dark:text-red-400"
+        >
+          {connectError}
+        </p>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/context/WalletContext.tsx
+++ b/apps/web/context/WalletContext.tsx
@@ -12,6 +12,8 @@ import {
 export interface WalletState {
   address: string | null;
   isConnecting: boolean;
+  /** Non-null when the last connect() attempt produced an error. */
+  connectError: string | null;
   connect: () => Promise<void>;
   disconnect: () => void;
 }
@@ -21,32 +23,82 @@ const WalletContext = createContext<WalletState | null>(null);
 export function WalletProvider({ children }: { children: ReactNode }) {
   const [address, setAddress] = useState<string | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
 
   const connect = useCallback(async () => {
     setIsConnecting(true);
+    setConnectError(null);
     try {
       const { isConnected, getAddress } = await import("@stellar/freighter-api");
-      if (!(await isConnected())) {
+
+      let connectedResult: { isConnected: boolean; error?: unknown };
+      try {
+        connectedResult = await isConnected();
+      } catch {
+        // isConnected() throws when the extension is not installed
+        setConnectError("Freighter wallet extension is not installed. Install it from freighter.app.");
+        return;
+      }
+
+      if (connectedResult.error) {
+        setConnectError("Freighter is not installed. Install it from freighter.app.");
         setAddress(null);
         return;
       }
-      const result = await getAddress();
-      if (result.address) {
-        setAddress(result.address);
+
+      if (!connectedResult.isConnected) {
+        setConnectError("Freighter is not connected. Open the extension and unlock your wallet.");
+        setAddress(null);
+        return;
       }
-    } catch {
-      // Freighter not installed — stub address for local UI work
-      setAddress("GSTUB…VATIX00000000000000000000000000001");
+
+      let result: { address: string; error?: unknown };
+      try {
+        result = await getAddress();
+      } catch (err) {
+        // User rejected the connection request in the extension popup
+        const msg = err instanceof Error ? err.message : String(err);
+        if (/denied|rejected|cancel/i.test(msg)) {
+          setConnectError("Connection request was rejected. Approve it in the Freighter popup.");
+        } else {
+          setConnectError(`Failed to get wallet address: ${msg}`);
+        }
+        return;
+      }
+
+      if (result.error) {
+        const msg = String(result.error);
+        if (/denied|rejected|cancel/i.test(msg)) {
+          setConnectError("Connection request was rejected. Approve it in the Freighter popup.");
+        } else {
+          setConnectError(`Failed to get wallet address: ${msg}`);
+        }
+        return;
+      }
+
+      if (!result.address) {
+        setConnectError("No address returned from Freighter. Ensure your wallet is unlocked.");
+        return;
+      }
+
+      setAddress(result.address);
+    } catch (err) {
+      // Freighter API not available (extension absent or incompatible)
+      const msg = err instanceof Error ? err.message : String(err);
+      setConnectError(`Freighter unavailable: ${msg}`);
     } finally {
       setIsConnecting(false);
     }
   }, []);
 
-  const disconnect = useCallback(() => setAddress(null), []);
+  const disconnect = useCallback(() => {
+    setAddress(null);
+    setConnectError(null);
+  }, []);
 
   const value = useMemo(
-    () => ({ address, isConnecting, connect, disconnect }),
-    [address, isConnecting, connect, disconnect],
+    () => ({ address, isConnecting, connectError, connect, disconnect }),
+    [address, isConnecting, connectError, connect, disconnect],
   );
 
   return (


### PR DESCRIPTION
Distinguish three failure modes and surface a human-readable message:

1. Extension not installed – isConnected() throws or returns error field
2. Wallet locked / not connected – isConnected().isConnected is false
3. User rejected the popup – getAddress() rejects or returns error with 'denied|rejected|cancel' in the message

WalletContext (context/WalletContext.tsx):
- Add connectError: string | null to WalletState
- connect() sets connectError on each failure path, clears it on success
- disconnect() also clears connectError
- Use the correct Freighter API return shapes: isConnected() → { isConnected: boolean; error?: ... } getAddress()  → { address: string; error?: ... }

WalletConnectButton (components/WalletConnectButton.tsx):
- Accept optional connectError prop
- Render role=alert <p> below the button when connectError is set

Navbar (components/Navbar.tsx):
- Destructure connectError from useWallet()
- Pass it through to WalletConnectButton
closes #361 