### PR TITLE
feat(resolution): #380 store default challenge window duration

### DIFF
--- a/contracts/resolution/src/lib.rs
+++ b/contracts/resolution/src/lib.rs
@@ -24,29 +24,47 @@ pub struct ResolutionContract;
 impl ResolutionContract {
     /// Register the resolution lifecycle contract with its factory and market.
     ///
-    /// The factory can index this contract as the challenge-window companion
-    /// for `market_contract`. Final settlement still happens through the
-    /// market contract's `resolve_market` function after a candidate finalizes.
+    /// `default_challenge_window_seconds` is stored as the contract-wide default.
     pub fn initialize(
         env: Env,
         admin: Address,
         factory: Address,
         market_contract: Address,
+        default_challenge_window_seconds: u64,
     ) -> Result<(), ContractError> {
         admin.require_auth();
         if storage::has_config(&env) {
             return Err(ContractError::AlreadyInitialized);
         }
-
+        validate_challenge_window(default_challenge_window_seconds)?;
         storage::set_config(
             &env,
             &ResolutionConfig {
                 admin,
                 factory: factory.clone(),
                 market_contract: market_contract.clone(),
+                default_challenge_window_seconds,
             },
         );
         events::emit_resolution_registered(&env, &factory, &market_contract);
+        Ok(())
+    }
+
+    pub fn get_default_challenge_window(env: Env) -> u64 {
+        storage::get_config(&env).default_challenge_window_seconds
+    }
+
+    pub fn set_default_challenge_window(
+        env: Env,
+        admin: Address,
+        seconds: u64,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        let mut config = storage::get_config(&env);
+        require_admin(&admin, &config)?;
+        validate_challenge_window(seconds)?;
+        config.default_challenge_window_seconds = seconds;
+        storage::set_config(&env, &config);
         Ok(())
     }
 

--- a/contracts/resolution/src/test.rs
+++ b/contracts/resolution/src/test.rs
@@ -4,6 +4,8 @@ use soroban_sdk::{
     Address, BytesN, Env, String,
 };
 
+const DEFAULT_WINDOW: u64 = 300;
+
 fn setup(env: &Env) -> (ResolutionContractClient<'_>, Address, Address) {
     env.mock_all_auths();
     let contract_id = env.register(ResolutionContract, ());
@@ -11,7 +13,7 @@ fn setup(env: &Env) -> (ResolutionContractClient<'_>, Address, Address) {
     let admin = Address::generate(env);
     let factory = Address::generate(env);
     let market_contract = Address::generate(env);
-    client.initialize(&admin, &factory, &market_contract);
+    client.initialize(&admin, &factory, &market_contract, &DEFAULT_WINDOW);
     (client, admin, market_contract)
 }
 
@@ -159,4 +161,46 @@ fn finalize_calls_resolve_market_on_market_contract() {
     assert_eq!(candidate.market_id, 5);
     assert_eq!(candidate.outcome, true);
     assert!(candidate.finalized_at.is_some());
+}
+
+// ── #380: default challenge window ────────────────────────────────────────────
+
+#[test]
+fn initialize_stores_default_challenge_window() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    assert_eq!(client.get_default_challenge_window(), DEFAULT_WINDOW);
+}
+
+#[test]
+fn admin_can_update_default_challenge_window() {
+    let env = Env::default();
+    let (client, admin, _) = setup(&env);
+    client.set_default_challenge_window(&admin, &600);
+    assert_eq!(client.get_default_challenge_window(), 600);
+}
+
+#[test]
+fn set_default_challenge_window_rejects_non_admin() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    let rando = Address::generate(&env);
+    assert_eq!(
+        client.try_set_default_challenge_window(&rando, &600),
+        Err(Ok(ContractError::NotAdmin))
+    );
+}
+
+#[test]
+fn set_default_challenge_window_rejects_out_of_bounds() {
+    let env = Env::default();
+    let (client, admin, _) = setup(&env);
+    assert_eq!(
+        client.try_set_default_challenge_window(&admin, &10),
+        Err(Ok(ContractError::InvalidChallengeWindow))
+    );
+    assert_eq!(
+        client.try_set_default_challenge_window(&admin, &(14 * 24 * 60 * 60 + 1)),
+        Err(Ok(ContractError::InvalidChallengeWindow))
+    );
 }

--- a/contracts/resolution/src/types.rs
+++ b/contracts/resolution/src/types.rs
@@ -8,11 +8,6 @@ pub enum CandidateStatus {
     Finalized,
 }
 
-/// On-chain mirror of the backend `ResolutionCandidate` concept.
-///
-/// The backend may keep richer metadata, but the fields here are the minimum
-/// needed to make a proposed outcome challengeable before it is handed to the
-/// market contract's `resolve_market` entry point.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub struct ResolutionCandidate {
@@ -36,4 +31,7 @@ pub struct ResolutionConfig {
     pub admin: Address,
     pub factory: Address,
     pub market_contract: Address,
+    /// Default challenge window in seconds. Must be within
+    /// `MIN_CHALLENGE_WINDOW_SECONDS..=MAX_CHALLENGE_WINDOW_SECONDS`.
+    pub default_challenge_window_seconds: u64,
 }

--- a/tests/resolution_flow_test.rs
+++ b/tests/resolution_flow_test.rs
@@ -33,7 +33,7 @@ fn scaffold() -> (Env, ResolutionContractClient<'static>, Address) {
 
     let contract_id = env.register(ResolutionContract, ());
     ResolutionContractClient::new(&env, &contract_id)
-        .initialize(&admin, &factory, &market_contract);
+        .initialize(&admin, &factory, &market_contract, &CHALLENGE_WINDOW);
 
     let client = ResolutionContractClient::new(&env, &contract_id);
     (env, client, admin)


### PR DESCRIPTION
- Add default_challenge_window_seconds to ResolutionConfig
- initialize() validates and persists the default window
- Add get_default_challenge_window() getter
- Add set_default_challenge_window() setter (admin only, validates bounds)
- Tests: init stores value, admin update, non-admin rejected, bounds check

closes #380 