### PR TITLE
ci: fix and verify TypeScript bindings generation in frontend job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,12 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown,wasm32v1-none
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> target
 
       - name: Install Stellar CLI
         run: |
@@ -196,6 +201,12 @@ jobs:
 
       - name: Generate TypeScript bindings
         run: pnpm build:bindings
+
+      - name: Verify bindings output
+        run: |
+          test -f apps/web/lib/contracts/index.ts || (echo "ERROR: contracts/index.ts missing" && exit 1)
+          echo "Bindings output:"
+          ls -lh apps/web/lib/contracts/
 
       - name: Lint web app
         run: pnpm --filter web lint


### PR DESCRIPTION
The frontend CI job was missing the wasm32v1-none Rust target, which is what stellar contract build actually outputs to (target/wasm32v1-none/release/). Without it, pnpm build:bindings would fail when trying to build contracts.

- Add wasm32v1-none to Setup Rust targets (alongside wasm32-unknown-unknown)
- Add Rust dependency cache (Swatinem/rust-cache) to speed up contract builds
- Add 'Verify bindings output' step that asserts contracts/index.ts exists and lists generated files, catching silent generation failures early
closes #360