### PR TITLE
Compact position layout, fee waivers, multi-token fees, oracle rotation

### DIFF
--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -684,6 +684,44 @@ pub fn emit_admin_transfer_accepted(env: &Env, old_admin: &Address, new_admin: &
 
 #[contractevent]
 #[derive(Clone, Debug)]
+pub struct MarketOracleUpdated {
+    #[topic]
+    pub market_id: u32,
+    pub admin: Address,
+    pub old_oracle_pubkey: BytesN<32>,
+    pub new_oracle_pubkey: BytesN<32>,
+    pub updated_at: u64,
+}
+
+/// Emit an event when a market's oracle public key is rotated by the admin (#486).
+///
+/// # Arguments
+/// * `env` - Soroban environment
+/// * `market_id` - Market whose oracle key was rotated
+/// * `admin` - Admin address that authorized the rotation
+/// * `old_oracle_pubkey` - Previous oracle public key
+/// * `new_oracle_pubkey` - Newly configured oracle public key
+/// * `updated_at` - Ledger timestamp of the rotation
+pub fn emit_market_oracle_updated(
+    env: &Env,
+    market_id: u32,
+    admin: &Address,
+    old_oracle_pubkey: &BytesN<32>,
+    new_oracle_pubkey: &BytesN<32>,
+    updated_at: u64,
+) {
+    MarketOracleUpdated {
+        market_id,
+        admin: admin.clone(),
+        old_oracle_pubkey: old_oracle_pubkey.clone(),
+        new_oracle_pubkey: new_oracle_pubkey.clone(),
+        updated_at,
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
 pub struct TreasurySet {
     #[topic]
     pub treasury: Address,
@@ -726,6 +764,46 @@ pub fn emit_admin_renounced(env: &Env, admin: &Address) {
     AdminRenouncedEvent {
         former_admin: admin.clone(),
         renounced_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+// ── Fee waiver list (#483) ────────────────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct FeeWaiverAdded {
+    #[topic]
+    pub account: Address,
+    pub admin: Address,
+    pub added_at: u64,
+}
+
+/// Emit an event when the admin adds an address to the fee waiver list.
+pub fn emit_fee_waiver_added(env: &Env, account: &Address, admin: &Address) {
+    FeeWaiverAdded {
+        account: account.clone(),
+        admin: admin.clone(),
+        added_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct FeeWaiverRemoved {
+    #[topic]
+    pub account: Address,
+    pub admin: Address,
+    pub removed_at: u64,
+}
+
+/// Emit an event when the admin removes an address from the fee waiver list.
+pub fn emit_fee_waiver_removed(env: &Env, account: &Address, admin: &Address) {
+    FeeWaiverRemoved {
+        account: account.clone(),
+        admin: admin.clone(),
+        removed_at: env.ledger().timestamp(),
     }
     .publish(env);
 }

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -32,6 +32,8 @@
 //! | `resolve_market` (oracle key)      | anyone (valid signature wins)   |
 //! | `resolve_market` (admin forced)    | admin (when oracle key is zero) |
 //! | `settle_position` / `batch_settle` | any user (resolved market)      |
+//! | `update_market_oracle`             | admin                           |
+//! | `add_fee_waiver` / `remove_fee_waiver` | admin                       |
 //!
 //! ## Storage layout
 //!
@@ -49,6 +51,7 @@
 //! | `ResolutionContract`                | `Address`       | Optional resolution contract that gates resolution |
 //! | `ThresholdSigners`                  | `Vec<BytesN<32>>` | Multi-signer quorum public keys (#378)           |
 //! | `ThresholdQuorum`                   | `u32`           | Min valid signatures required for resolution (#378)|
+//! | `FeeWaivers`                        | `Vec<Address>`  | Admin-managed fee-exempt address list (#483)       |
 
 mod deposit;
 mod error;
@@ -794,6 +797,135 @@ impl MarketContract {
             return Err(ContractError::FeeCapExceeded);
         }
         storage::set_fee_rate_bps(&env, fee_rate_bps);
+        Ok(())
+    }
+
+    // ========== Fee Waiver List (#483) ==========
+
+    /// Add `account` to the admin-managed fee waiver list.
+    ///
+    /// Waived addresses pay no withdrawal fee regardless of the configured
+    /// [`set_fee_rate`]. Adding an address that is already waived is a no-op.
+    ///
+    /// Only the stored admin may call this.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] — `admin` is not the stored admin.
+    pub fn add_fee_waiver(
+        env: Env,
+        admin: Address,
+        account: Address,
+    ) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        storage::add_fee_waiver(&env, &account);
+        events::emit_fee_waiver_added(&env, &account, &admin);
+        Ok(())
+    }
+
+    /// Remove `account` from the admin-managed fee waiver list.
+    ///
+    /// Removing an address that is not currently waived is a no-op.
+    ///
+    /// Only the stored admin may call this.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] — `admin` is not the stored admin.
+    pub fn remove_fee_waiver(
+        env: Env,
+        admin: Address,
+        account: Address,
+    ) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        storage::remove_fee_waiver(&env, &account);
+        events::emit_fee_waiver_removed(&env, &account, &admin);
+        Ok(())
+    }
+
+    /// Return whether `account` is currently exempt from withdrawal fees.
+    pub fn is_fee_waived(env: Env, account: Address) -> bool {
+        storage::is_fee_waived(&env, &account)
+    }
+
+    /// Return the full list of addresses currently exempt from withdrawal fees.
+    pub fn get_fee_waivers(env: Env) -> soroban_sdk::Vec<Address> {
+        storage::get_fee_waivers(&env)
+    }
+
+    // ========== Oracle Pubkey Rotation (#486) ==========
+
+    /// Rotate the oracle public key used to verify resolution signatures for
+    /// `market_id`.
+    ///
+    /// Intended for recovery from a compromised or retired oracle signing key
+    /// without requiring the market to be recreated. Only permitted while the
+    /// market is still [`MarketStatus::Active`] — a resolved or canceled
+    /// market has no further use for oracle verification.
+    ///
+    /// Only the stored admin may call this.
+    ///
+    /// # Arguments
+    /// * `env` - Contract environment
+    /// * `admin` - Must be the stored admin address (authorizes the call)
+    /// * `market_id` - Identifier of the market whose oracle key is rotated
+    /// * `new_oracle_pubkey` - Replacement Ed25519 oracle public key
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] – `admin` is not the stored admin.
+    /// - [`ContractError::MarketNotFound`] – the market does not exist.
+    /// - [`ContractError::MarketNotActive`] – the market is resolved or canceled.
+    /// - [`ContractError::InvalidSignature`] – `new_oracle_pubkey` is the
+    ///   all-zero key, which can never produce a valid Ed25519 signature.
+    ///
+    /// # Events
+    /// Emits [`events::MarketOracleUpdated`] with the old and new oracle keys.
+    pub fn update_market_oracle(
+        env: Env,
+        admin: Address,
+        market_id: u32,
+        new_oracle_pubkey: BytesN<32>,
+    ) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+
+        // Guard: an all-zero pubkey can never produce a valid Ed25519 signature,
+        // making the market permanently unresolvable (mirrors initialize_market).
+        if new_oracle_pubkey == BytesN::from_array(&env, &[0u8; 32]) {
+            return Err(ContractError::InvalidSignature);
+        }
+
+        let mut market =
+            storage::get_market(&env, market_id)?.ok_or(ContractError::MarketNotFound)?;
+        if market.status != MarketStatus::Active {
+            return Err(ContractError::MarketNotActive);
+        }
+
+        let old_oracle_pubkey = market.oracle_pubkey.clone();
+        market.oracle_pubkey = new_oracle_pubkey.clone();
+        storage::set_market(&env, market_id, &market)?;
+
+        events::emit_market_oracle_updated(
+            &env,
+            market_id,
+            &admin,
+            &old_oracle_pubkey,
+            &new_oracle_pubkey,
+            env.ledger().timestamp(),
+        );
+
         Ok(())
     }
 

--- a/contracts/market/src/storage.rs
+++ b/contracts/market/src/storage.rs
@@ -68,6 +68,8 @@ pub enum StorageKey {
     /// Flag indicating the contract is paused for emergency maintenance.
     /// When true, all state-mutating operations are rejected.
     Paused,
+    /// Admin-managed list of addresses exempt from withdrawal fees (#483).
+    FeeWaivers,
 }
 
 // --- Version helpers ---
@@ -281,6 +283,54 @@ pub fn is_paused(env: &Env) -> bool {
 /// Pause or unpause the contract (emergency halt).
 pub fn set_paused(env: &Env, paused: bool) {
     env.storage().persistent().set(&StorageKey::Paused, &paused);
+}
+
+// --- Fee Waiver List Storage (#483) ---
+//
+// Admin-managed allowlist of addresses that are exempt from withdrawal fees,
+// mirroring the `ThresholdSigners` list pattern used elsewhere in this module.
+
+/// Return the current fee waiver list (empty if never configured).
+pub fn get_fee_waivers(env: &Env) -> Vec<Address> {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::FeeWaivers)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn set_fee_waivers(env: &Env, waivers: &Vec<Address>) {
+    env.storage().persistent().set(&StorageKey::FeeWaivers, waivers);
+}
+
+/// Whether `account` is currently exempt from withdrawal fees.
+pub fn is_fee_waived(env: &Env, account: &Address) -> bool {
+    get_fee_waivers(env).contains(account)
+}
+
+/// Add `account` to the fee waiver list. Idempotent: adding an
+/// already-waived address is a no-op.
+pub fn add_fee_waiver(env: &Env, account: &Address) {
+    let mut waivers = get_fee_waivers(env);
+    if !waivers.contains(account) {
+        waivers.push_back(account.clone());
+        set_fee_waivers(env, &waivers);
+    }
+}
+
+/// Remove `account` from the fee waiver list. Idempotent: removing an
+/// address that is not present is a no-op.
+pub fn remove_fee_waiver(env: &Env, account: &Address) {
+    let waivers = get_fee_waivers(env);
+    if !waivers.contains(account) {
+        return;
+    }
+    let mut updated = Vec::new(env);
+    for addr in waivers.iter() {
+        if addr != *account {
+            updated.push_back(addr);
+        }
+    }
+    set_fee_waivers(env, &updated);
 }
 
 #[cfg(test)]

--- a/contracts/market/src/types.rs
+++ b/contracts/market/src/types.rs
@@ -51,10 +51,29 @@ pub struct Market {
 }
 
 /// Tracks the position and shares of a specific user in a market.
+///
+/// # Storage layout (#482)
+///
+/// Fields are ordered largest/widest-first (`Address`, then the `i128` share
+/// and collateral amounts) down to the narrowest fields (the `u32` market id
+/// and the single-byte `is_settled` flag) last. This groups same-width fields
+/// together to avoid wasted padding in the on-chain encoded representation
+/// and keeps the compact layout intent explicit for future field additions.
+///
+/// Note: this is a breaking storage-layout change — reordering the declared
+/// fields changes the serialized on-chain representation of `Position`. No
+/// migration is included per the scope of #482; existing deployments would
+/// need to redeploy/reinitialize as with any other breaking storage change
+/// (see `STORAGE_VERSION` in `storage.rs`).
+///
+/// The `i128` amount fields (`yes_shares`, `no_shares`, `locked_collateral`,
+/// `total_deposited`) are intentionally left wide: they represent token
+/// quantities that can legitimately grow very large, so narrowing them would
+/// risk overflow. Only the naturally-bounded `market_id` (`u32`) and
+/// `is_settled` (`bool`) fields are narrow.
 #[derive(Clone, Debug, PartialEq)]
 #[contracttype]
 pub struct Position {
-    pub market_id: u32,
     pub user: Address,
     pub yes_shares: i128,
     pub no_shares: i128,
@@ -62,6 +81,7 @@ pub struct Position {
     pub locked_collateral: i128,
     /// Total collateral deposited by user in this market (never decreased except by withdraw).
     pub total_deposited: i128,
+    pub market_id: u32,
     pub is_settled: bool,
 }
 

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -72,9 +72,10 @@ pub fn withdraw_unused_collateral(
     }
 
     // 5. Compute the fee (single path, no duplication).
+    // Addresses on the admin-managed fee waiver list pay no withdrawal fee (#483).
     let fee_rate_bps = storage::get_fee_rate_bps(&env);
     validation::validate_fee_rate_bps(fee_rate_bps)?;
-    let fee_amount = if fee_rate_bps > 0 {
+    let fee_amount = if fee_rate_bps > 0 && !storage::is_fee_waived(&env, &user) {
         validation::calculate_fee(amount, fee_rate_bps)?
     } else {
         0

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -10,23 +10,25 @@
 //!
 //! ## Authorization model
 //!
-//! | Operation             | Who may call              |
-//! |-----------------------|---------------------------|
-//! | `initialize`          | anyone (once)             |
-//! | `collect_fee`         | registered market contract|
-//! | `withdraw_fees`       | admin                     |
-//! | `set_market_contract` | admin                     |
-//! | Getters               | anyone                    |
+//! | Operation                        | Who may call              |
+//! |-----------------------------------|---------------------------|
+//! | `initialize`                      | anyone (once)             |
+//! | `collect_fee`                      | registered market contract|
+//! | `withdraw_fees`                    | admin                     |
+//! | `add_market` / `remove_market`     | admin                     |
+//! | `set_market_contract`              | admin                     |
+//! | Getters                            | anyone                    |
 //!
 //! ## Storage layout
 //!
-//! | Key                       | Type      | Description                              |
-//! |---------------------------|-----------|------------------------------------------|
-//! | `StorageVersion`          | `u32`     | Schema version guard                     |
-//! | `Admin`                   | `Address` | Protocol admin                           |
-//! | `AuthorizedMarket`        | `Address` | Authorized fee-depositing contract       |
-//! | `TokenBalance(Address)`   | `i128`    | Current custodied balance (decreasable)  |
-//! | `CumulativeFees(Address)` | `i128`    | Historical total collected (monotone)    |
+//! | Key                       | Type            | Description                              |
+//! |---------------------------|-----------------|-------------------------------------------|
+//! | `StorageVersion`          | `u32`           | Schema version guard                     |
+//! | `Admin`                   | `Address`       | Protocol admin                           |
+//! | `AuthorizedMarkets`       | `Vec<Address>`  | Market contracts allowed to call `collect_fee` |
+//! | `TokenBalance(Address)`   | `i128`          | Current custodied balance per token (decreasable) |
+//! | `CumulativeFees(Address)` | `i128`          | Historical total collected per token (monotone)   |
+//! | `FeeTokens`               | `Vec<Address>`  | Registry of every token ever collected (#484)     |
 
 pub mod error;
 pub mod events;
@@ -56,7 +58,8 @@ impl TreasuryContract {
             return Err(TreasuryError::AlreadyInitialized);
         }
         storage::set_admin(&env, &admin);
-        storage::set_authorized_market(&env, &market_contract);
+        let markets = soroban_sdk::vec![&env, market_contract.clone()];
+        storage::set_authorized_markets(&env, &markets);
         storage::set_version(&env);
         events::emit_treasury_initialized(&env, &admin, &market_contract);
         Ok(())
@@ -65,6 +68,11 @@ impl TreasuryContract {
     // ── Fee collection ─────────────────────────────────────────────────────────
 
     /// Record a protocol fee transferred from any registered market contract.
+    ///
+    /// `token` identifies which token mint the fee was paid in (#484): the
+    /// treasury custodies an independent balance per token, so markets using
+    /// different collateral tokens can all route fees through the same
+    /// treasury deployment without their balances colliding.
     pub fn collect_fee(
         env: Env,
         caller: Address,
@@ -80,13 +88,16 @@ impl TreasuryContract {
         if storage::is_paused(&env) {
             return Err(TreasuryError::ContractPaused);
         }
-        let market_contract = storage::get_authorized_market(&env)?;
-        if caller != market_contract {
+        if !storage::is_authorized_market(&env, &caller) {
             return Err(TreasuryError::CallerNotMarket);
         }
         if fee_amount <= 0 {
             return Err(TreasuryError::InvalidAmount);
         }
+
+        // Track every token we've ever seen so callers can enumerate the full
+        // set of fee-bearing tokens without prior knowledge (#484).
+        storage::register_fee_token(&env, &token);
 
         let prev_balance = storage::get_token_balance(&env, &token)?;
         let new_balance = prev_balance
@@ -174,7 +185,34 @@ impl TreasuryContract {
         Ok(())
     }
 
-    /// Rotate the registered market contract address (e.g. after an upgrade).
+    /// Register an additional market contract allowed to call `collect_fee`.
+    ///
+    /// Idempotent: adding an already-registered market is a no-op. Only the
+    /// admin may call this.
+    pub fn add_market(
+        env: Env,
+        caller: Address,
+        market_contract: Address,
+    ) -> Result<(), TreasuryError> {
+        caller.require_auth();
+
+        if !storage::has_admin(&env) {
+            return Err(TreasuryError::NotInitialized);
+        }
+        let admin = storage::get_admin(&env)?;
+        if caller != admin {
+            return Err(TreasuryError::Unauthorized);
+        }
+
+        let mut markets = storage::get_authorized_markets(&env);
+        if !markets.contains(&market_contract) {
+            markets.push_back(market_contract.clone());
+            storage::set_authorized_markets(&env, &markets);
+        }
+        Ok(())
+    }
+
+    /// Deregister a market contract, revoking its ability to call `collect_fee`.
     ///
     /// Returns [`TreasuryError::CallerNotMarket`] if the address is not registered.
     pub fn remove_market(
@@ -192,8 +230,43 @@ impl TreasuryContract {
             return Err(TreasuryError::Unauthorized);
         }
 
-        let old = storage::get_authorized_market(&env)?;
-        storage::set_authorized_market(&env, &new_market_contract);
+        let markets = storage::get_authorized_markets(&env);
+        if !markets.contains(&market_contract) {
+            return Err(TreasuryError::CallerNotMarket);
+        }
+        let mut updated = Vec::new(&env);
+        for m in markets.iter() {
+            if m != market_contract {
+                updated.push_back(m);
+            }
+        }
+        storage::set_authorized_markets(&env, &updated);
+        Ok(())
+    }
+
+    /// Rotate the full set of authorized markets to a single new market
+    /// contract (e.g. after a market-contract upgrade). Existing
+    /// registrations are replaced entirely — use [`add_market`] /
+    /// [`remove_market`] to manage individual entries instead.
+    pub fn set_market_contract(
+        env: Env,
+        caller: Address,
+        new_market_contract: Address,
+    ) -> Result<(), TreasuryError> {
+        caller.require_auth();
+
+        if !storage::has_admin(&env) {
+            return Err(TreasuryError::NotInitialized);
+        }
+        let admin = storage::get_admin(&env)?;
+        if caller != admin {
+            return Err(TreasuryError::Unauthorized);
+        }
+
+        let old_markets = storage::get_authorized_markets(&env);
+        let old = old_markets.get(0).unwrap_or_else(|| new_market_contract.clone());
+        let updated = soroban_sdk::vec![&env, new_market_contract.clone()];
+        storage::set_authorized_markets(&env, &updated);
         events::emit_market_contract_updated(&env, &old, &new_market_contract);
         Ok(())
     }
@@ -253,9 +326,30 @@ impl TreasuryContract {
         storage::get_admin(&env)
     }
 
-    /// Return the registered market contract address. Returns `UpgradeRequired` if version mismatches.
+    /// Return the primary registered market contract address (the first entry
+    /// in the authorized-markets registry). Returns `NotInitialized` if no
+    /// market has ever been registered.
     pub fn market_contract(env: Env) -> Result<Address, TreasuryError> {
-        storage::get_authorized_market(&env)
+        storage::get_authorized_markets(&env)
+            .get(0)
+            .ok_or(TreasuryError::NotInitialized)
+    }
+
+    /// Return whether `market` is currently authorized to call `collect_fee`.
+    pub fn is_authorized_market(env: Env, market: Address) -> bool {
+        storage::is_authorized_market(&env, &market)
+    }
+
+    /// Return every market contract currently authorized to call `collect_fee`.
+    pub fn list_markets(env: Env) -> Vec<Address> {
+        storage::get_authorized_markets(&env)
+    }
+
+    /// Return every distinct token mint that has ever had a fee collected for
+    /// it (#484). Useful for admin tooling to discover which per-token
+    /// balances exist without prior knowledge of the token addresses.
+    pub fn list_fee_tokens(env: Env) -> Vec<Address> {
+        storage::get_fee_tokens(&env)
     }
 
     /// Return the current custodied balance for `token` (decreases on withdrawal).

--- a/contracts/treasury/src/storage.rs
+++ b/contracts/treasury/src/storage.rs
@@ -1,5 +1,6 @@
 //! Persistent storage helpers for the Vatix Treasury contract.
 
+use crate::error::TreasuryError;
 use soroban_sdk::{contracttype, Address, Env, Vec};
 
 /// Bump this constant whenever the treasury storage layout changes in a breaking way.
@@ -24,6 +25,10 @@ pub enum StorageKey {
     TotalCollected,
     /// When `true`, `collect_fee` and `withdraw_fees` are blocked until unpaused.
     Paused,
+    /// Registry of every distinct token mint that has ever had a fee routed
+    /// through `collect_fee` (#484). Lets callers enumerate which tokens hold
+    /// a balance without needing prior knowledge of the token address.
+    FeeTokens,
 }
 
 // ── Version ───────────────────────────────────────────────────────────────────
@@ -36,6 +41,15 @@ pub fn set_version(env: &Env) {
 
 pub fn get_version(env: &Env) -> Option<u32> {
     env.storage().instance().get(&StorageKey::StorageVersion)
+}
+
+/// Guard used by every versioned storage accessor: rejects reads/writes
+/// against a deployment whose on-chain schema doesn't match this build.
+fn assert_version(env: &Env) -> Result<(), TreasuryError> {
+    if get_version(env) != Some(STORAGE_VERSION) {
+        return Err(TreasuryError::UpgradeRequired);
+    }
+    Ok(())
 }
 
 // ── Admin ─────────────────────────────────────────────────────────────────────
@@ -58,14 +72,16 @@ pub fn set_admin(env: &Env, admin: &Address) {
 }
 
 // ── Authorized markets registry ───────────────────────────────────────────────
+//
+// Note: fixed alongside #484 (multi-token fee collection) since this file was
+// touched for that change — `get_authorized_markets`/`is_authorized_market`
+// previously referenced a non-existent singular `AuthorizedMarket` key.
 
-pub fn get_authorized_market(env: &Env) -> Result<Address, TreasuryError> {
-    assert_version(env)?;
-    Ok(env
-        .storage()
+pub fn get_authorized_markets(env: &Env) -> Vec<Address> {
+    env.storage()
         .instance()
-        .get(&StorageKey::AuthorizedMarket)
-        .expect("treasury not initialized"))
+        .get(&StorageKey::AuthorizedMarkets)
+        .unwrap_or_else(|| Vec::new(env))
 }
 
 pub fn set_authorized_markets(env: &Env, markets: &Vec<Address>) {
@@ -110,6 +126,26 @@ pub fn set_cumulative_fees(env: &Env, token: &Address, amount: i128) {
     env.storage()
         .persistent()
         .set(&StorageKey::CumulativeFees(token.clone()), &amount);
+}
+
+// ── Fee token registry (#484: multi-token fee collection support) ────────────
+
+/// Return every distinct token mint that has ever had a fee collected for it.
+pub fn get_fee_tokens(env: &Env) -> Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&StorageKey::FeeTokens)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Record `token` in the fee-token registry if it hasn't been seen before.
+/// Idempotent: re-registering an already-known token is a no-op.
+pub fn register_fee_token(env: &Env, token: &Address) {
+    let mut tokens = get_fee_tokens(env);
+    if !tokens.contains(token) {
+        tokens.push_back(token.clone());
+        env.storage().instance().set(&StorageKey::FeeTokens, &tokens);
+    }
 }
 
 // ── Global cumulative (sum across all tokens, monotone) ───────────────────────


### PR DESCRIPTION
Closes #482
Closes #483
Closes #484
Closes #486

## Summary

**#482 — Compact position struct layout**
Reordered `Position`'s fields (market contract) largest-to-smallest — `Address`, then the `i128` share/collateral amounts, then the narrow `u32` market id, then the single-byte `is_settled` flag — to avoid wasted padding in the on-chain encoded representation. Token/collateral amount fields are kept as `i128` (no narrowing) since they can legitimately grow large. This is a breaking storage-layout change (documented inline); no migration is included per scope.

**#483 — Fee waiver list for admin**
Added an admin-managed `FeeWaivers` list (`Vec<Address>`) on the market contract, mirroring the existing `ThresholdSigners` admin-list pattern. New admin-only instructions `add_fee_waiver` / `remove_fee_waiver` (idempotent), plus `is_fee_waived` / `get_fee_waivers` getters. The withdrawal fee calculation now skips the fee entirely for waived addresses. Emits `FeeWaiverAdded` / `FeeWaiverRemoved` events.

**#484 — Multi-token fee collection support**
The treasury already kept per-token balances (`TokenBalance(Address)` / `CumulativeFees(Address)`), so this adds the missing enumeration piece: a `FeeTokens` registry populated on every `collect_fee` call, exposed via a new `list_fee_tokens()` getter, so tooling can discover which tokens hold a balance without prior knowledge of the addresses.

While in this file for #484, also fixed pre-existing breakage that prevented the treasury contract from compiling at all (unrelated to token multiplicity but directly adjacent): a dangling reference to a non-existent `AuthorizedMarket` storage key / undefined `get_authorized_markets` helper, a missing `assert_version` function, and an undefined variable in `remove_market`. Completed the authorized-market registry API (`add_market`, `remove_market`, `is_authorized_market`, `list_markets`) that `contracts/treasury/src/test.rs` already exercised, keeping `set_market_contract` as a single-market rotation on top of the same registry to match `tests/client_entrypoints_test.rs`.

**#486 — Oracle pubkey rotation per market**
Added `update_market_oracle(admin, market_id, new_oracle_pubkey)` on the market contract, gated by the same admin-only check used elsewhere (e.g. `cancel_market`, `set_treasury_contract`). Rejects rotating to the all-zero pubkey (mirrors the guard in `initialize_market`) and requires the market to still be `Active`. Emits a new `MarketOracleUpdated` event with the old and new keys.

## Notes
- No build/tests were run per task instructions — implementation is based on direct code reading and matching existing conventions (error enums, event structs, admin-auth pattern, storage-key style).
- #482 is a breaking storage-layout change, called out in the commit message.