### PR TITLE
Oracle adapter fallback, signature hardening, created_at, stakeholder fee distribution

### DIFF
--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -730,6 +730,33 @@ pub fn emit_admin_renounced(env: &Env, admin: &Address) {
     .publish(env);
 }
 
+// ── Oracle adapter enable/disable (#488) ──────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct OracleAdapterConfigured {
+    #[topic]
+    pub adapter_type: crate::types::AdapterType,
+    pub enabled: bool,
+    pub configured_at: u64,
+}
+
+/// Emitted when the admin enables/disables the Reflector or Pyth adapter via
+/// `set_adapter_enabled`. While an adapter is disabled, resolution falls back
+/// to direct Ed25519 verification — see `oracle::verify_market_outcome`.
+pub fn emit_oracle_adapter_configured(
+    env: &Env,
+    adapter_type: crate::types::AdapterType,
+    enabled: bool,
+) {
+    OracleAdapterConfigured {
+        adapter_type,
+        enabled,
+        configured_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -415,6 +415,74 @@ impl MarketContract {
         Ok(())
     }
 
+    /// Verify an oracle signature for `(market_id, outcome)` without mutating
+    /// any state (#489).
+    ///
+    /// This is the read-only counterpart of the verification step performed
+    /// inside [`resolve_market`]: it delegates to
+    /// [`oracle::verify_market_outcome`] so the exact same signed-payload
+    /// construction, adapter dispatch, and Ed25519 fallback logic (#488) are
+    /// used. The resolution contract's `propose()` calls this cross-contract
+    /// to reject an invalid oracle signature before opening a challenge
+    /// window, rather than only discovering the bad signature later at
+    /// `finalize()` time.
+    ///
+    /// No authorization is required — this never changes contract state, it
+    /// only reports whether `signature` verifies.
+    ///
+    /// # Errors
+    /// - [`ContractError::MarketNotFound`] — the market does not exist.
+    /// - [`ContractError::InvalidSignature`] / [`ContractError::UnauthorizedOracle`]
+    ///   — signature does not verify (see [`oracle::verify_market_outcome`]).
+    pub fn verify_signature(
+        env: Env,
+        market_id: u32,
+        outcome: bool,
+        signature: BytesN<64>,
+    ) -> Result<(), ContractError> {
+        let market = storage::get_market(&env, market_id)?.ok_or(ContractError::MarketNotFound)?;
+        oracle::verify_market_outcome(
+            &env,
+            market_id,
+            &market,
+            market.adapter_type.clone(),
+            outcome,
+            &signature,
+        )
+    }
+
+    /// Enable or disable the Reflector/Pyth oracle adapter for resolution (#488).
+    ///
+    /// Only the stored admin may call this. While an adapter is disabled (the
+    /// default), `resolve_market` and `verify_signature` fall back to direct
+    /// Ed25519 verification of the proof against the market's `oracle_pubkey`
+    /// instead of routing through the (unavailable) adapter — see
+    /// [`oracle::verify_market_outcome`] for the full rationale.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] — `admin` is not the stored admin.
+    pub fn set_adapter_enabled(
+        env: Env,
+        admin: Address,
+        adapter_type: AdapterType,
+        enabled: bool,
+    ) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        storage::set_adapter_enabled(&env, &adapter_type, enabled);
+        events::emit_oracle_adapter_configured(&env, adapter_type, enabled);
+        Ok(())
+    }
+
+    /// Return whether the given oracle adapter type is currently enabled (#488).
+    pub fn is_adapter_enabled(env: Env, adapter_type: AdapterType) -> bool {
+        storage::is_adapter_enabled(&env, &adapter_type)
+    }
+
     /// Cancel a market before it is resolved, halting all further trading.
     ///
     /// Only the stored admin may call this. The market must still be

--- a/contracts/market/src/oracle.rs
+++ b/contracts/market/src/oracle.rs
@@ -114,8 +114,22 @@ pub fn validate_oracle_authorization(
 /// Verify that the market outcome is valid according to the configured oracle adapter.
 ///
 /// For `AdapterType::Ed25519`, this verifies the provided signature against the
-/// market's `oracle_pubkey`. Other adapter types are not yet implemented and
-/// currently return `UnauthorizedOracle` to prevent accidental silent success.
+/// market's `oracle_pubkey`.
+///
+/// For `AdapterType::Reflector` / `AdapterType::Pyth` the full on-chain adapter
+/// integration (price fetch + comparison) is tracked separately under #139 and
+/// is not wired into this dispatch. Rather than leaving markets configured with
+/// one of these adapters permanently unresolvable, we check the per-adapter
+/// `enabled` flag (#488):
+/// - If the adapter has been explicitly marked enabled by the admin, we still
+///   fail closed with `UnauthorizedOracle` — this dispatch has no code path to
+///   actually query Reflector/Pyth yet, so silently succeeding would be unsafe.
+/// - If the adapter is disabled (the default), we fall back to verifying
+///   `proof` as a direct Ed25519 signature over the same canonical payload
+///   (`construct_oracle_message`) against the market's `oracle_pubkey`, using
+///   the identical [`verify_oracle_signature`] path as `AdapterType::Ed25519`.
+///   This lets a market keep resolving via the trusted single-signer key while
+///   its richer oracle adapter is unavailable, instead of getting stuck.
 pub fn verify_market_outcome(
     env: &Env,
     market_id: u32,
@@ -126,7 +140,14 @@ pub fn verify_market_outcome(
 ) -> Result<(), ContractError> {
     match adapter_type {
         AdapterType::Ed25519 => verify_oracle_signature(env, market_id, outcome, proof, &market.oracle_pubkey),
-        AdapterType::Reflector | AdapterType::Pyth => Err(ContractError::UnauthorizedOracle),
+        AdapterType::Reflector | AdapterType::Pyth => {
+            if crate::storage::is_adapter_enabled(env, &adapter_type) {
+                Err(ContractError::UnauthorizedOracle)
+            } else {
+                // Adapter disabled/unavailable — fall back to raw Ed25519 verification.
+                verify_oracle_signature(env, market_id, outcome, proof, &market.oracle_pubkey)
+            }
+        }
     }
 }
 
@@ -575,5 +596,98 @@ mod threshold_tests {
             verify_threshold_signatures(&env, 42, false, &signers, &sigs, 1),
             Ok(())
         );
+    }
+}
+
+#[cfg(test)]
+mod adapter_fallback_tests {
+    //! Tests for the Reflector/Pyth → Ed25519 fallback dispatch (#488).
+    use super::*;
+    use crate::types::{AdapterType, Market, MarketStatus};
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+    fn make_reflector_market(env: &Env, oracle_pubkey: BytesN<32>) -> Market {
+        Market {
+            id: 1,
+            question: String::from_str(env, "Reflector fallback test"),
+            end_time: 1000,
+            oracle_pubkey,
+            status: MarketStatus::Active,
+            result: None,
+            creator: Address::generate(env),
+            created_at: 0,
+            collateral_token: Address::generate(env),
+            price_bps: 5_000,
+            resolver: None,
+            resolved_at: None,
+            adapter_type: AdapterType::Reflector,
+            outcome_count: 2,
+            closed_to_deposits: false,
+        }
+    }
+
+    #[test]
+    fn reflector_disabled_by_default_falls_back_to_ed25519() {
+        use ed25519_dalek::{Signer, SigningKey};
+        use rand::rngs::OsRng;
+
+        let env = Env::default();
+        let contract_id = env.register(crate::MarketContract, ());
+        let market_id = 1u32;
+        let outcome = true;
+
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let message = construct_oracle_message(&env, market_id, outcome);
+        let signature = signing_key.sign(message.to_array().as_slice());
+        let pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let sig = BytesN::from_array(&env, &signature.to_bytes());
+        let market = make_reflector_market(&env, pubkey);
+
+        env.as_contract(&contract_id, || {
+            // No admin has enabled the Reflector adapter, so it defaults to
+            // disabled and resolution falls back to direct Ed25519 verification.
+            let result =
+                verify_market_outcome(&env, market_id, &market, AdapterType::Reflector, outcome, &sig);
+            assert_eq!(result, Ok(()));
+        });
+    }
+
+    #[test]
+    fn reflector_fallback_rejects_invalid_signature() {
+        let env = Env::default();
+        let contract_id = env.register(crate::MarketContract, ());
+        let market = make_reflector_market(&env, BytesN::from_array(&env, &[1u8; 32]));
+
+        env.as_contract(&contract_id, || {
+            let result = verify_market_outcome(
+                &env,
+                1,
+                &market,
+                AdapterType::Reflector,
+                true,
+                &BytesN::from_array(&env, &[0u8; 64]),
+            );
+            assert_eq!(result, Err(ContractError::InvalidSignature));
+        });
+    }
+
+    #[test]
+    fn reflector_enabled_still_rejects_since_adapter_not_wired() {
+        let env = Env::default();
+        let contract_id = env.register(crate::MarketContract, ());
+        let market = make_reflector_market(&env, BytesN::from_array(&env, &[1u8; 32]));
+
+        env.as_contract(&contract_id, || {
+            crate::storage::set_adapter_enabled(&env, &AdapterType::Reflector, true);
+            let result = verify_market_outcome(
+                &env,
+                1,
+                &market,
+                AdapterType::Reflector,
+                true,
+                &BytesN::from_array(&env, &[0u8; 64]),
+            );
+            assert_eq!(result, Err(ContractError::UnauthorizedOracle));
+        });
     }
 }

--- a/contracts/market/src/storage.rs
+++ b/contracts/market/src/storage.rs
@@ -31,15 +31,17 @@ use soroban_sdk::{contracttype, Address, BytesN, Env, Vec};
 /// 5. Initialize: `stellar contract invoke ... -- initialize --admin <addr>`
 /// 6. Verify old deployment returns `UpgradeRequired` error
 ///
-/// ## Current version: 3
+/// ## Current version: 4
 ///
 /// ### Version history:
+/// - **v4:** Added per-adapter-type `AdapterEnabled` flag for the Reflector/Pyth
+///   Ed25519 fallback path (#488)
 /// - **v3:** Added Treasury, Outcome Token, Resolution Contract, Threshold Signers
 /// - **v2:** Fixed locked_collateral semantics (#262)
 /// - **v1:** Initial storage layout
 ///
 /// See `STORAGE_MIGRATION_GUIDE.md` and `MIGRATION.md` for detailed history.
-pub const STORAGE_VERSION: u32 = 3;
+pub const STORAGE_VERSION: u32 = 4;
 
 #[contracttype]
 pub enum StorageKey {
@@ -68,6 +70,11 @@ pub enum StorageKey {
     /// Flag indicating the contract is paused for emergency maintenance.
     /// When true, all state-mutating operations are rejected.
     Paused,
+    /// Whether the Reflector/Pyth adapter for a given [`AdapterType`] is live.
+    /// Defaults to `false` (disabled) when unset — see #488: while disabled,
+    /// `resolve_market` falls back to direct Ed25519 verification against the
+    /// market's `oracle_pubkey` instead of routing through the adapter.
+    AdapterEnabled(crate::types::AdapterType),
 }
 
 // --- Version helpers ---
@@ -281,6 +288,29 @@ pub fn is_paused(env: &Env) -> bool {
 /// Pause or unpause the contract (emergency halt).
 pub fn set_paused(env: &Env, paused: bool) {
     env.storage().persistent().set(&StorageKey::Paused, &paused);
+}
+
+// --- Oracle Adapter Enabled Flag (#488) ---
+
+/// Whether the given adapter type is live for resolution.
+///
+/// Defaults to `false` (disabled) when never explicitly configured, which is
+/// the correct default today since the Reflector/Pyth on-chain integration is
+/// not yet wired into `resolve_market` (tracked under #139). While disabled,
+/// callers fall back to direct Ed25519 verification — see
+/// [`crate::oracle::verify_market_outcome`].
+pub fn is_adapter_enabled(env: &Env, adapter_type: &crate::types::AdapterType) -> bool {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::AdapterEnabled(adapter_type.clone()))
+        .unwrap_or(false)
+}
+
+/// Enable or disable the given adapter type (admin-gated in `lib.rs`).
+pub fn set_adapter_enabled(env: &Env, adapter_type: &crate::types::AdapterType, enabled: bool) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::AdapterEnabled(adapter_type.clone()), &enabled);
 }
 
 #[cfg(test)]

--- a/contracts/treasury/src/error.rs
+++ b/contracts/treasury/src/error.rs
@@ -25,8 +25,16 @@ pub enum TreasuryError {
     /// `fee_amount` or `amount` is zero or negative.
     InvalidAmount = 31,
 
+    /// Stakeholder share list is empty, or the `share_bps` values do not sum
+    /// to exactly 10_000 (100%).
+    InvalidStakeholderWeights = 32,
+
     /// The treasury has not been initialized yet.
     NotInitialized = 33,
+
+    /// `distribute_fees` was called but no stakeholder list has been
+    /// configured via `set_stakeholders`.
+    NoStakeholdersConfigured = 34,
 
     // ── Authorization (40–49) ─────────────────────────────────────────────────
     /// `collect_fee` was invoked by an address that is not the registered
@@ -57,7 +65,9 @@ mod tests {
         assert_eq!(TreasuryError::UpgradeRequired as u32, 10);
         assert_eq!(TreasuryError::InsufficientBalance as u32, 21);
         assert_eq!(TreasuryError::InvalidAmount as u32, 31);
+        assert_eq!(TreasuryError::InvalidStakeholderWeights as u32, 32);
         assert_eq!(TreasuryError::NotInitialized as u32, 33);
+        assert_eq!(TreasuryError::NoStakeholdersConfigured as u32, 34);
         assert_eq!(TreasuryError::CallerNotMarket as u32, 40);
         assert_eq!(TreasuryError::Unauthorized as u32, 41);
         assert_eq!(TreasuryError::AlreadyInitialized as u32, 42);

--- a/contracts/treasury/src/events.rs
+++ b/contracts/treasury/src/events.rs
@@ -13,6 +13,10 @@
 //! | `FeesWithdrawn`         | `fees_withdrawn`                   |
 //! | `AdminTransferred`      | `admin_transferred`                |
 //! | `MarketContractUpdated` | `market_contract_updated`          |
+//! | `MarketAdded`           | `market_added`                     |
+//! | `MarketRemoved`         | `market_removed`                   |
+//! | `StakeholdersUpdated`   | `stakeholders_updated`             |
+//! | `FeesDistributed`       | `fees_distributed`                 |
 
 use soroban_sdk::{contractevent, Address, Env};
 
@@ -143,6 +147,77 @@ pub fn emit_market_contract_updated(
     MarketContractUpdated {
         old_market_contract: old_market_contract.clone(),
         new_market_contract: new_market_contract.clone(),
+    }
+    .publish(env);
+}
+
+// ── Market registry (add/remove) ──────────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct MarketAdded {
+    #[topic]
+    pub market_contract: Address,
+}
+
+pub fn emit_market_added(env: &Env, market_contract: &Address) {
+    MarketAdded { market_contract: market_contract.clone() }.publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct MarketRemoved {
+    #[topic]
+    pub market_contract: Address,
+}
+
+pub fn emit_market_removed(env: &Env, market_contract: &Address) {
+    MarketRemoved { market_contract: market_contract.clone() }.publish(env);
+}
+
+// ── Stakeholder fee distribution (#485) ───────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct StakeholdersUpdated {
+    pub stakeholder_count: u32,
+    pub updated_at: u64,
+}
+
+pub fn emit_stakeholders_updated(env: &Env, stakeholder_count: u32) {
+    StakeholdersUpdated {
+        stakeholder_count,
+        updated_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct FeesDistributed {
+    #[topic]
+    pub token: Address,
+    pub distributed_amount: i128,
+    pub remaining_token_balance: i128,
+    pub stakeholder_count: u32,
+    pub distributed_at: u64,
+}
+
+/// Emitted once per `distribute_fees` call, summarizing the payout across all
+/// configured stakeholders for `token`.
+pub fn emit_fees_distributed(
+    env: &Env,
+    token: &Address,
+    distributed_amount: i128,
+    remaining_token_balance: i128,
+    stakeholder_count: u32,
+) {
+    FeesDistributed {
+        token: token.clone(),
+        distributed_amount,
+        remaining_token_balance,
+        stakeholder_count,
+        distributed_at: env.ledger().timestamp(),
     }
     .publish(env);
 }

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -13,20 +13,24 @@
 //! | Operation             | Who may call              |
 //! |-----------------------|---------------------------|
 //! | `initialize`          | anyone (once)             |
-//! | `collect_fee`         | registered market contract|
+//! | `collect_fee`         | any registered market     |
 //! | `withdraw_fees`       | admin                     |
-//! | `set_market_contract` | admin                     |
+//! | `add_market`          | admin                     |
+//! | `remove_market`       | admin                     |
+//! | `set_stakeholders`    | admin                     |
+//! | `distribute_fees`     | admin                     |
 //! | Getters               | anyone                    |
 //!
 //! ## Storage layout
 //!
-//! | Key                       | Type      | Description                              |
-//! |---------------------------|-----------|------------------------------------------|
-//! | `StorageVersion`          | `u32`     | Schema version guard                     |
-//! | `Admin`                   | `Address` | Protocol admin                           |
-//! | `AuthorizedMarket`        | `Address` | Authorized fee-depositing contract       |
-//! | `TokenBalance(Address)`   | `i128`    | Current custodied balance (decreasable)  |
-//! | `CumulativeFees(Address)` | `i128`    | Historical total collected (monotone)    |
+//! | Key                       | Type                  | Description                              |
+//! |---------------------------|-----------------------|-------------------------------------------|
+//! | `StorageVersion`          | `u32`                 | Schema version guard                      |
+//! | `Admin`                   | `Address`             | Protocol admin                            |
+//! | `AuthorizedMarkets`       | `Vec<Address>`        | Fee-depositing contracts allowed to call `collect_fee` |
+//! | `TokenBalance(Address)`   | `i128`                | Current custodied balance (decreasable)   |
+//! | `CumulativeFees(Address)` | `i128`                | Historical total collected (monotone)     |
+//! | `Stakeholders`            | `Vec<(Address, u32)>` | Revenue-share list, `share_bps` sums to 10_000 (#485) |
 
 pub mod error;
 pub mod events;
@@ -37,6 +41,9 @@ mod test;
 pub use error::TreasuryError;
 
 use soroban_sdk::{contract, contractimpl, token, Address, Env, Vec};
+
+/// Basis-point denominator: stakeholder shares must sum to exactly this value.
+const BPS_DENOMINATOR: i128 = 10_000;
 
 #[contract]
 pub struct TreasuryContract;
@@ -56,7 +63,9 @@ impl TreasuryContract {
             return Err(TreasuryError::AlreadyInitialized);
         }
         storage::set_admin(&env, &admin);
-        storage::set_authorized_market(&env, &market_contract);
+        let mut markets: Vec<Address> = Vec::new(&env);
+        markets.push_back(market_contract.clone());
+        storage::set_authorized_markets(&env, &markets);
         storage::set_version(&env);
         events::emit_treasury_initialized(&env, &admin, &market_contract);
         Ok(())
@@ -80,8 +89,7 @@ impl TreasuryContract {
         if storage::is_paused(&env) {
             return Err(TreasuryError::ContractPaused);
         }
-        let market_contract = storage::get_authorized_market(&env)?;
-        if caller != market_contract {
+        if !storage::is_authorized_market(&env, &caller) {
             return Err(TreasuryError::CallerNotMarket);
         }
         if fee_amount <= 0 {
@@ -174,9 +182,40 @@ impl TreasuryContract {
         Ok(())
     }
 
-    /// Rotate the registered market contract address (e.g. after an upgrade).
+    /// Register an additional market contract allowed to call `collect_fee`.
     ///
-    /// Returns [`TreasuryError::CallerNotMarket`] if the address is not registered.
+    /// Idempotent — adding an already-registered market is a no-op (no
+    /// duplicate entry, no event). Only the admin may call this.
+    pub fn add_market(
+        env: Env,
+        caller: Address,
+        market_contract: Address,
+    ) -> Result<(), TreasuryError> {
+        caller.require_auth();
+
+        if !storage::has_admin(&env) {
+            return Err(TreasuryError::NotInitialized);
+        }
+        let admin = storage::get_admin(&env)?;
+        if caller != admin {
+            return Err(TreasuryError::Unauthorized);
+        }
+
+        let mut markets = storage::get_authorized_markets(&env)?;
+        if !markets.contains(&market_contract) {
+            markets.push_back(market_contract.clone());
+            storage::set_authorized_markets(&env, &markets);
+            events::emit_market_added(&env, &market_contract);
+        }
+        Ok(())
+    }
+
+    /// Deregister a market contract, revoking its ability to call `collect_fee`.
+    ///
+    /// Only the admin may call this.
+    ///
+    /// # Errors
+    /// - [`TreasuryError::CallerNotMarket`] — `market_contract` is not currently registered.
     pub fn remove_market(
         env: Env,
         caller: Address,
@@ -192,10 +231,57 @@ impl TreasuryContract {
             return Err(TreasuryError::Unauthorized);
         }
 
+        let mut markets = storage::get_authorized_markets(&env)?;
+        match markets.first_index_of(&market_contract) {
+            Some(idx) => {
+                markets.remove(idx);
+                storage::set_authorized_markets(&env, &markets);
+                events::emit_market_removed(&env, &market_contract);
+                Ok(())
+            }
+            None => Err(TreasuryError::CallerNotMarket),
+        }
+    }
+
+    /// Replace the entire authorized-market registry with a single market
+    /// contract (full rotation), e.g. after deploying a new market contract
+    /// version. Equivalent to removing every previously registered market and
+    /// calling `add_market` with only `new_market_contract`.
+    ///
+    /// Prefer `add_market`/`remove_market` for incremental registry changes
+    /// when more than one market should remain authorized at a time.
+    ///
+    /// Only the admin may call this.
+    pub fn set_market_contract(
+        env: Env,
+        caller: Address,
+        new_market_contract: Address,
+    ) -> Result<(), TreasuryError> {
+        caller.require_auth();
+        if !storage::has_admin(&env) {
+            return Err(TreasuryError::NotInitialized);
+        }
+        let admin = storage::get_admin(&env)?;
+        if caller != admin {
+            return Err(TreasuryError::Unauthorized);
+        }
+
         let old = storage::get_authorized_market(&env)?;
-        storage::set_authorized_market(&env, &new_market_contract);
+        let mut markets: Vec<Address> = Vec::new(&env);
+        markets.push_back(new_market_contract.clone());
+        storage::set_authorized_markets(&env, &markets);
         events::emit_market_contract_updated(&env, &old, &new_market_contract);
         Ok(())
+    }
+
+    /// Return whether `market_contract` is currently authorized to call `collect_fee`.
+    pub fn is_authorized_market(env: Env, market_contract: Address) -> bool {
+        storage::is_authorized_market(&env, &market_contract)
+    }
+
+    /// Return the full list of markets currently authorized to call `collect_fee`.
+    pub fn list_markets(env: Env) -> Result<Vec<Address>, TreasuryError> {
+        storage::get_authorized_markets(&env)
     }
 
     /// Pause the treasury, blocking `collect_fee` and `withdraw_fees`.
@@ -238,6 +324,124 @@ impl TreasuryContract {
         }
         storage::set_paused(&env, false);
         events::emit_treasury_unpaused(&env, &caller);
+        Ok(())
+    }
+
+    // ── Stakeholder fee distribution (#485) ────────────────────────────────────
+
+    /// Configure the stakeholder revenue-share list (admin only).
+    ///
+    /// `stakeholders` is a list of `(address, share_bps)` pairs. `share_bps`
+    /// values must sum to exactly 10_000 (100%); this fully replaces any
+    /// previously configured list.
+    ///
+    /// # Errors
+    /// - [`TreasuryError::NotInitialized`] – treasury not initialized.
+    /// - [`TreasuryError::Unauthorized`] – caller is not the admin.
+    /// - [`TreasuryError::InvalidStakeholderWeights`] – list is empty, or the
+    ///   `share_bps` values do not sum to exactly 10_000.
+    pub fn set_stakeholders(
+        env: Env,
+        caller: Address,
+        stakeholders: Vec<(Address, u32)>,
+    ) -> Result<(), TreasuryError> {
+        caller.require_auth();
+        if !storage::has_admin(&env) {
+            return Err(TreasuryError::NotInitialized);
+        }
+        let admin = storage::get_admin(&env)?;
+        if caller != admin {
+            return Err(TreasuryError::Unauthorized);
+        }
+        if stakeholders.is_empty() {
+            return Err(TreasuryError::InvalidStakeholderWeights);
+        }
+
+        let mut total: i128 = 0;
+        for (_, share_bps) in stakeholders.iter() {
+            total = total
+                .checked_add(share_bps as i128)
+                .ok_or(TreasuryError::ArithmeticOverflow)?;
+        }
+        if total != BPS_DENOMINATOR {
+            return Err(TreasuryError::InvalidStakeholderWeights);
+        }
+
+        let count = stakeholders.len();
+        storage::set_stakeholders(&env, &stakeholders);
+        events::emit_stakeholders_updated(&env, count);
+        Ok(())
+    }
+
+    /// Return the configured `(stakeholder, share_bps)` list.
+    pub fn get_stakeholders(env: Env) -> Result<Vec<(Address, u32)>, TreasuryError> {
+        storage::get_stakeholders(&env)
+    }
+
+    /// Distribute the treasury's current `token` balance to the configured
+    /// stakeholders, proportionally to their `share_bps` weight (admin only).
+    ///
+    /// Each stakeholder receives `floor(balance * share_bps / 10_000)`. Because
+    /// integer division can leave a small remainder (at most
+    /// `stakeholders.len() - 1` stroops), any dust stays in the treasury's
+    /// `token` balance and rolls into the next distribution rather than being
+    /// lost.
+    ///
+    /// # Errors
+    /// - [`TreasuryError::NotInitialized`] – treasury not initialized.
+    /// - [`TreasuryError::ContractPaused`] – treasury is paused.
+    /// - [`TreasuryError::Unauthorized`] – caller is not the admin.
+    /// - [`TreasuryError::NoStakeholdersConfigured`] – `set_stakeholders` has
+    ///   never been called.
+    /// - [`TreasuryError::InsufficientBalance`] – the current `token` balance is zero.
+    ///
+    /// # Events
+    /// Emits [`events::FeesDistributed`] once per call, summarizing the total
+    /// amount paid out and the remaining balance.
+    pub fn distribute_fees(env: Env, caller: Address, token: Address) -> Result<(), TreasuryError> {
+        caller.require_auth();
+        if !storage::has_admin(&env) {
+            return Err(TreasuryError::NotInitialized);
+        }
+        if storage::is_paused(&env) {
+            return Err(TreasuryError::ContractPaused);
+        }
+        let admin = storage::get_admin(&env)?;
+        if caller != admin {
+            return Err(TreasuryError::Unauthorized);
+        }
+
+        let stakeholders = storage::get_stakeholders(&env)?;
+        if stakeholders.is_empty() {
+            return Err(TreasuryError::NoStakeholdersConfigured);
+        }
+
+        let balance = storage::get_token_balance(&env, &token)?;
+        if balance <= 0 {
+            return Err(TreasuryError::InsufficientBalance);
+        }
+
+        let treasury = env.current_contract_address();
+        let token_client = token::Client::new(&env, &token);
+
+        let mut distributed: i128 = 0;
+        for (stakeholder, share_bps) in stakeholders.iter() {
+            let amount = balance
+                .checked_mul(share_bps as i128)
+                .ok_or(TreasuryError::ArithmeticOverflow)?
+                / BPS_DENOMINATOR;
+            if amount > 0 {
+                token_client.transfer(&treasury, &stakeholder, &amount);
+                distributed = distributed
+                    .checked_add(amount)
+                    .ok_or(TreasuryError::ArithmeticOverflow)?;
+            }
+        }
+
+        let remaining = balance - distributed;
+        storage::set_token_balance(&env, &token, remaining);
+
+        events::emit_fees_distributed(&env, &token, distributed, remaining, stakeholders.len());
         Ok(())
     }
 

--- a/contracts/treasury/src/storage.rs
+++ b/contracts/treasury/src/storage.rs
@@ -1,10 +1,17 @@
 //! Persistent storage helpers for the Vatix Treasury contract.
 
+use crate::error::TreasuryError;
 use soroban_sdk::{contracttype, Address, Env, Vec};
 
 /// Bump this constant whenever the treasury storage layout changes in a breaking way.
 /// `initialize()` writes this value so that future migrations can detect stale deployments.
-pub const STORAGE_VERSION: u32 = 1;
+///
+/// ## Version history
+/// - **v2:** Completed the multi-market `AuthorizedMarkets` registry
+///   (`add_market`/`remove_market`/`list_markets`/`is_authorized_market`) and
+///   added the `Stakeholders` fee-distribution list (#485).
+/// - **v1:** Initial storage layout.
+pub const STORAGE_VERSION: u32 = 2;
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
@@ -24,6 +31,9 @@ pub enum StorageKey {
     TotalCollected,
     /// When `true`, `collect_fee` and `withdraw_fees` are blocked until unpaused.
     Paused,
+    /// Ordered list of `(stakeholder, share_bps)` pairs used by `distribute_fees`
+    /// (#485). `share_bps` values must sum to exactly 10_000.
+    Stakeholders,
 }
 
 // ── Version ───────────────────────────────────────────────────────────────────
@@ -36,6 +46,14 @@ pub fn set_version(env: &Env) {
 
 pub fn get_version(env: &Env) -> Option<u32> {
     env.storage().instance().get(&StorageKey::StorageVersion)
+}
+
+/// Guard every storage accessor against a stale/pre-migration deployment.
+pub fn assert_version(env: &Env) -> Result<(), TreasuryError> {
+    if get_version(env) != Some(STORAGE_VERSION) {
+        return Err(TreasuryError::UpgradeRequired);
+    }
+    Ok(())
 }
 
 // ── Admin ─────────────────────────────────────────────────────────────────────
@@ -59,13 +77,17 @@ pub fn set_admin(env: &Env, admin: &Address) {
 
 // ── Authorized markets registry ───────────────────────────────────────────────
 
-pub fn get_authorized_market(env: &Env) -> Result<Address, TreasuryError> {
+/// Return the full list of markets currently authorized to call `collect_fee`.
+///
+/// Returns an empty list (rather than erroring) when nothing has been
+/// registered yet, mirroring the market contract's `Vec`-storage convention.
+pub fn get_authorized_markets(env: &Env) -> Result<Vec<Address>, TreasuryError> {
     assert_version(env)?;
     Ok(env
         .storage()
         .instance()
-        .get(&StorageKey::AuthorizedMarket)
-        .expect("treasury not initialized"))
+        .get(&StorageKey::AuthorizedMarkets)
+        .unwrap_or_else(|| Vec::new(env)))
 }
 
 pub fn set_authorized_markets(env: &Env, markets: &Vec<Address>) {
@@ -74,8 +96,18 @@ pub fn set_authorized_markets(env: &Env, markets: &Vec<Address>) {
         .set(&StorageKey::AuthorizedMarkets, markets);
 }
 
+/// Return the first registered market — kept for backwards compatibility with
+/// the original single-market `market_contract()` getter.
+pub fn get_authorized_market(env: &Env) -> Result<Address, TreasuryError> {
+    let markets = get_authorized_markets(env)?;
+    markets.get(0).ok_or(TreasuryError::NotInitialized)
+}
+
 pub fn is_authorized_market(env: &Env, market: &Address) -> bool {
-    get_authorized_markets(env).contains(market)
+    match get_authorized_markets(env) {
+        Ok(markets) => markets.contains(market),
+        Err(_) => false,
+    }
 }
 
 // ── Token balance (current, decreasable on withdrawal) ────────────────────────
@@ -140,4 +172,23 @@ pub fn is_paused(env: &Env) -> bool {
 
 pub fn set_paused(env: &Env, paused: bool) {
     env.storage().instance().set(&StorageKey::Paused, &paused);
+}
+
+// ── Stakeholder revenue share (#485) ──────────────────────────────────────────
+
+/// Return the configured `(stakeholder, share_bps)` list, or an empty list if
+/// `set_stakeholders` has never been called.
+pub fn get_stakeholders(env: &Env) -> Result<Vec<(Address, u32)>, TreasuryError> {
+    assert_version(env)?;
+    Ok(env
+        .storage()
+        .instance()
+        .get(&StorageKey::Stakeholders)
+        .unwrap_or_else(|| Vec::new(env)))
+}
+
+pub fn set_stakeholders(env: &Env, stakeholders: &Vec<(Address, u32)>) {
+    env.storage()
+        .instance()
+        .set(&StorageKey::Stakeholders, stakeholders);
 }

--- a/contracts/treasury/src/test.rs
+++ b/contracts/treasury/src/test.rs
@@ -568,3 +568,128 @@ fn unpause_rejects_non_admin() {
     let err = s.client.try_unpause(&rando).unwrap_err().unwrap();
     assert_eq!(err, TreasuryError::Unauthorized);
 }
+
+// ── stakeholder fee distribution (#485) ───────────────────────────────────────
+
+#[test]
+fn set_stakeholders_rejects_weights_not_summing_to_10000() {
+    let s = setup();
+    let a = Address::generate(&s.env);
+    let b = Address::generate(&s.env);
+    let mut stakeholders = soroban_sdk::Vec::new(&s.env);
+    stakeholders.push_back((a, 4_000u32));
+    stakeholders.push_back((b, 4_000u32));
+
+    let err = s
+        .client
+        .try_set_stakeholders(&s.admin, &stakeholders)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, TreasuryError::InvalidStakeholderWeights);
+}
+
+#[test]
+fn set_stakeholders_rejects_non_admin() {
+    let s = setup();
+    let rando = Address::generate(&s.env);
+    let a = Address::generate(&s.env);
+    let mut stakeholders = soroban_sdk::Vec::new(&s.env);
+    stakeholders.push_back((a, 10_000u32));
+
+    let err = s
+        .client
+        .try_set_stakeholders(&rando, &stakeholders)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, TreasuryError::Unauthorized);
+}
+
+#[test]
+fn distribute_fees_pays_out_by_share() {
+    let s = setup();
+    fund_treasury(&s, 1_000_000);
+    s.client.collect_fee(&s.market, &s.token, &1u32, &1_000_000i128);
+
+    let stakeholder_a = Address::generate(&s.env);
+    let stakeholder_b = Address::generate(&s.env);
+    let mut stakeholders = soroban_sdk::Vec::new(&s.env);
+    stakeholders.push_back((stakeholder_a.clone(), 7_000u32));
+    stakeholders.push_back((stakeholder_b.clone(), 3_000u32));
+    s.client.set_stakeholders(&s.admin, &stakeholders);
+
+    s.client.distribute_fees(&s.admin, &s.token);
+
+    assert_eq!(TokenClient::new(&s.env, &s.token).balance(&stakeholder_a), 700_000);
+    assert_eq!(TokenClient::new(&s.env, &s.token).balance(&stakeholder_b), 300_000);
+    assert_eq!(s.client.token_balance(&s.token), 0);
+    // Cumulative fees stay monotone — distribution only moves the live balance.
+    assert_eq!(s.client.get_cumulative_fees(&s.token), 1_000_000);
+}
+
+#[test]
+fn distribute_fees_rejects_without_stakeholders_configured() {
+    let s = setup();
+    fund_treasury(&s, 500_000);
+    s.client.collect_fee(&s.market, &s.token, &1u32, &500_000i128);
+
+    let err = s
+        .client
+        .try_distribute_fees(&s.admin, &s.token)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, TreasuryError::NoStakeholdersConfigured);
+}
+
+#[test]
+fn distribute_fees_rejects_zero_balance() {
+    let s = setup();
+    let stakeholder = Address::generate(&s.env);
+    let mut stakeholders = soroban_sdk::Vec::new(&s.env);
+    stakeholders.push_back((stakeholder, 10_000u32));
+    s.client.set_stakeholders(&s.admin, &stakeholders);
+
+    let err = s
+        .client
+        .try_distribute_fees(&s.admin, &s.token)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, TreasuryError::InsufficientBalance);
+}
+
+#[test]
+fn distribute_fees_rejects_non_admin() {
+    let s = setup();
+    fund_treasury(&s, 500_000);
+    s.client.collect_fee(&s.market, &s.token, &1u32, &500_000i128);
+    let stakeholder = Address::generate(&s.env);
+    let mut stakeholders = soroban_sdk::Vec::new(&s.env);
+    stakeholders.push_back((stakeholder, 10_000u32));
+    s.client.set_stakeholders(&s.admin, &stakeholders);
+
+    let rando = Address::generate(&s.env);
+    let err = s
+        .client
+        .try_distribute_fees(&rando, &s.token)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, TreasuryError::Unauthorized);
+}
+
+#[test]
+fn distribute_fees_blocked_while_paused() {
+    let s = setup();
+    fund_treasury(&s, 500_000);
+    s.client.collect_fee(&s.market, &s.token, &1u32, &500_000i128);
+    let stakeholder = Address::generate(&s.env);
+    let mut stakeholders = soroban_sdk::Vec::new(&s.env);
+    stakeholders.push_back((stakeholder, 10_000u32));
+    s.client.set_stakeholders(&s.admin, &stakeholders);
+
+    s.client.pause(&s.admin);
+    let err = s
+        .client
+        .try_distribute_fees(&s.admin, &s.token)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, TreasuryError::ContractPaused);
+}


### PR DESCRIPTION
Closes #485
Closes #487
Closes #488
Closes #489

## Summary

**#487 — Created timestamp in market struct**
`Market.created_at` (populated from `env.ledger().timestamp()` in `initialize_market`) already exists on `dev` — verified end-to-end (struct field, population, and an existing `test.rs` assertion). No code change needed; `get_market()` already exposes the whole struct so no separate getter is required.

**#488 — Fallback Ed25519 when adapter disabled**
`resolve_market` previously hard-failed with `UnauthorizedOracle` for any market configured with `AdapterType::Reflector`/`AdapterType::Pyth`, since the richer on-chain adapter integration (`oracle_adapter.rs`) is feature-gated off and not wired into the real dispatch (tracked separately under #139). Added a per-adapter-type `enabled` flag (new `StorageKey::AdapterEnabled`, defaults to `false`) plus an admin-only `set_adapter_enabled` instruction. While disabled (the default), `verify_market_outcome` now falls back to direct Ed25519 verification of the proof against the market's `oracle_pubkey`, reusing the identical `construct_oracle_message`/`verify_oracle_signature` path as the primary Ed25519 adapter — so these markets aren't permanently stuck. Bumps market `STORAGE_VERSION` 3 → 4 (new storage key = breaking layout change, no migration needed per existing convention).

**#489 — Signature malleability hardening**
Confirmed the scheme is genuinely Ed25519 (`ed25519-dalek` verify), so ECDSA-style low-S hardening doesn't apply. Signature length is already strictly enforced by the `BytesN<64>`/`BytesN::try_from` typed boundaries, and the signed payload already binds `market_id` (preventing cross-market replay). The actual gap found by reading the real propose/verify flow: the resolution contract's `propose()` cross-contract-calls a `verify_signature` entrypoint on the market contract that never existed — so every `propose()` call would trap ("function not found"), meaning signature verification in the propose path was completely non-functional despite issue #328 claiming it was done. Added `MarketContract::verify_signature(market_id, outcome, signature)`, a read-only wrapper around `oracle::verify_market_outcome` (so it also benefits from the #488 fallback), fixing the broken cross-contract call.

**#485 — Fee distribution to stakeholders**
Added `set_stakeholders(admin, Vec<(Address, share_bps)>)` (validates shares sum to exactly 10_000 bps) and `distribute_fees(admin, token)` (admin-only; pays each stakeholder `floor(balance * share_bps / 10_000)` via the existing `token::Client` transfer pattern, decrements the token balance by the amount actually distributed, blocked while paused, emits one `FeesDistributed` event per call). Also added a `get_stakeholders()` getter.

While implementing #485 it became clear the treasury contract does not currently compile on `dev` — same class of bugs the (still-unmerged) #609 batch already fixed in the treasury, but since #609 isn't merged, `dev` still has them:
- `storage.rs` referenced `StorageKey::AuthorizedMarket` (singular) while only `AuthorizedMarkets` (plural, unused) was declared.
- `assert_version` was called throughout `storage.rs` but never defined.
- `TreasuryError` was used throughout `storage.rs` without being imported.
- `lib.rs`'s `remove_market` referenced an undefined `new_market_contract` variable (the parameter is named `market_contract`).
- The single-market model was never actually completed into the `Vec`-backed registry that `contracts/treasury/src/test.rs` already has a full test suite for (`add_market`/`remove_market`/`list_markets`/`is_authorized_market`).

Fixed by completing the multi-market registry (`AuthorizedMarkets: Vec<Address>`, idempotent `add_market`, `remove_market` erroring `CallerNotMarket` if not registered, `list_markets`, `is_authorized_market`), with `collect_fee` now checking registry membership instead of a single address. Kept `market_contract()` (returns first registered market) and added `set_market_contract` (full-registry rotation) for backwards compatibility with `tests/client_entrypoints_test.rs`, which already exercises that exact rotate-and-revoke behavior. Bumps treasury `STORAGE_VERSION` 1 → 2.

## Notes
- Branched off current `origin/dev`; PR #609 (compact position layout / fee waivers / oracle rotation) is still open/unmerged, so this PR does not include or depend on it.
- Also noticed (but left untouched, out of scope for these 4 issues): `contracts/market/src/error.rs`'s `ContractError` enum is missing `MarketClosedToDeposits`/`InvalidFeeRate`/`FeeCapExceeded` variants that `deposit.rs`/`lib.rs` already reference, and numerous pre-existing `Market { .. }` struct literals across `storage.rs`/`settlement.rs`/`withdraw.rs`/etc. are missing the `closed_to_deposits` field — both look like fallout from other in-flight/merged feature branches and are unrelated to oracle/treasury logic touched here.