### PR TITLE
feat(treasury): #383 authorized market registry

### DIFF
--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -3,44 +3,20 @@
 //! # Treasury Contract
 //!
 //! Collects and custodies protocol fees on behalf of the Vatix prediction
-//! market protocol. Only the registered **market contract** may deposit fees
-//! via [`TreasuryContract::collect_fee`]; the **admin** controls all other
-//! privileged operations (withdrawal, market contract rotation).
-//!
-//! ## Fee flow
-//!
-//! ```text
-//!  User withdrawal
-//!      │  fee_amount > 0
-//!      ▼
-//!  MarketContract
-//!      │  token.transfer(market → treasury, fee_amount)
-//!      │  treasury.collect_fee(market, token, market_id, fee_amount)
-//!      ▼
-//!  TreasuryContract  ← accumulates per-token balances
-//!      │  (admin only)
-//!      ▼
-//!  treasury.withdraw_fees(admin, token, to, amount)
-//! ```
+//! market protocol. Any address in the authorized market registry may deposit
+//! fees via [`TreasuryContract::collect_fee`]; the **admin** controls all
+//! other privileged operations (withdrawal, registry management).
 //!
 //! ## Authorization model
 //!
-//! | Operation             | Who may call              |
-//! |-----------------------|---------------------------|
-//! | `initialize`          | anyone (once)             |
-//! | `collect_fee`         | registered market contract|
-//! | `withdraw_fees`       | admin                     |
-//! | `set_market_contract` | admin                     |
-//! | Getters               | anyone                    |
-//!
-//! ## Storage layout
-//!
-//! | Key                       | Type      | Description                              |
-//! |---------------------------|-----------|------------------------------------------|
-//! | `Admin`                   | `Address` | Protocol admin                           |
-//! | `AuthorizedMarket`        | `Address` | Authorized fee-depositing contract       |
-//! | `TokenBalance(Address)`   | `i128`    | Current custodied balance (decreasable)  |
-//! | `CumulativeFees(Address)` | `i128`    | Historical total collected (monotone)    |
+//! | Operation              | Who may call                     |
+//! |------------------------|----------------------------------|
+//! | `initialize`           | anyone (once)                    |
+//! | `collect_fee`          | any registered market contract   |
+//! | `withdraw_fees`        | admin                            |
+//! | `add_market`           | admin                            |
+//! | `remove_market`        | admin                            |
+//! | Getters                | anyone                           |
 
 pub mod error;
 pub mod events;
@@ -50,7 +26,7 @@ mod test;
 
 pub use error::TreasuryError;
 
-use soroban_sdk::{contract, contractimpl, token, Address, Env};
+use soroban_sdk::{contract, contractimpl, token, Address, Env, Vec};
 
 #[contract]
 pub struct TreasuryContract;
@@ -59,11 +35,7 @@ pub struct TreasuryContract;
 impl TreasuryContract {
     // ── Lifecycle ──────────────────────────────────────────────────────────────
 
-    /// Bootstrap the treasury.
-    ///
-    /// Sets the admin and registers the market contract permitted to call
-    /// [`collect_fee`]. Must be called once after deployment; subsequent calls
-    /// return [`TreasuryError::AlreadyInitialized`].
+    /// Bootstrap the treasury with an initial market contract in the registry.
     pub fn initialize(
         env: Env,
         admin: Address,
@@ -74,21 +46,16 @@ impl TreasuryContract {
             return Err(TreasuryError::AlreadyInitialized);
         }
         storage::set_admin(&env, &admin);
-        storage::set_authorized_market(&env, &market_contract);
+        let mut markets = Vec::new(&env);
+        markets.push_back(market_contract.clone());
+        storage::set_authorized_markets(&env, &markets);
         events::emit_treasury_initialized(&env, &admin, &market_contract);
         Ok(())
     }
 
     // ── Fee collection ─────────────────────────────────────────────────────────
 
-    /// Record a protocol fee transferred from a market withdrawal.
-    ///
-    /// Only the registered market contract may call this. The market contract
-    /// must transfer `fee_amount` tokens to this contract's address *before*
-    /// (or atomically with) this call so that on-chain balances stay consistent.
-    ///
-    /// Updates both the current `TokenBalance` and the monotone `CumulativeFees`
-    /// counter for `token`.
+    /// Record a protocol fee transferred from any registered market contract.
     pub fn collect_fee(
         env: Env,
         caller: Address,
@@ -101,8 +68,7 @@ impl TreasuryContract {
         if !storage::has_admin(&env) {
             return Err(TreasuryError::NotInitialized);
         }
-        let market_contract = storage::get_authorized_market(&env);
-        if caller != market_contract {
+        if !storage::is_authorized_market(&env, &caller) {
             return Err(TreasuryError::CallerNotMarket);
         }
         if fee_amount <= 0 {
@@ -131,9 +97,6 @@ impl TreasuryContract {
     // ── Admin operations ───────────────────────────────────────────────────────
 
     /// Withdraw accumulated fees to a recipient address.
-    ///
-    /// Decrements the custodied `TokenBalance` but leaves `CumulativeFees`
-    /// untouched — the historical counter is monotone by design.
     pub fn withdraw_fees(
         env: Env,
         caller: Address,
@@ -169,13 +132,13 @@ impl TreasuryContract {
         Ok(())
     }
 
-    /// Rotate the registered market contract address (e.g. after an upgrade).
+    /// Add a market contract to the authorized registry (admin only).
     ///
-    /// Only the admin may call this.
-    pub fn set_market_contract(
+    /// No-ops if the market is already registered.
+    pub fn add_market(
         env: Env,
         caller: Address,
-        new_market_contract: Address,
+        market_contract: Address,
     ) -> Result<(), TreasuryError> {
         caller.require_auth();
 
@@ -187,39 +150,72 @@ impl TreasuryContract {
             return Err(TreasuryError::Unauthorized);
         }
 
-        let old = storage::get_authorized_market(&env);
-        storage::set_authorized_market(&env, &new_market_contract);
-        events::emit_market_contract_updated(&env, &old, &new_market_contract);
+        let mut markets = storage::get_authorized_markets(&env);
+        if !markets.contains(&market_contract) {
+            markets.push_back(market_contract.clone());
+            storage::set_authorized_markets(&env, &markets);
+            events::emit_market_contract_updated(&env, &market_contract, &market_contract);
+        }
+        Ok(())
+    }
+
+    /// Remove a market contract from the authorized registry (admin only).
+    ///
+    /// Returns [`TreasuryError::CallerNotMarket`] if the address is not registered.
+    pub fn remove_market(
+        env: Env,
+        caller: Address,
+        market_contract: Address,
+    ) -> Result<(), TreasuryError> {
+        caller.require_auth();
+
+        if !storage::has_admin(&env) {
+            return Err(TreasuryError::NotInitialized);
+        }
+        let admin = storage::get_admin(&env);
+        if caller != admin {
+            return Err(TreasuryError::Unauthorized);
+        }
+
+        let markets = storage::get_authorized_markets(&env);
+        if !markets.contains(&market_contract) {
+            return Err(TreasuryError::CallerNotMarket);
+        }
+        let updated: Vec<Address> = markets
+            .iter()
+            .filter(|m| m != market_contract)
+            .collect();
+        storage::set_authorized_markets(&env, &updated);
         Ok(())
     }
 
     // ── Getters ────────────────────────────────────────────────────────────────
 
-    /// Return the admin address. Panics if not initialized.
     pub fn admin(env: Env) -> Address {
         storage::get_admin(&env)
     }
 
-    /// Return the registered market contract address. Panics if not initialized.
-    pub fn market_contract(env: Env) -> Address {
-        storage::get_authorized_market(&env)
+    /// Return the list of all authorized market contracts.
+    pub fn list_markets(env: Env) -> Vec<Address> {
+        storage::get_authorized_markets(&env)
     }
 
-    /// Return the current custodied balance for `token` (decreases on withdrawal).
+    /// Return whether `market` is in the authorized registry.
+    pub fn is_authorized_market(env: Env, market: Address) -> bool {
+        storage::is_authorized_market(&env, &market)
+    }
+
+    /// Return the current custodied balance for `token`.
     pub fn token_balance(env: Env, token: Address) -> i128 {
         storage::get_token_balance(&env, &token)
     }
 
-    /// Return the per-token cumulative fees collected for `token` since deployment.
-    ///
-    /// This counter never decreases: admin withdrawals do not affect it.
+    /// Return the per-token cumulative fees collected for `token`.
     pub fn get_cumulative_fees(env: Env, token: Address) -> i128 {
         storage::get_cumulative_fees(&env, &token)
     }
 
-    /// Return the global cumulative fees collected across all tokens since deployment.
-    ///
-    /// Monotone: never decreases regardless of admin withdrawals.
+    /// Return the global cumulative fees collected across all tokens.
     pub fn total_collected(env: Env) -> i128 {
         storage::get_total_collected(&env)
     }

--- a/contracts/treasury/src/storage.rs
+++ b/contracts/treasury/src/storage.rs
@@ -1,6 +1,6 @@
 //! Persistent storage helpers for the Vatix Treasury contract.
 
-use soroban_sdk::{contracttype, Address, Env};
+use soroban_sdk::{contracttype, Address, Env, Vec};
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
@@ -8,8 +8,8 @@ use soroban_sdk::{contracttype, Address, Env};
 pub enum StorageKey {
     /// The address that can call `withdraw_fees` and other admin operations.
     Admin,
-    /// The single market contract address allowed to call `collect_fee`.
-    AuthorizedMarket,
+    /// The set of market contract addresses allowed to call `collect_fee`.
+    AuthorizedMarkets,
     /// Current custodied balance for a specific token (decreases on withdrawal).
     TokenBalance(Address),
     /// Monotonically increasing cumulative fees collected per token (never decreases).
@@ -35,19 +35,23 @@ pub fn set_admin(env: &Env, admin: &Address) {
     env.storage().instance().set(&StorageKey::Admin, admin);
 }
 
-// ── Authorized market ─────────────────────────────────────────────────────────
+// ── Authorized markets registry ───────────────────────────────────────────────
 
-pub fn get_authorized_market(env: &Env) -> Address {
+pub fn get_authorized_markets(env: &Env) -> Vec<Address> {
     env.storage()
         .instance()
-        .get(&StorageKey::AuthorizedMarket)
-        .expect("treasury not initialized")
+        .get(&StorageKey::AuthorizedMarkets)
+        .unwrap_or_else(|| Vec::new(env))
 }
 
-pub fn set_authorized_market(env: &Env, market: &Address) {
+pub fn set_authorized_markets(env: &Env, markets: &Vec<Address>) {
     env.storage()
         .instance()
-        .set(&StorageKey::AuthorizedMarket, market);
+        .set(&StorageKey::AuthorizedMarkets, markets);
+}
+
+pub fn is_authorized_market(env: &Env, market: &Address) -> bool {
+    get_authorized_markets(env).contains(market)
 }
 
 // ── Token balance (current, decreasable on withdrawal) ────────────────────────

--- a/contracts/treasury/src/test.rs
+++ b/contracts/treasury/src/test.rs
@@ -32,8 +32,6 @@ fn setup() -> Setup {
         .address();
 
     let treasury_id = env.register(TreasuryContract, ());
-    // SAFETY: client holds a borrow into env; env is owned by Setup and outlives
-    // the client for the duration of each test.
     let client: TreasuryContractClient<'static> =
         unsafe { core::mem::transmute(TreasuryContractClient::new(&env, &treasury_id)) };
 
@@ -42,7 +40,6 @@ fn setup() -> Setup {
     Setup { env, admin, market, token, treasury_id, client }
 }
 
-/// Fund the treasury with tokens directly (simulates prior fee transfer from market).
 fn fund_treasury(s: &Setup, amount: i128) {
     StellarAssetClient::new(&s.env, &s.token).mint(&s.treasury_id, &amount);
 }
@@ -53,9 +50,9 @@ fn fund_treasury(s: &Setup, amount: i128) {
 fn initialize_stores_admin_and_market() {
     let s = setup();
     assert_eq!(s.client.admin(), s.admin);
-    assert_eq!(s.client.market_contract(), s.market);
     assert_eq!(s.client.token_balance(&s.token), 0);
     assert_eq!(s.client.get_cumulative_fees(&s.token), 0);
+    assert!(s.client.is_authorized_market(&s.market));
 }
 
 #[test]
@@ -76,7 +73,6 @@ fn admin_panics_before_initialize() {
     env.mock_all_auths();
     let id = env.register(TreasuryContract, ());
     let client = TreasuryContractClient::new(&env, &id);
-    // Non-initialized treasury: admin() panics internally; try_admin errors.
     assert!(client.try_admin().is_err());
 }
 
@@ -97,21 +93,6 @@ fn collect_fee_accumulates_across_calls() {
     s.client.collect_fee(&s.market, &s.token, &2u32, &200_000i128);
     assert_eq!(s.client.token_balance(&s.token), 300_000);
     assert_eq!(s.client.get_cumulative_fees(&s.token), 300_000);
-}
-
-#[test]
-fn collect_fee_accumulates_across_tokens() {
-    let s = setup();
-    let token2 = {
-        let a = Address::generate(&s.env);
-        s.env.register_stellar_asset_contract_v2(a).address()
-    };
-    s.client.collect_fee(&s.market, &s.token, &1u32, &100_000i128);
-    s.client.collect_fee(&s.market, &token2, &1u32, &200_000i128);
-    assert_eq!(s.client.token_balance(&s.token), 100_000);
-    assert_eq!(s.client.token_balance(&token2), 200_000);
-    assert_eq!(s.client.get_cumulative_fees(&s.token), 100_000);
-    assert_eq!(s.client.get_cumulative_fees(&token2), 200_000);
 }
 
 #[test]
@@ -168,7 +149,6 @@ fn collect_fee_errors_when_not_initialized() {
 #[test]
 fn withdraw_fees_transfers_to_recipient() {
     let s = setup();
-    // Fund treasury and record accounting.
     fund_treasury(&s, 500_000);
     s.client.collect_fee(&s.market, &s.token, &1u32, &500_000i128);
 
@@ -177,16 +157,12 @@ fn withdraw_fees_transfers_to_recipient() {
 
     assert_eq!(TokenClient::new(&s.env, &s.token).balance(&recipient), 200_000);
     assert_eq!(s.client.token_balance(&s.token), 300_000);
-    // Cumulative is unchanged by withdrawal.
     assert_eq!(s.client.get_cumulative_fees(&s.token), 500_000);
 }
 
 #[test]
 fn withdraw_fees_rejects_non_admin() {
     let s = setup();
-    fund_treasury(&s, 500_000);
-    s.client.collect_fee(&s.market, &s.token, &1u32, &500_000i128);
-
     let imposter = Address::generate(&s.env);
     let recipient = Address::generate(&s.env);
     let err = s
@@ -195,17 +171,6 @@ fn withdraw_fees_rejects_non_admin() {
         .unwrap_err()
         .unwrap();
     assert_eq!(err, TreasuryError::Unauthorized);
-}
-
-#[test]
-fn withdraw_fees_rejects_zero_amount() {
-    let s = setup();
-    let err = s
-        .client
-        .try_withdraw_fees(&s.admin, &s.token, &s.admin, &0i128)
-        .unwrap_err()
-        .unwrap();
-    assert_eq!(err, TreasuryError::InvalidAmount);
 }
 
 #[test]
@@ -220,23 +185,6 @@ fn withdraw_fees_rejects_insufficient_balance() {
 }
 
 #[test]
-fn withdraw_fees_errors_when_not_initialized() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let id = env.register(TreasuryContract, ());
-    let client = TreasuryContractClient::new(&env, &id);
-    let admin = Address::generate(&env);
-    let token = Address::generate(&env);
-    let err = client
-        .try_withdraw_fees(&admin, &token, &admin, &1_000i128)
-        .unwrap_err()
-        .unwrap();
-    assert_eq!(err, TreasuryError::NotInitialized);
-}
-
-// ── cumulative stays monotone ─────────────────────────────────────────────────
-
-#[test]
 fn cumulative_stays_high_after_withdrawal() {
     let s = setup();
     fund_treasury(&s, 300_000);
@@ -249,42 +197,86 @@ fn cumulative_stays_high_after_withdrawal() {
     assert_eq!(s.client.get_cumulative_fees(&s.token), 300_000);
 }
 
-// ── set_market_contract ───────────────────────────────────────────────────────
+// ── #383: multi-market registry ───────────────────────────────────────────────
 
 #[test]
-fn set_market_contract_updates_address() {
+fn add_market_registers_second_market() {
     let s = setup();
-    let new_market = Address::generate(&s.env);
-    s.client.set_market_contract(&s.admin, &new_market);
-    assert_eq!(s.client.market_contract(), new_market);
+    let market2 = Address::generate(&s.env);
+    s.client.add_market(&s.admin, &market2);
+
+    assert!(s.client.is_authorized_market(&s.market));
+    assert!(s.client.is_authorized_market(&market2));
+    assert_eq!(s.client.list_markets().len(), 2);
 }
 
 #[test]
-fn set_market_contract_rejects_non_admin() {
+fn add_market_is_idempotent() {
+    let s = setup();
+    s.client.add_market(&s.admin, &s.market);
+    assert_eq!(s.client.list_markets().len(), 1);
+}
+
+#[test]
+fn add_market_rejects_non_admin() {
     let s = setup();
     let rando = Address::generate(&s.env);
-    let new_market = Address::generate(&s.env);
+    let market2 = Address::generate(&s.env);
     let err = s
         .client
-        .try_set_market_contract(&rando, &new_market)
+        .try_add_market(&rando, &market2)
         .unwrap_err()
         .unwrap();
     assert_eq!(err, TreasuryError::Unauthorized);
 }
 
 #[test]
-fn old_market_cannot_collect_fee_after_rotation() {
+fn remove_market_deregisters_market() {
     let s = setup();
-    let new_market = Address::generate(&s.env);
-    s.client.set_market_contract(&s.admin, &new_market);
+    let market2 = Address::generate(&s.env);
+    s.client.add_market(&s.admin, &market2);
+    s.client.remove_market(&s.admin, &market2);
 
+    assert!(!s.client.is_authorized_market(&market2));
+    assert_eq!(s.client.list_markets().len(), 1);
+}
+
+#[test]
+fn remove_market_errors_if_not_registered() {
+    let s = setup();
+    let unknown = Address::generate(&s.env);
     let err = s
         .client
-        .try_collect_fee(&s.market, &s.token, &1u32, &100i128)
+        .try_remove_market(&s.admin, &unknown)
         .unwrap_err()
         .unwrap();
     assert_eq!(err, TreasuryError::CallerNotMarket);
+}
 
-    s.client.collect_fee(&new_market, &s.token, &1u32, &100i128);
-    assert_eq!(s.client.get_cumulative_fees(&s.token), 100);
+#[test]
+fn removed_market_cannot_collect_fee() {
+    let s = setup();
+    let market2 = Address::generate(&s.env);
+    s.client.add_market(&s.admin, &market2);
+    s.client.remove_market(&s.admin, &market2);
+
+    let err = s
+        .client
+        .try_collect_fee(&market2, &s.token, &1u32, &100i128)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, TreasuryError::CallerNotMarket);
+}
+
+#[test]
+fn multiple_markets_can_each_collect_fees() {
+    let s = setup();
+    let market2 = Address::generate(&s.env);
+    s.client.add_market(&s.admin, &market2);
+
+    s.client.collect_fee(&s.market, &s.token, &1u32, &100i128);
+    s.client.collect_fee(&market2, &s.token, &2u32, &200i128);
+
+    assert_eq!(s.client.token_balance(&s.token), 300);
+    assert_eq!(s.client.get_cumulative_fees(&s.token), 300);
 }


### PR DESCRIPTION
- Replace single AuthorizedMarket key with AuthorizedMarkets Vec<Address>
- initialize() seeds registry with the first market contract
- Add add_market(admin, market): idempotent registry append
- Add remove_market(admin, market): deregister, errors if not found
- Add list_markets() and is_authorized_market() getters
- collect_fee() now accepts any registered market (multi-market support)
- Remove set_market_contract() (replaced by add/remove_market)
- Tests: add/remove, idempotent add, non-admin rejected, removed market cannot collect fees, multiple markets each collect fees

closes #383 