### PR TITLE
feat(outcome-token): #382 scaffold SAC metadata

### DIFF
--- a/contracts/outcome-token/src/lib.rs
+++ b/contracts/outcome-token/src/lib.rs
@@ -10,22 +10,23 @@ mod test;
 
 use crate::error::ContractError;
 use crate::types::{OutcomeTokenConfig, TokenKind};
-use soroban_sdk::{contract, contractimpl, Address, Env};
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
 
 #[contract]
 pub struct OutcomeTokenContract;
 
 #[contractimpl]
 impl OutcomeTokenContract {
-    /// Bootstrap the contract by registering the admin and the sole market
-    /// contract allowed to call `mint` and `burn`.
+    /// Bootstrap the contract.
     ///
-    /// Must be called once immediately after deployment. Returns
-    /// [`ContractError::AlreadyInitialized`] on subsequent calls.
+    /// `name` and `symbol` are SAC-compatible metadata stored on-chain.
+    /// `decimals` is a compile-time constant (7) and is not stored.
     pub fn initialize(
         env: Env,
         admin: Address,
         market_contract: Address,
+        name: String,
+        symbol: String,
     ) -> Result<(), ContractError> {
         admin.require_auth();
         if storage::has_config(&env) {
@@ -36,6 +37,8 @@ impl OutcomeTokenContract {
             &OutcomeTokenConfig {
                 admin,
                 market_contract,
+                name,
+                symbol,
             },
         );
         Ok(())
@@ -46,8 +49,6 @@ impl OutcomeTokenContract {
     }
 
     /// Update the market contract address allowed to mint/burn tokens.
-    ///
-    /// Only the stored admin may call this.
     pub fn set_market_contract(
         env: Env,
         admin: Address,
@@ -61,6 +62,39 @@ impl OutcomeTokenContract {
         config.market_contract = market_contract;
         storage::set_config(&env, &config);
         Ok(())
+    }
+
+    /// Update the SAC metadata (name and symbol). Admin only.
+    pub fn set_metadata(
+        env: Env,
+        admin: Address,
+        name: String,
+        symbol: String,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        let mut config = storage::get_config(&env);
+        if admin != config.admin {
+            return Err(ContractError::Unauthorized);
+        }
+        config.name = name;
+        config.symbol = symbol;
+        storage::set_config(&env, &config);
+        Ok(())
+    }
+
+    // ── SAC metadata getters ──────────────────────────────────────────────────
+
+    pub fn name(env: Env) -> String {
+        storage::get_config(&env).name
+    }
+
+    pub fn symbol(env: Env) -> String {
+        storage::get_config(&env).symbol
+    }
+
+    /// Number of decimal places (SAC standard: 7).
+    pub fn decimals(_env: Env) -> u32 {
+        7
     }
 
     /// Mint `amount` tokens of `kind` (Yes or No) for `user` in `market_id`.
@@ -132,13 +166,5 @@ impl OutcomeTokenContract {
     /// Return the total outstanding supply for a `(market_id, kind)` pair.
     pub fn total_supply(env: Env, market_id: u32, kind: TokenKind) -> i128 {
         storage::get_total_supply(&env, market_id, &kind)
-    }
-
-    /// Return the number of decimal places used by this token.
-    ///
-    /// Aligned with the Stellar Asset Contract (SAC) standard: 7 decimals,
-    /// meaning 1 token = 10_000_000 stroops.
-    pub fn decimals(_env: Env) -> u32 {
-        7
     }
 }

--- a/contracts/outcome-token/src/test.rs
+++ b/contracts/outcome-token/src/test.rs
@@ -1,6 +1,6 @@
 use crate::types::TokenKind;
 use crate::{ContractError, OutcomeTokenContract, OutcomeTokenContractClient};
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
 fn setup(env: &Env) -> (OutcomeTokenContractClient<'_>, Address, Address) {
     env.mock_all_auths();
@@ -8,7 +8,9 @@ fn setup(env: &Env) -> (OutcomeTokenContractClient<'_>, Address, Address) {
     let client = OutcomeTokenContractClient::new(env, &contract_id);
     let admin = Address::generate(env);
     let market_contract = Address::generate(env);
-    client.initialize(&admin, &market_contract);
+    let name = String::from_str(env, "Vatix YES Token");
+    let symbol = String::from_str(env, "vYES");
+    client.initialize(&admin, &market_contract, &name, &symbol);
     (client, admin, market_contract)
 }
 
@@ -21,15 +23,60 @@ fn initialize_stores_config() {
     let config = client.get_config();
     assert_eq!(config.admin, admin);
     assert_eq!(config.market_contract, market_contract);
+    assert_eq!(config.name, String::from_str(&env, "Vatix YES Token"));
+    assert_eq!(config.symbol, String::from_str(&env, "vYES"));
 }
 
 #[test]
 fn initialize_twice_is_rejected() {
     let env = Env::default();
     let (client, admin, market_contract) = setup(&env);
+    let name = String::from_str(&env, "X");
+    let symbol = String::from_str(&env, "X");
     assert_eq!(
-        client.try_initialize(&admin, &market_contract),
+        client.try_initialize(&admin, &market_contract, &name, &symbol),
         Err(Ok(ContractError::AlreadyInitialized))
+    );
+}
+
+// ── SAC metadata (#382) ──────────────────────────────────────────────────────
+
+#[test]
+fn name_and_symbol_getters_return_stored_values() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    assert_eq!(client.name(), String::from_str(&env, "Vatix YES Token"));
+    assert_eq!(client.symbol(), String::from_str(&env, "vYES"));
+}
+
+#[test]
+fn decimals_returns_seven() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    assert_eq!(client.decimals(), 7u32);
+}
+
+#[test]
+fn admin_can_update_metadata() {
+    let env = Env::default();
+    let (client, admin, _) = setup(&env);
+    let new_name = String::from_str(&env, "Vatix NO Token");
+    let new_symbol = String::from_str(&env, "vNO");
+    client.set_metadata(&admin, &new_name, &new_symbol);
+    assert_eq!(client.name(), new_name);
+    assert_eq!(client.symbol(), new_symbol);
+}
+
+#[test]
+fn non_admin_cannot_update_metadata() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    let stranger = Address::generate(&env);
+    let n = String::from_str(&env, "Bad");
+    let s = String::from_str(&env, "BAD");
+    assert_eq!(
+        client.try_set_metadata(&stranger, &n, &s),
+        Err(Ok(ContractError::Unauthorized))
     );
 }
 
@@ -178,14 +225,4 @@ fn non_admin_cannot_update_market_contract() {
         client.try_set_market_contract(&stranger, &new_market),
         Err(Ok(ContractError::Unauthorized))
     );
-}
-
-// ── decimals ────────────────────────────────────────────────────────────────
-
-/// #405: decimals() returns 7 to match the Stellar Asset Contract (SAC) standard.
-#[test]
-fn decimals_returns_seven() {
-    let env = Env::default();
-    let (client, _, _) = setup(&env);
-    assert_eq!(client.decimals(), 7u32);
 }

--- a/contracts/outcome-token/src/types.rs
+++ b/contracts/outcome-token/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address};
+use soroban_sdk::{contracttype, Address, String};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -13,4 +13,8 @@ pub struct OutcomeTokenConfig {
     pub admin: Address,
     /// Only this address may call mint and burn.
     pub market_contract: Address,
+    /// Human-readable token name (SAC metadata).
+    pub name: String,
+    /// Ticker symbol (SAC metadata).
+    pub symbol: String,
 }


### PR DESCRIPTION
- Add name and symbol fields to OutcomeTokenConfig
- initialize() now accepts name and symbol parameters
- Add name(), symbol() getters (SAC interface)
- decimals() returns 7 (SAC standard, already existed)
- Add set_metadata(admin, name, symbol) setter
- Tests: getters return stored values, admin can update, non-admin rejected, decimals returns 7, double-init rejected

closes #382 