### PR TITLE
feat(market/resolution): net position view, paginated settlement, fee-rate timelock, reject resolved-market proposals

### DIFF
--- a/contracts/market/src/error.rs
+++ b/contracts/market/src/error.rs
@@ -55,6 +55,12 @@ pub enum ContractError {
     /// Withdraw attempted before the cooldown period since the last deposit has elapsed.
     WithdrawCooldownActive = 6,
 
+    /// Deposit attempted into a market that an admin has closed to new deposits.
+    ///
+    /// Set via the `closed_to_deposits` flag; trading, withdrawals, and
+    /// settlement remain unaffected.
+    MarketClosedToDeposits = 7,
+
     // ========== Position Errors (10-19) ==========
     /// User does not have enough collateral locked to perform this operation.
     ///
@@ -132,6 +138,15 @@ pub enum ContractError {
     /// or any special/reserved address.
     InvalidAdmin = 35,
 
+    /// Deposit amount is below the configured minimum deposit.
+    BelowMinDeposit = 36,
+
+    /// Market metadata URI is invalid (e.g. exceeds the maximum length).
+    InvalidMetadataUri = 37,
+
+    /// Proposed fee rate exceeds the configured fee cap.
+    FeeCapExceeded = 38,
+
     // ========== Authorization Errors (40-49) ==========
     /// Caller is not authorized to perform this action.
     ///
@@ -202,6 +217,13 @@ pub enum ContractError {
     /// A reentrant call was detected (e.g. a token contract calling back into
     /// `deposit_collateral` before the initial call has finished).
     ReentrantCall = 100,
+
+    // ========== Timelock Errors (110-119) ==========
+    /// `execute_fee_rate_change` was called but no fee rate change is pending.
+    NoPendingFeeChange = 110,
+
+    /// `execute_fee_rate_change` was called before the timelock delay elapsed.
+    TimelockNotElapsed = 111,
 
 }
 

--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -847,6 +847,46 @@ pub fn emit_treasury_set(env: &Env, treasury: &Address) {
     .publish(env);
 }
 
+/// Emitted when an admin proposes a new withdrawal fee rate (Issue #496).
+/// The change does not take effect until `effective_at` and
+/// `execute_fee_rate_change` is called.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct FeeRateChangeProposed {
+    #[topic]
+    pub version: u32,
+    pub new_rate_bps: i128,
+    pub effective_at: u64,
+}
+
+pub fn emit_fee_rate_change_proposed(env: &Env, new_rate_bps: i128, effective_at: u64) {
+    FeeRateChangeProposed {
+        version: EVENT_VERSION,
+        new_rate_bps,
+        effective_at,
+    }
+    .publish(env);
+}
+
+/// Emitted once a previously-proposed fee rate change actually takes effect.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct FeeRateChangeExecuted {
+    #[topic]
+    pub version: u32,
+    pub new_rate_bps: i128,
+    pub executed_at: u64,
+}
+
+pub fn emit_fee_rate_change_executed(env: &Env, new_rate_bps: i128, executed_at: u64) {
+    FeeRateChangeExecuted {
+        version: EVENT_VERSION,
+        new_rate_bps,
+        executed_at,
+    }
+    .publish(env);
+}
+
 #[contractevent]
 #[derive(Clone, Debug)]
 pub struct AdminRenounceProposedEvent {

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -52,6 +52,8 @@
 //! | `ThresholdSigners`                  | `Vec<BytesN<32>>` | Multi-signer quorum public keys (#378)           |
 //! | `ThresholdQuorum`                   | `u32`           | Min valid signatures required for resolution (#378)|
 //! | `FeeWaivers`                        | `Vec<Address>`  | Admin-managed fee-exempt address list (#483)       |
+//! | `MarketParticipants(u32)`           | `Vec<Address>`  | Every address that ever held a position (#495)     |
+//! | `PendingFeeRate`                    | `PendingFeeRateChange` | Timelocked fee rate change awaiting execution (#496) |
 
 mod deposit;
 mod error;
@@ -79,6 +81,11 @@ use crate::types::{AdapterType, Market, MarketStatus, Position};
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String};
 use vatix_outcome_token_contract::{OutcomeTokenContractClient, types::TokenKind};
 use vatix_resolution_contract::types::CandidateStatus as ResolutionCandidateStatus;
+
+/// Delay, in seconds, an admin-proposed fee rate change must wait before it
+/// can be applied via `execute_fee_rate_change` (Issue #496). 48 hours gives
+/// integrators and users advance notice of a fee change before it lands.
+pub const FEE_RATE_TIMELOCK_SECONDS: u64 = 172_800;
 
 #[contract]
 pub struct MarketContract;
@@ -643,7 +650,9 @@ impl MarketContract {
         // 4. Enforce that deposited collateral covers any increase in the lock.
         //    Negative-share deltas are left for positions::update_position to
         //    reject (it also emits a PositionLimitExceeded event).
-        let position = storage::get_position(&env, market_id, &user)?
+        let existing_position = storage::get_position(&env, market_id, &user)?;
+        let position = existing_position
+            .clone()
             .unwrap_or_else(|| Position::new_empty(market_id, user.clone()));
         let new_yes = position.yes_shares + yes_delta;
         let new_no = position.no_shares + no_delta;
@@ -666,7 +675,14 @@ impl MarketContract {
                     positions::PositionError::InvalidMarketPrice => ContractError::InvalidPrice,
                 })?;
 
-        // 5a. Mint or burn outcome tokens for the updated position.
+        // 5a. Track first-time participants so the market can later be
+        //     settled page-by-page via `settle_positions_page` (Issue #495)
+        //     without requiring an off-chain index of every trader.
+        if existing_position.is_none() {
+            storage::add_market_participant(&env, market_id, &user);
+        }
+
+        // 5b. Mint or burn outcome tokens for the updated position.
         if let Some(outcome_token_address) = storage::get_outcome_token_contract(&env) {
             let token_client = OutcomeTokenContractClient::new(&env, &outcome_token_address);
             if yes_delta > 0 {
@@ -745,6 +761,34 @@ impl MarketContract {
         settlement::batch_settle_positions(&env, market_id, users)
     }
 
+    /// Settle a bounded page of a resolved market's participants (Issue #495).
+    ///
+    /// Unlike [`batch_settle_positions`], the caller does not supply the user
+    /// list — it is drawn from the on-chain participant registry that
+    /// [`Self::update_position`] maintains, so a market with more positions
+    /// than fit one transaction's resource budget can be fully settled by
+    /// repeated calls, advancing `start_index` to the returned next index
+    /// each time until `is_complete` is `true`.
+    ///
+    /// # Returns
+    /// `(total_payout_this_page, next_index, is_complete)`
+    pub fn settle_positions_page(
+        env: Env,
+        market_id: u32,
+        start_index: u32,
+        limit: u32,
+    ) -> Result<(i128, u32, bool), ContractError> {
+        settlement::settle_positions_page(&env, market_id, start_index, limit)
+    }
+
+    /// Number of distinct addresses that have ever held a position in a market.
+    ///
+    /// Useful to determine how many [`Self::settle_positions_page`] calls are
+    /// needed to fully settle a resolved market.
+    pub fn get_market_participant_count(env: Env, market_id: u32) -> u32 {
+        storage::get_market_participant_count(&env, market_id)
+    }
+
     /// Register the treasury contract address for protocol fee routing.
     ///
     /// Once set, any non-zero withdrawal fee computed during
@@ -771,10 +815,14 @@ impl MarketContract {
         Ok(())
     }
 
-    /// Set the withdrawal fee rate in basis points (0–10_000).
+    /// Propose a new withdrawal fee rate in basis points (0–10_000), subject
+    /// to a timelock (Issue #496) before it takes effect.
     ///
-    /// Only the stored admin may call this. A rate of 0 disables fees.
-    /// The rate must not exceed the configured fee cap (see `set_fee_cap`).
+    /// Only the stored admin may call this. The change does not apply
+    /// immediately — call [`Self::execute_fee_rate_change`] once
+    /// [`FEE_RATE_TIMELOCK_SECONDS`] have elapsed to actually apply it.
+    /// Proposing again before the pending change executes overwrites it with
+    /// a freshly-timed change.
     ///
     /// # Errors
     /// - [`ContractError::NotAdmin`] — `admin` is not the stored admin.
@@ -796,8 +844,41 @@ impl MarketContract {
         if fee_rate_bps > cap {
             return Err(ContractError::FeeCapExceeded);
         }
-        storage::set_fee_rate_bps(&env, fee_rate_bps);
+
+        let effective_at = env.ledger().timestamp() + FEE_RATE_TIMELOCK_SECONDS;
+        storage::set_pending_fee_rate_change(
+            &env,
+            &crate::types::PendingFeeRateChange {
+                new_rate_bps: fee_rate_bps,
+                effective_at,
+            },
+        );
+        events::emit_fee_rate_change_proposed(&env, fee_rate_bps, effective_at);
         Ok(())
+    }
+
+    /// Apply a previously-proposed fee rate change once its timelock has
+    /// elapsed (Issue #496). Callable by anyone — the timelock itself is the
+    /// access control; there is nothing sensitive about who triggers it.
+    ///
+    /// # Errors
+    /// - [`ContractError::NoPendingFeeChange`] — no change is currently pending.
+    /// - [`ContractError::TimelockNotElapsed`] — `effective_at` has not passed yet.
+    pub fn execute_fee_rate_change(env: Env) -> Result<i128, ContractError> {
+        let pending = storage::get_pending_fee_rate_change(&env)
+            .ok_or(ContractError::NoPendingFeeChange)?;
+        if env.ledger().timestamp() < pending.effective_at {
+            return Err(ContractError::TimelockNotElapsed);
+        }
+        storage::set_fee_rate_bps(&env, pending.new_rate_bps);
+        storage::clear_pending_fee_rate_change(&env);
+        events::emit_fee_rate_change_executed(&env, pending.new_rate_bps, env.ledger().timestamp());
+        Ok(pending.new_rate_bps)
+    }
+
+    /// Return the currently pending fee rate change, if any (Issue #496).
+    pub fn get_pending_fee_rate_change(env: Env) -> Option<crate::types::PendingFeeRateChange> {
+        storage::get_pending_fee_rate_change(&env)
     }
 
     // ========== Fee Waiver List (#483) ==========
@@ -1283,6 +1364,34 @@ impl MarketContract {
         user: Address,
     ) -> Result<Option<Position>, ContractError> {
         storage::get_position(&env, market_id, &user)
+    }
+
+    /// Return a user's net position across YES and NO shares in a market.
+    ///
+    /// Positive => net long YES, negative => net long NO, zero => hedged (or
+    /// no position at all — a user with no stored `Position` is treated as
+    /// fully hedged at `0`).
+    ///
+    /// # Arguments
+    /// * `market_id` - Market identifier
+    /// * `user` - User address to query
+    ///
+    /// # Example
+    /// ```ignore
+    /// let net = client.get_net_position(&market_id, &user);
+    /// // net > 0  => user is net long YES
+    /// // net < 0  => user is net long NO
+    /// ```
+    pub fn get_net_position(
+        env: Env,
+        market_id: u32,
+        user: Address,
+    ) -> Result<i128, ContractError> {
+        let position = storage::get_position(&env, market_id, &user)?;
+        Ok(match position {
+            Some(p) => positions::calculate_net_position(p.yes_shares, p.no_shares),
+            None => 0,
+        })
     }
 
     /// Return the current fee cap in basis points (defaults to 10_000 when unset).

--- a/contracts/market/src/settlement.rs
+++ b/contracts/market/src/settlement.rs
@@ -270,6 +270,93 @@ pub fn batch_settle_positions(
     Ok(total_payout)
 }
 
+/// Settle a bounded page of a market's tracked participants (Issue #495).
+///
+/// Markets with more positions than fit comfortably in one transaction's
+/// resource budget can be fully settled by repeatedly calling this with
+/// `start_index` advanced to the returned `next_index`, until the returned
+/// `is_complete` flag is `true`. Unlike [`batch_settle_positions`], the
+/// caller does not need to know or supply the list of participant
+/// addresses — it is read from the on-chain participant registry that
+/// [`crate::MarketContract::update_position`] maintains.
+///
+/// # Arguments
+/// * `env` - Contract environment
+/// * `market_id` - Market identifier (must be resolved)
+/// * `start_index` - Index into the market's participant list to resume from
+/// * `limit` - Maximum number of participants to process in this call
+///
+/// # Returns
+/// `(total_payout_this_page, next_index, is_complete)` — `is_complete` is
+/// `true` once `next_index` has reached the end of the participant list.
+///
+/// # Errors
+/// - [`ContractError::MarketNotFound`] – the market does not exist
+/// - [`ContractError::MarketNotResolved`] – the market is not resolved
+pub fn settle_positions_page(
+    env: &Env,
+    market_id: u32,
+    start_index: u32,
+    limit: u32,
+) -> Result<(i128, u32, bool), ContractError> {
+    let market = storage::get_market(env, market_id)?.ok_or(ContractError::MarketNotFound)?;
+    if market.status != MarketStatus::Resolved {
+        return Err(ContractError::MarketNotResolved);
+    }
+
+    let participants = storage::get_market_participants(env, market_id);
+    let total = participants.len();
+
+    if start_index >= total {
+        return Ok((0, total, true));
+    }
+
+    let end_index = start_index.saturating_add(limit).min(total);
+
+    let mut total_payout: i128 = 0;
+    let mut settled_users: Vec<Address> = Vec::new(env);
+    let mut settled_payouts: Vec<i128> = Vec::new(env);
+
+    for i in start_index..end_index {
+        let user = participants.get(i).expect("index within bounds");
+
+        let Ok(Some(mut position)) = storage::get_position(env, market_id, &user) else {
+            continue;
+        };
+
+        let Ok(payout) = compute_settlement(&mut position, &market) else {
+            continue;
+        };
+
+        if storage::set_position(env, market_id, &user, &position).is_err() {
+            continue;
+        }
+
+        if payout > 0 {
+            let contract_address = env.current_contract_address();
+            let token_client = TokenClient::new(env, &market.collateral_token);
+            token_client.transfer(&contract_address, &user, &payout);
+        }
+
+        total_payout = total_payout.saturating_add(payout);
+        settled_users.push_back(user);
+        settled_payouts.push_back(payout);
+    }
+
+    if !settled_users.is_empty() {
+        let settled_at = env.ledger().timestamp();
+        crate::events::emit_positions_batch_settled(
+            env,
+            market_id,
+            &settled_users,
+            &settled_payouts,
+            settled_at,
+        );
+    }
+
+    Ok((total_payout, end_index, end_index >= total))
+}
+
 /// Calculate what a user would receive if they settled now
 ///
 /// # Arguments

--- a/contracts/market/src/storage.rs
+++ b/contracts/market/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::error::ContractError;
-use crate::types::{Market, Position};
+use crate::types::{Market, PendingFeeRateChange, Position};
 use soroban_sdk::{contracttype, Address, BytesN, Env, Vec};
 
 /// Bump this constant whenever the storage layout changes in a breaking way.
@@ -72,6 +72,13 @@ pub enum StorageKey {
     /// deposit's external token transfer is in flight so a reentrant call
     /// back into `deposit_collateral` from that transfer is rejected.
     DepositLock,
+    /// Ordered list of every distinct address that has ever held a position
+    /// in a market (Issue #495). Enables paginated settlement of markets with
+    /// too many positions to settle — or even enumerate off-chain — in a
+    /// single transaction.
+    MarketParticipants(u32),
+    /// Pending fee-rate change awaiting its timelock delay (Issue #496).
+    PendingFeeRate,
 }
 
 // --- Version helpers ---
@@ -139,6 +146,34 @@ pub fn set_position(
 pub fn has_position(env: &Env, market_id: u32, user: &Address) -> Result<bool, ContractError> {
     assert_version(env)?;
     Ok(env.storage().persistent().has(&StorageKey::Position(market_id, user.clone())))
+}
+
+// --- Market Participants (Issue #495) ---
+
+/// Return the ordered list of every address that has ever held a position
+/// in `market_id`. Empty if the market has no positions yet.
+pub fn get_market_participants(env: &Env, market_id: u32) -> Vec<Address> {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::MarketParticipants(market_id))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Record `user` as a participant of `market_id` if not already tracked.
+/// Idempotent — safe to call on every position update.
+pub fn add_market_participant(env: &Env, market_id: u32, user: &Address) {
+    let mut participants = get_market_participants(env, market_id);
+    if !participants.iter().any(|p| &p == user) {
+        participants.push_back(user.clone());
+        env.storage()
+            .persistent()
+            .set(&StorageKey::MarketParticipants(market_id), &participants);
+    }
+}
+
+/// Number of distinct addresses that have ever held a position in `market_id`.
+pub fn get_market_participant_count(env: &Env, market_id: u32) -> u32 {
+    get_market_participants(env, market_id).len()
 }
 
 // --- Admin Storage ---
@@ -272,6 +307,20 @@ pub fn get_fee_rate_bps(env: &Env) -> i128 {
 
 pub fn set_fee_rate_bps(env: &Env, fee_rate_bps: i128) {
     env.storage().persistent().set(&StorageKey::FeeRateBps, &fee_rate_bps);
+}
+
+// --- Pending Fee Rate Change / Timelock (Issue #496) ---
+
+pub fn get_pending_fee_rate_change(env: &Env) -> Option<PendingFeeRateChange> {
+    env.storage().persistent().get(&StorageKey::PendingFeeRate)
+}
+
+pub fn set_pending_fee_rate_change(env: &Env, pending: &PendingFeeRateChange) {
+    env.storage().persistent().set(&StorageKey::PendingFeeRate, pending);
+}
+
+pub fn clear_pending_fee_rate_change(env: &Env) {
+    env.storage().persistent().remove(&StorageKey::PendingFeeRate);
 }
 
 

--- a/contracts/market/src/types.rs
+++ b/contracts/market/src/types.rs
@@ -85,6 +85,17 @@ pub struct Position {
     pub is_settled: bool,
 }
 
+/// A fee-rate change awaiting its timelock delay before it can take effect
+/// (Issue #496). Only one change may be pending at a time; proposing a new
+/// one overwrites any earlier pending change.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct PendingFeeRateChange {
+    pub new_rate_bps: i128,
+    /// Ledger timestamp at or after which `execute_fee_rate_change` may apply this change.
+    pub effective_at: u64,
+}
+
 impl Position {
     /// Create an empty position for a user in a market.
     /// Used when a position has not been previously recorded in storage.

--- a/contracts/resolution/src/error.rs
+++ b/contracts/resolution/src/error.rs
@@ -16,6 +16,20 @@ pub enum ContractError {
     SignatureExpired = 9,
     /// The provided signature expiry timestamp is invalid (e.g. in the past).
     InvalidSignatureExpiry = 10,
+    /// The underlying market is already resolved (or canceled) and can no
+    /// longer accept a new resolution proposal (Issue #497).
+    MarketAlreadyResolved = 11,
+    /// `appeal` was called on a candidate that is not currently `Challenged`.
+    CandidateNotChallenged = 12,
+    /// A candidate has already been re-proposed `MAX_APPEAL_ROUNDS` times.
+    AppealLimitExceeded = 13,
+    /// `propose`'s `bond_amount` is below `MIN_BOND_AMOUNT`.
+    InsufficientBond = 14,
+    /// A proposer/challenger does not have enough deposited collateral for
+    /// the requested operation.
+    InsufficientCollateral = 15,
+    /// A collateral amount is invalid (e.g. zero or negative).
+    InvalidCollateral = 16,
     Unauthorized = 40,
     NotAdmin = 41,
     AlreadyInitialized = 42,

--- a/contracts/resolution/src/lib.rs
+++ b/contracts/resolution/src/lib.rs
@@ -37,7 +37,7 @@ pub mod types;
 mod test;
 
 use crate::error::ContractError;
-use crate::types::{CandidateStatus, ResolutionCandidate, ResolutionConfig};
+use crate::types::{CandidateStatus, MarketStatus, ResolutionCandidate, ResolutionConfig};
 use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, String};
 use soroban_sdk::{IntoVal, Symbol, Val, Vec};
 
@@ -169,6 +169,14 @@ impl ResolutionContract {
             return Err(ContractError::CandidateAlreadyExists);
         }
 
+        // Reject proposals for a market that is already resolved or canceled
+        // (Issue #497). `CandidateAlreadyExists` above only catches markets
+        // this contract itself has already finalized — a market resolved
+        // through some other path (e.g. an admin-forced `resolve_market`)
+        // would otherwise have no local candidate record to block a
+        // now-meaningless new proposal.
+        require_market_active(&env, &config, market_id)?;
+
         // Verify the provided oracle signature by delegating to the market
         // contract's `verify_signature` entrypoint. This ensures proposals are
         // rejected early if the signature does not verify.
@@ -286,6 +294,11 @@ impl ResolutionContract {
         if candidate.appeal_round >= MAX_APPEAL_ROUNDS {
             return Err(ContractError::AppealLimitExceeded);
         }
+
+        // Defense in depth (Issue #497): the market should be unresolved for
+        // any Challenged candidate under normal operation, but re-check in
+        // case it was resolved/canceled out of band since the challenge.
+        require_market_active(&env, &config, candidate.market_id)?;
 
         // Re-verify the new signed outcome the same way `propose` does.
         let args: Vec<Val> = soroban_sdk::vec![&env,
@@ -471,4 +484,25 @@ fn get_collateral_token(env: &Env, config: &ResolutionConfig, market_id: u32) ->
         &Symbol::new(env, "get_collateral_token"),
         soroban_sdk::vec![env, market_id.into_val(env)],
     )
+}
+
+/// Reject the call if `market_id` is not `Active` on the registered market
+/// contract (Issue #497). Guards against accepting a new resolution proposal
+/// or appeal for a market that has already been resolved or canceled through
+/// some other path (e.g. an admin-forced `resolve_market` call that bypassed
+/// this contract's `finalize`).
+fn require_market_active(
+    env: &Env,
+    config: &ResolutionConfig,
+    market_id: u32,
+) -> Result<(), ContractError> {
+    let status: MarketStatus = env.invoke_contract(
+        &config.market_contract,
+        &Symbol::new(env, "get_market_status"),
+        soroban_sdk::vec![env, market_id.into_val(env)],
+    );
+    if status != MarketStatus::Active {
+        return Err(ContractError::MarketAlreadyResolved);
+    }
+    Ok(())
 }

--- a/contracts/resolution/src/types.rs
+++ b/contracts/resolution/src/types.rs
@@ -1,5 +1,19 @@
 use soroban_sdk::{contracttype, Address, BytesN, String};
 
+/// Local mirror of `vatix_market::types::MarketStatus` (Issue #497).
+///
+/// The resolution crate cannot depend on the market crate directly (the
+/// market crate already depends on this one), so this enum must be kept in
+/// variant-for-variant sync with the market contract's `MarketStatus` for
+/// cross-contract calls to `get_market_status` to decode correctly.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum MarketStatus {
+    Active,
+    Resolved,
+    Canceled,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub enum CandidateStatus {


### PR DESCRIPTION
Closes #494
Closes #495
Closes #496
Closes #497

## #494 — Net position across YES and NO
Added `get_net_position(market_id, user)` view entrypoint on the market contract, returning `yes_shares - no_shares` (positive = net long YES, negative = net long NO, `0` for hedged or no position). Reuses the existing `positions::calculate_net_position` helper that was previously untenanted by any public entrypoint.

## #495 — Partial settlement for large markets
`update_position` now records every first-time participant in a per-market on-chain list (`MarketParticipants(market_id)`). Added `settle_positions_page(market_id, start_index, limit)`, which settles a bounded slice of that list per call and returns `(payout, next_index, is_complete)` so a market with more positions than fit one transaction's resource budget can be fully settled via repeated calls — without the caller needing to supply or off-chain-index the user list themselves (unlike the existing `batch_settle_positions`). Added `get_market_participant_count` to size the pagination loop.

## #496 — Timelock on fee rate changes
`set_fee_rate` now stores a *pending* fee-rate change with a 48h (`FEE_RATE_TIMELOCK_SECONDS`) effective timestamp instead of applying immediately, emitting `FeeRateChangeProposed`. A new `execute_fee_rate_change` (callable by anyone — the timelock itself is the access control) applies it once the delay has elapsed, emitting `FeeRateChangeExecuted`. Added `get_pending_fee_rate_change` view.

## #497 — Reject resolved market mutations
The resolution contract's `propose()` and `appeal()` now cross-check the underlying market's on-chain status (via a local `MarketStatus` mirror enum + `invoke_contract` to `get_market_status`, mirroring the same pattern the outcome-token contract already uses) and reject with `MarketAlreadyResolved` if the market isn't `Active`. Previously only `CandidateAlreadyExists` guarded this, which doesn't catch a market resolved through a path other than this contract's own `finalize()` (e.g. an admin-forced `resolve_market` call).

## Also fixed: pre-existing undefined error variants blocking compilation
While implementing the above, found the market and resolution crates on `dev` both reference several `ContractError` variants in real (non-test) code that were never actually added to their error enums — meaning neither crate currently compiles as-is, independent of anything in this PR:

- **market crate**: `MarketClosedToDeposits` (used in `deposit.rs`), `FeeCapExceeded` (used in `set_fee_rate`), `InvalidMetadataUri` and `BelowMinDeposit` (used in `validation.rs`) were all referenced but undefined.
- **resolution crate**: `CandidateNotChallenged`, `AppealLimitExceeded`, `InsufficientBond` (used in `propose`/`appeal`), plus `InsufficientCollateral`/`InvalidCollateral` (used in the collateral entrypoints) were all referenced but undefined.

Added all of these to their respective `ContractError` enums with fresh, non-colliding discriminants and doc comments, since otherwise this PR (and anything else) would be built on a foundation that can't compile. Note: a couple of `#[cfg(test)]` modules elsewhere still assert stale discriminant values or construct struct literals missing newer fields (e.g. `closed_to_deposits` on `Market`) — those are pre-existing test-fixture drift unrelated to these 4 issues and are left as-is.

No tests/builds were run — code was not verified to compile.