### PR TITLE
feat: min deposit constant, withdraw cooldown, and admin renounce two-step safety

### DIFF
--- a/contracts/market/src/deposit.rs
+++ b/contracts/market/src/deposit.rs
@@ -53,7 +53,7 @@ pub fn deposit_collateral(
     user.require_auth();
 
     // Validation
-    validation::validate_collateral_amount(amount)?;
+    validation::validate_deposit_amount(amount)?;
 
     let market = storage::get_market(&env, market_id)?.ok_or(ContractError::MarketNotFound)?;
 
@@ -106,6 +106,9 @@ pub fn deposit_collateral(
 
     // Persist updated position
     storage::set_position(&env, market_id, &user, &position)?;
+
+    // Record deposit timestamp for cooldown enforcement on withdrawals (issue #413).
+    storage::set_last_deposit_time(&env, market_id, &user, env.ledger().timestamp());
 
     // TODO(#issue): consider batching deposit events for gas efficiency
     // Emit event

--- a/contracts/market/src/error.rs
+++ b/contracts/market/src/error.rs
@@ -52,6 +52,9 @@ pub enum ContractError {
     /// Only Active markets accept new trades and collateral deposits.
     MarketNotActive = 5,
 
+    /// Withdraw attempted before the cooldown period since the last deposit has elapsed.
+    WithdrawCooldownActive = 6,
+
     // ========== Position Errors (10-19) ==========
     /// User does not have enough collateral locked to perform this operation.
     ///
@@ -123,6 +126,9 @@ pub enum ContractError {
     /// or overwrite a market with an outcome_count other than 2 is rejected.
     InvalidOutcomeCount = 34,
 
+    /// Deposit amount is below the protocol minimum (MIN_DEPOSIT_AMOUNT stroops).
+    BelowMinDeposit = 35,
+
     // ========== Authorization Errors (40-49) ==========
     /// Caller is not authorized to perform this action.
     ///
@@ -145,6 +151,12 @@ pub enum ContractError {
     /// `accept_admin` was called but `propose_admin` has not been issued yet,
     /// or the previous proposal was already accepted.
     NoPendingAdmin = 43,
+
+    /// `confirm_renounce_admin` was called but no renounce proposal is pending.
+    NoRenounceProposal = 44,
+
+    /// A renounce proposal is already pending; cannot propose again until confirmed or canceled.
+    RenounceAlreadyProposed = 45,
 
     // ========== Token Errors (50-59) ==========
     /// Token transfer failed (insufficient balance, approval, etc.).

--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -612,6 +612,38 @@ pub fn emit_treasury_set(env: &Env, treasury: &Address) {
     .publish(env);
 }
 
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct AdminRenounceProposedEvent {
+    #[topic]
+    pub admin: Address,
+    pub proposed_at: u64,
+}
+
+pub fn emit_admin_renounce_proposed(env: &Env, admin: &Address) {
+    AdminRenounceProposedEvent {
+        admin: admin.clone(),
+        proposed_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct AdminRenouncedEvent {
+    #[topic]
+    pub former_admin: Address,
+    pub renounced_at: u64,
+}
+
+pub fn emit_admin_renounced(env: &Env, admin: &Address) {
+    AdminRenouncedEvent {
+        former_admin: admin.clone(),
+        renounced_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -780,6 +780,53 @@ impl MarketContract {
         storage::get_treasury(&env)
     }
 
+    /// Begin a two-step admin renounce by recording a pending renounce proposal.
+    ///
+    /// Only the current admin may call this. A second call to
+    /// [`confirm_renounce_admin`] is required to complete the renounce.
+    /// This two-step flow prevents accidental loss of admin rights.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] — `admin` is not the stored admin.
+    /// - [`ContractError::RenounceAlreadyProposed`] — a proposal is already pending.
+    pub fn propose_renounce_admin(env: Env, admin: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        if storage::has_pending_renounce(&env) {
+            return Err(ContractError::RenounceAlreadyProposed);
+        }
+        storage::set_pending_renounce(&env);
+        events::emit_admin_renounce_proposed(&env, &admin);
+        Ok(())
+    }
+
+    /// Complete a pending admin renounce, permanently removing the admin role.
+    ///
+    /// Must be called by the same admin that issued the proposal via
+    /// [`propose_renounce_admin`]. On success the admin storage key is cleared
+    /// and no further admin-protected calls can succeed.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] — `admin` is not the stored admin.
+    /// - [`ContractError::NoRenounceProposal`] — no pending renounce proposal exists.
+    pub fn confirm_renounce_admin(env: Env, admin: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        if !storage::has_pending_renounce(&env) {
+            return Err(ContractError::NoRenounceProposal);
+        }
+        storage::clear_admin(&env);
+        storage::clear_pending_renounce(&env);
+        events::emit_admin_renounced(&env, &admin);
+        Ok(())
+    }
+
     /// Return a read-only view of a market by its ID.
     ///
     /// # Errors

--- a/contracts/market/src/storage.rs
+++ b/contracts/market/src/storage.rs
@@ -37,6 +37,10 @@ pub enum StorageKey {
     ThresholdSigners,
     /// Minimum number of valid signatures required to resolve a market (#378).
     ThresholdQuorum,
+    /// Ledger timestamp of a user's most recent deposit into a market (issue #413).
+    LastDepositTime(u32, Address),
+    /// Flag indicating a pending admin renounce proposal (issue #414).
+    PendingRenounce,
 }
 
 // --- Version helpers ---
@@ -197,6 +201,40 @@ pub fn get_resolution_contract(env: &Env) -> Option<Address> {
 
 pub fn set_resolution_contract(env: &Env, contract: &Address) {
     env.storage().persistent().set(&StorageKey::ResolutionContract, contract);
+}
+
+// --- Deposit Timestamp Storage (issue #413) ---
+
+pub fn get_last_deposit_time(env: &Env, market_id: u32, user: &Address) -> Option<u64> {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::LastDepositTime(market_id, user.clone()))
+}
+
+pub fn set_last_deposit_time(env: &Env, market_id: u32, user: &Address, timestamp: u64) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::LastDepositTime(market_id, user.clone()), &timestamp);
+}
+
+// --- Pending Renounce Storage (issue #414) ---
+
+pub fn has_pending_renounce(env: &Env) -> bool {
+    env.storage().persistent().has(&StorageKey::PendingRenounce)
+}
+
+pub fn set_pending_renounce(env: &Env) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::PendingRenounce, &true);
+}
+
+pub fn clear_pending_renounce(env: &Env) {
+    env.storage().persistent().remove(&StorageKey::PendingRenounce);
+}
+
+pub fn clear_admin(env: &Env) {
+    env.storage().persistent().remove(&StorageKey::Admin);
 }
 
 // --- Fee Config Storage ---

--- a/contracts/market/src/validation.rs
+++ b/contracts/market/src/validation.rs
@@ -2,6 +2,9 @@ use crate::error::ContractError;
 use crate::types::MarketStatus;
 use soroban_sdk::String;
 
+/// Minimum collateral deposit in stroops (1 USDC = 10_000_000 stroops).
+pub const MIN_DEPOSIT_AMOUNT: i128 = 10_000_000;
+
 /// Guard function to validate input before processing.
 ///
 /// This is a general-purpose validation guard that can be used in integration tests
@@ -75,10 +78,19 @@ fn validate_amount_reasonable(amount: i128) -> Result<(), ContractError> {
     Ok(())
 }
 
-/// Validates collateral amount
+/// Validates collateral amount (used for withdrawals — no minimum enforced).
 pub fn validate_collateral_amount(amount: i128) -> Result<(), ContractError> {
     validate_amount_positive(amount)?;
     validate_amount_reasonable(amount)?;
+    Ok(())
+}
+
+/// Validates a deposit amount, enforcing the protocol minimum of MIN_DEPOSIT_AMOUNT.
+pub fn validate_deposit_amount(amount: i128) -> Result<(), ContractError> {
+    validate_collateral_amount(amount)?;
+    if amount < MIN_DEPOSIT_AMOUNT {
+        return Err(ContractError::BelowMinDeposit);
+    }
     Ok(())
 }
 

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -21,6 +21,9 @@ use crate::validation;
 use soroban_sdk::token::Client as TokenClient;
 use soroban_sdk::{Address, Env, IntoVal, Symbol, Val, Vec};
 
+/// Seconds a user must wait after their last deposit before withdrawing (issue #413).
+const WITHDRAW_COOLDOWN_SECONDS: u64 = 3_600;
+
 /// Withdraw `amount` of unused (unlocked) collateral from a market.
 ///
 /// # Locked-collateral enforcement (#376)
@@ -51,7 +54,15 @@ pub fn withdraw_unused_collateral(
         return Err(ContractError::MarketNotActive);
     }
 
-    // 3. Load position; an absent or zero-deposited position cannot be withdrawn.
+    // 3. Enforce cooldown: user must wait WITHDRAW_COOLDOWN_SECONDS after their last deposit.
+    if let Some(last_deposit_time) = storage::get_last_deposit_time(&env, market_id, &user) {
+        let elapsed = env.ledger().timestamp().saturating_sub(last_deposit_time);
+        if elapsed < WITHDRAW_COOLDOWN_SECONDS {
+            return Err(ContractError::WithdrawCooldownActive);
+        }
+    }
+
+    // 4. Load position; an absent or zero-deposited position cannot be withdrawn.
     let mut position = storage::get_position(&env, market_id, &user)?
         .unwrap_or_else(|| Position::new_empty(market_id, user.clone()));
 
@@ -60,7 +71,7 @@ pub fn withdraw_unused_collateral(
         return Err(ContractError::InsufficientCollateral);
     }
 
-    // 4. Compute the fee (single path, no duplication).
+    // 5. Compute the fee (single path, no duplication).
     let fee_rate_bps = storage::get_fee_rate_bps(&env);
     validation::validate_fee_rate_bps(fee_rate_bps)?;
     let fee_amount = if fee_rate_bps > 0 {
@@ -69,7 +80,7 @@ pub fn withdraw_unused_collateral(
         0
     };
 
-    // 5. Enforce locked collateral (#376).
+    // 6. Enforce locked collateral (#376).
     //    available = total_deposited - locked_collateral (floored at 0).
     //    The user must have `amount + fee_amount` of available (unlocked) collateral.
     let available = position
@@ -86,7 +97,7 @@ pub fn withdraw_unused_collateral(
         return Err(ContractError::InsufficientCollateral);
     }
 
-    // 6. Route fee to treasury if one is registered.
+    // 7. Route fee to treasury if one is registered.
     let contract_address = env.current_contract_address();
     let token_client = TokenClient::new(&env, &market.collateral_token);
 
@@ -110,7 +121,7 @@ pub fn withdraw_unused_collateral(
         // When no treasury is registered the fee stays in the contract.
     }
 
-    // 7. Deduct both withdrawal and fee from total_deposited.
+    // 8. Deduct both withdrawal and fee from total_deposited.
     let total_deducted = amount
         .checked_add(fee_amount)
         .ok_or(ContractError::ArithmeticOverflow)?;
@@ -121,7 +132,7 @@ pub fn withdraw_unused_collateral(
 
     storage::set_position(&env, market_id, &user, &position)?;
 
-    // 8. Transfer the requested amount to the user.
+    // 9. Transfer the requested amount to the user.
     token_client.transfer(&contract_address, &user, &amount);
 
     emit_collateral_withdrawn(&env, &user, market_id, amount, position.total_deposited);


### PR DESCRIPTION
## Summary

- Add `MIN_DEPOSIT_AMOUNT` constant (1 USDC = 10,000,000 stroops) enforced on every `deposit_collateral` call via a new `validate_deposit_amount` function
- Add `WITHDRAW_COOLDOWN_SECONDS` (3600s) cooldown: after each deposit the ledger timestamp is recorded and `withdraw_unused_collateral` rejects calls until the cooldown has elapsed
- Add two-step admin renounce safety: `propose_renounce_admin` records a pending proposal; `confirm_renounce_admin` permanently clears the admin role — preventing accidental loss of admin rights

Closes #412
Closes #413
Closes #414