### PR TITLE
feat:  docs/ci: bindings drift check, testnet registry, smoke test, event reference 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,20 @@ jobs:
           echo "Bindings output:"
           ls -lh apps/web/lib/contracts/
 
+      # Fails the build if the bindings just generated above differ from what
+      # is committed in git. This catches drift where a contributor changed a
+      # contract's public interface (or the generator itself) without
+      # regenerating and committing the bindings under apps/web/lib/contracts/.
+      - name: Fail on stale committed bindings
+        run: |
+          if ! git diff --exit-code -- apps/web/lib/contracts; then
+            echo ""
+            echo "ERROR: Generated TypeScript bindings differ from what is committed."
+            echo "Run 'pnpm build:bindings' locally and commit the resulting changes"
+            echo "under apps/web/lib/contracts/."
+            exit 1
+          fi
+
       - name: Lint web app
         run: pnpm --filter web lint
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ The Market Contract still owns the final `resolve_market(market_id, outcome, sig
 
 ## Event Catalog
 
+> For the complete, up-to-date field reference across **all four contracts** (Market, Treasury, Resolution, Outcome Token), see [`docs/events-reference.md`](docs/events-reference.md) — the canonical schema reference for off-chain indexers. The table below covers a subset of Market events for a quick overview.
+
 The Market Contract emits the following events for off-chain indexing and tracking:
 
 | Event | Topics | Fields | Description |
@@ -231,6 +233,29 @@ bash scripts/deploy.sh
 
 > Requires Stellar CLI and a funded account. Set `SOROBAN_NETWORK` and `SOROBAN_ACCOUNT` env vars before running.
 
+### Testnet contract registry
+
+[`deployments/testnet.json`](deployments/testnet.json) (schema documented in [`deployments/README.md`](deployments/README.md)) is the single source of truth for testnet contract IDs, network passphrase, and RPC URL. After deploying a contract, record its ID there so `apps/web` and the scripts below can pick it up. Until a real deploy happens, `contractId` fields are empty-string placeholders.
+
+### Testnet smoke test
+
+`scripts/testnet-smoke.sh` performs a **read-only, simulate-only** invocation (`stellar contract invoke --send=no`) against a deployed Market contract on testnet, to confirm it's reachable — no signing or secret key is required.
+
+```bash
+pnpm testnet:smoke
+# or
+bash scripts/testnet-smoke.sh
+```
+
+**What it needs:**
+- The `stellar` CLI on PATH
+- A market contract ID, resolved from (in order): the `MARKET_CONTRACT_ID` env var, or `.contracts.market.contractId` in `deployments/testnet.json`
+- RPC URL / network passphrase, resolved from `SOROBAN_RPC_URL` / `NETWORK_PASSPHRASE` env vars, else the registry file, else the default Stellar testnet values (`https://soroban-testnet.stellar.org`, `Test SDF Network ; September 2015`)
+
+If no contract ID is configured, or the `stellar` CLI isn't installed, the script prints a message and exits `0` (guard mode) instead of failing — it's safe to run on a fresh checkout before any testnet deployment exists.
+
+> **Freighter is not needed here.** Freighter (the browser wallet) is only required for *signed* testnet interactions from the web app; this script never signs or submits a transaction.
+
 ### Build Verification
 
 To verify your local WASM matches what CI produces, compare hashes:
@@ -300,6 +325,22 @@ Example artifacts:
 - `vatix_treasury_contract.wasm`
 - `vatix_outcome_token_contract.wasm`
 - `vatix_resolution_contract.wasm`
+
+### Regenerating contract bindings
+
+The web app consumes auto-generated TypeScript bindings for each contract, committed under [`apps/web/lib/contracts/`](apps/web/lib/contracts/README.md). Regenerate them locally whenever a contract's public interface changes:
+
+```bash
+pnpm build:bindings
+```
+
+**Prerequisites:**
+- Stellar CLI **v21+** on PATH
+- Rust `wasm32-unknown-unknown` and `wasm32v1-none` targets installed
+
+This runs `scripts/generate-bindings.ts`, which builds every contract to WASM and generates fresh TypeScript clients into `apps/web/lib/contracts/`. **Commit the resulting changes** alongside your contract change.
+
+The `frontend` CI job regenerates bindings on every push/PR and fails with `git diff --exit-code` if the committed output under `apps/web/lib/contracts/` differs from what was just generated — so stale bindings will block CI until you run `pnpm build:bindings` and commit the diff.
 
 ## Scripts
 

--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -1,5 +1,10 @@
 # Soroban contract configuration
 # Copy this file to .env.local and fill in your values.
+#
+# Canonical registry: see /deployments/testnet.json (and deployments/README.md)
+# at the repo root for the source-of-truth testnet contract IDs, network
+# passphrase, and RPC URL. Copy the relevant `contractId` values from there
+# into the NEXT_PUBLIC_*_CONTRACT_ID vars below.
 
 # Market Contract ID deployed on the target network
 NEXT_PUBLIC_MARKET_CONTRACT_ID=

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -1,0 +1,56 @@
+# Deployments Registry
+
+This directory holds machine-readable registries of deployed contract
+instances, keyed by network. It is the **single source of truth** for
+contract IDs that `apps/web` and the `scripts/` tooling should reference —
+prefer reading from here over hardcoding IDs in multiple places.
+
+## `testnet.json`
+
+Registry of Stellar testnet contract instances.
+
+### Schema
+
+```jsonc
+{
+  "network": "testnet",
+  "networkPassphrase": "Test SDF Network ; September 2015",
+  "rpcUrl": "https://soroban-testnet.stellar.org",
+  "contracts": {
+    "market": { "contractId": "", "wasmHash": "" },
+    "treasury": { "contractId": "", "wasmHash": "" },
+    "resolution": { "contractId": "", "wasmHash": "" },
+    "outcomeToken": { "contractId": "", "wasmHash": "" }
+  }
+}
+```
+
+Since JSON has no comment syntax, field meanings are documented here instead:
+
+| Field | Meaning |
+|---|---|
+| `network` | Human-readable network name (`testnet`). |
+| `networkPassphrase` | Soroban/Stellar network passphrase used to sign transactions for this network. |
+| `rpcUrl` | Soroban RPC endpoint for this network. |
+| `contracts.<name>.contractId` | The deployed contract's Stellar contract ID (`C...`). **Placeholder empty string (`""`) until a real deploy has happened** — fill this in after running `scripts/deploy-testnet.sh` (or an equivalent deploy) and recording the resulting contract ID. |
+| `contracts.<name>.wasmHash` | Optional: the SHA-256 hash of the deployed WASM artifact (see `scripts/verify-wasm-hash.sh`), useful for confirming which build is live on-chain. Also a placeholder until filled in. |
+
+### Filling in placeholders after a deploy
+
+1. Deploy the contract (e.g. `TESTNET_SECRET_KEY=... bash scripts/deploy-testnet.sh`).
+2. Copy the printed contract ID into the matching `contractId` field above.
+3. Optionally record the WASM hash via `bash scripts/verify-wasm-hash.sh <contract-dir>` in `wasmHash`.
+4. Commit the update so downstream consumers (web app, scripts) pick up the new ID.
+
+### Consumers
+
+- `apps/web/.env.local.example` points here as the canonical registry for
+  testnet contract IDs (the web app itself still reads its actual IDs from
+  `NEXT_PUBLIC_*` env vars at build/runtime — this file is the reference for
+  what to put in them).
+- `scripts/testnet-smoke.sh` reads this file as a fallback when the
+  corresponding `*_CONTRACT_ID` environment variable isn't set.
+
+Until real contracts are deployed, `contractId` values are empty strings and
+any tooling that depends on them should treat that as "not yet configured"
+rather than a valid address.

--- a/deployments/testnet.json
+++ b/deployments/testnet.json
@@ -1,0 +1,23 @@
+{
+  "network": "testnet",
+  "networkPassphrase": "Test SDF Network ; September 2015",
+  "rpcUrl": "https://soroban-testnet.stellar.org",
+  "contracts": {
+    "market": {
+      "contractId": "",
+      "wasmHash": ""
+    },
+    "treasury": {
+      "contractId": "",
+      "wasmHash": ""
+    },
+    "resolution": {
+      "contractId": "",
+      "wasmHash": ""
+    },
+    "outcomeToken": {
+      "contractId": "",
+      "wasmHash": ""
+    }
+  }
+}

--- a/docs/events-reference.md
+++ b/docs/events-reference.md
@@ -1,0 +1,102 @@
+# Contract Events Reference
+
+> **Update this table whenever `events.rs` files change.** This is the
+> canonical reference for off-chain indexers consuming Vatix contract
+> events — keep it in sync with `contracts/*/src/events.rs` whenever an
+> event's fields, topics, or emission site change.
+
+Every event below is defined with `#[contractevent]` and published via
+`.publish(env)` in the corresponding `emit_*` function. The **Event/Topic**
+column is the first (auto-generated) topic in the on-chain event — Soroban's
+`#[contractevent]` macro derives it by converting the struct name to
+`snake_case` **verbatim** (no suffix stripping), so a struct literally named
+e.g. `MarketClosedToDepositsEvent` produces the topic
+`market_closed_to_deposits_event`, not `market_closed_to_deposits`.
+
+In the **Fields** column, fields marked `(topic)` are additional indexed
+topics (in declaration order, after the auto-generated event-name topic);
+unmarked fields are part of the event's data payload. Many Market contract
+events additionally carry a `version: u32 (topic)` field
+(`EVENT_VERSION`, currently `1`) as a schema-version topic — see the
+"Event schema versioning" note in `contracts/market/src/events.rs`.
+
+## Market (`contracts/market/src/events.rs`)
+
+| Event/Topic | Fields (name: type) | Emitted When |
+|---|---|---|
+| `contract_initialized` | `version: u32 (topic)`, `admin: Address (topic)`, `initialized_at: u64` | Contract is initialized with an admin (`initialize`) |
+| `emergency_pause_toggled_event` | `version: u32 (topic)`, `paused: bool (topic)`, `timestamp: u64` | The emergency pause flag is toggled on/off |
+| `market_created` | `version: u32 (topic)`, `market_id: u32 (topic)`, `creator: Address`, `question: String`, `end_time: u64`, `metadata_uri: Option<String>` | A new prediction market is created |
+| `collateral_deposited` | `version: u32 (topic)`, `user: Address (topic)`, `market_id: u32 (topic)`, `amount: i128`, `new_total: i128` | A user deposits collateral into a market |
+| `collateral_withdrawn` | `version: u32 (topic)`, `user: Address (topic)`, `market_id: u32 (topic)`, `amount: i128`, `new_total: i128` | A user withdraws collateral from a market |
+| `withdraw_edge_case` | `version: u32 (topic)`, `user: Address (topic)`, `market_id: u32 (topic)`, `amount: i128` | A user attempts to withdraw with zero collateral deposited (edge case for monitoring) |
+| `market_closed_to_deposits_event` | `version: u32 (topic)`, `market_id: u32 (topic)`, `admin: Address`, `closed_at: u64` | An admin closes a market to new collateral deposits |
+| `market_resolved` | `version: u32 (topic)`, `market_id: u32 (topic)`, `oracle_pubkey: BytesN<32>`, `resolver: Address`, `outcome: bool`, `resolved_at: u64` | A market is resolved with an oracle-signed outcome |
+| `market_canceled` | `version: u32 (topic)`, `market_id: u32 (topic)`, `canceler: Address`, `canceled_at: u64` | An admin cancels a market before resolution |
+| `position_limit_exceeded` | `version: u32 (topic)`, `market_id: u32 (topic)`, `user: Address (topic)`, `side_yes: bool` | A trade/position change is rejected because a share balance would go negative |
+| `position_updated` | `version: u32 (topic)`, `market_id: u32 (topic)`, `user: Address (topic)`, `yes_shares: i128`, `no_shares: i128`, `locked_collateral: i128` | A user's position (share balances / locked collateral) changes |
+| `trade_executed` | `version: u32 (topic)`, `market_id: u32 (topic)`, `user: Address (topic)`, `quantity: i128`, `price_bps: i128`, `side_yes: bool`, `executed_at: u64` | A user executes a trade (buy or sell of YES/NO shares) |
+| `validation_failed` | `version: u32 (topic)`, `context: Symbol (topic)`, `error_code: u32` | A validation step fails, recording the call-site context and `ContractError` code |
+| `position_settled` | `version: u32 (topic)`, `market_id: u32 (topic)`, `user: Address (topic)`, `payout: i128`, `settled_at: u64` | A user's position is settled and payout transferred after resolution |
+| `positions_batch_settled` | `version: u32 (topic)`, `market_id: u32 (topic)`, `users: Vec<Address>`, `payouts: Vec<i128>`, `settled_at: u64` | One aggregated event summarizing a `batch_settle_positions` call (replaces per-user `position_settled`/`position_updated` pairs) |
+| `oracle_signature_verified` | `version: u32 (topic)`, `market_id: u32 (topic)`, `outcome: bool`, `verified_at: u64` | An oracle's Ed25519 signature is successfully verified during resolution |
+| `fee_calculated` | `version: u32 (topic)`, `market_id: u32 (topic)`, `user: Address (topic)`, `fee_amount: i128`, `available_after_fee: i128` | A withdrawal fee is calculated for a user |
+| `admin_transfer_proposed` | `version: u32 (topic)`, `current_admin: Address (topic)`, `pending_admin: Address (topic)`, `proposed_at: u64` | The current admin proposes transferring the admin role |
+| `admin_transfer_accepted` | `version: u32 (topic)`, `old_admin: Address (topic)`, `new_admin: Address (topic)`, `accepted_at: u64` | The pending admin accepts the proposed transfer |
+| `market_oracle_updated` | `market_id: u32 (topic)`, `admin: Address`, `old_oracle_pubkey: BytesN<32>`, `new_oracle_pubkey: BytesN<32>`, `updated_at: u64` | The admin rotates a market's oracle public key |
+| `treasury_set` | `version: u32 (topic)`, `treasury: Address (topic)`, `set_at: u64` | The Treasury contract address is registered on the market |
+| `fee_rate_change_proposed` | `version: u32 (topic)`, `new_rate_bps: i128`, `effective_at: u64` | An admin proposes a new withdrawal fee rate, effective at a future timestamp |
+| `fee_rate_change_executed` | `version: u32 (topic)`, `new_rate_bps: i128`, `executed_at: u64` | A previously-proposed fee rate change takes effect |
+| `admin_renounce_proposed_event` | `version: u32 (topic)`, `admin: Address (topic)`, `proposed_at: u64` | The admin proposes renouncing the admin role |
+| `admin_renounced_event` | `version: u32 (topic)`, `former_admin: Address (topic)`, `renounced_at: u64` | The admin renounce is finalized (admin role given up) |
+| `oracle_adapter_configured` | `adapter_type: AdapterType (topic)`, `enabled: bool`, `configured_at: u64` | The admin enables/disables the Reflector or Pyth oracle adapter |
+| `fee_waiver_added` | `account: Address (topic)`, `admin: Address`, `added_at: u64` | The admin adds an address to the withdrawal fee waiver list |
+| `fee_waiver_removed` | `account: Address (topic)`, `admin: Address`, `removed_at: u64` | The admin removes an address from the fee waiver list |
+
+## Treasury (`contracts/treasury/src/events.rs`)
+
+| Event/Topic | Fields (name: type) | Emitted When |
+|---|---|---|
+| `treasury_initialized` | `admin: Address (topic)`, `market_contract: Address (topic)`, `initialized_at: u64` | The Treasury contract is initialized with an admin and linked market contract |
+| `fee_collected` | `market_id: u32 (topic)`, `token: Address (topic)`, `fee_amount: i128`, `new_token_balance: i128`, `new_cumulative_fees: i128` | A fee is collected from a market's withdrawal event |
+| `fees_withdrawn` | `token: Address (topic)`, `to: Address (topic)`, `amount: i128`, `remaining_token_balance: i128` | The admin withdraws collected fees to a destination address |
+| `admin_transferred` | `old_admin: Address (topic)`, `new_admin: Address (topic)`, `transferred_at: u64` | The Treasury admin role is transferred |
+| `market_contract_updated` | `old_market_contract: Address (topic)`, `new_market_contract: Address (topic)` | The Treasury's registered market contract address is rotated |
+| `market_added` | `market_contract: Address (topic)` | A market contract is added to the Treasury's multi-market registry |
+| `market_removed` | `market_contract: Address (topic)` | A market contract is removed from the Treasury's registry |
+| `stakeholders_updated` | `stakeholder_count: u32`, `updated_at: u64` | The fee-distribution stakeholder list is updated |
+| `fees_distributed` | `token: Address (topic)`, `distributed_amount: i128`, `remaining_token_balance: i128`, `stakeholder_count: u32`, `distributed_at: u64` | Fees for `token` are distributed across all configured stakeholders (once per `distribute_fees` call) |
+| `treasury_paused_event` | `admin: Address (topic)`, `paused_at: u64` | The Treasury is paused for emergency maintenance |
+| `treasury_unpaused_event` | `admin: Address (topic)`, `unpaused_at: u64` | The Treasury is unpaused |
+
+## Resolution (`contracts/resolution/src/events.rs`)
+
+| Event/Topic | Fields (name: type) | Emitted When |
+|---|---|---|
+| `resolution_registered` | `factory: Address (topic)`, `market_contract: Address`, `registered_at: u64` | The Resolution contract is initialized, registering the factory/market relationship |
+| `candidate_proposed` | `candidate_id: u32 (topic)`, `market_id: u32 (topic)`, `outcome: bool`, `proposer: Address`, `evidence_uri: String`, `challenge_deadline: u64`, `signature_expiry: u64` | A proposer submits a signed resolution candidate (`propose`) |
+| `candidate_challenged` | `candidate_id: u32 (topic)`, `market_id: u32 (topic)`, `challenger: Address`, `challenge_uri: String`, `challenged_at: u64` | A challenger disputes a candidate before its challenge deadline |
+| `candidate_finalized` | `candidate_id: u32 (topic)`, `market_id: u32 (topic)`, `outcome: bool`, `finalized_at: u64` | A candidate is finalized after its challenge window closes (`finalize`) |
+| `candidate_appealed` | `candidate_id: u32 (topic)`, `market_id: u32 (topic)`, `outcome: bool`, `proposer: Address`, `appeal_round: u32`, `evidence_uri: String`, `challenge_deadline: u64`, `appealed_at: u64` | A challenged candidate is re-proposed/appealed for another round |
+
+## Outcome Token (`contracts/outcome-token/src/events.rs`)
+
+| Event/Topic | Fields (name: type) | Emitted When |
+|---|---|---|
+| `token_minted` | `market_id: u32 (topic)`, `user: Address (topic)`, `kind: TokenKind`, `amount: i128`, `new_balance: i128` | Outcome tokens (YES/NO) are minted to a user |
+| `token_burned` | `market_id: u32 (topic)`, `user: Address (topic)`, `kind: TokenKind`, `amount: i128`, `new_balance: i128` | Outcome tokens are burned from a user |
+| `token_transferred_event` | `market_id: u32 (topic)`, `from: Address (topic)`, `to: Address`, `kind: TokenKind`, `amount: i128` | Outcome tokens are transferred between two users |
+
+## Notes for indexers
+
+- `market_id`/`candidate_id`/topic addresses are indexed (declared with
+  `#[topic]`) specifically so off-chain services can filter the Soroban
+  event stream server-side rather than scanning every event.
+- `TokenKind` (outcome-token) and `AdapterType` (market) are contract-defined
+  enums — see `contracts/outcome-token/src/types.rs` and
+  `contracts/market/src/types.rs` respectively for their variants.
+- Some Market events (e.g. `market_oracle_updated`, `oracle_adapter_configured`,
+  `fee_waiver_added`/`fee_waiver_removed`) do **not** carry the `version`
+  topic that most other Market events do — this reflects when each event was
+  added relative to the Issue #500 schema-versioning change, not an error in
+  this table.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build:bindings": "tsx scripts/generate-bindings.ts",
     "lint:web": "pnpm --filter web lint",
     "issues:generate": "tsx scripts/generate-issues.ts",
-    "issues:publish": "tsx scripts/generate-issues.ts --publish"
+    "issues:publish": "tsx scripts/generate-issues.ts --publish",
+    "testnet:smoke": "bash scripts/testnet-smoke.sh"
   },
   "devDependencies": {
     "tsx": "^4.19.0",

--- a/scripts/testnet-smoke.sh
+++ b/scripts/testnet-smoke.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# testnet-smoke.sh — read-only smoke test against a Market contract already
+# deployed on Stellar testnet.
+#
+# This performs a single simulated (never signed/submitted) invocation of a
+# harmless read-only getter (`get_fee_rate`, which takes no arguments beyond
+# `env`) to prove the configured contract ID is reachable and callable on the
+# configured RPC endpoint. Nothing is written on-chain and no secret key is
+# required — `stellar contract invoke --send=no` only simulates the call, and
+# `--source-account` accepts a bare public key (G...) for simulation, so no
+# funded/signing account is needed.
+#
+# Requirements:
+#   - The `stellar` CLI on PATH (https://developers.stellar.org/docs/tools/cli)
+#
+# Contract ID resolution (first match wins):
+#   1. MARKET_CONTRACT_ID environment variable
+#   2. .contracts.market.contractId in deployments/testnet.json (see
+#      deployments/README.md for the registry schema)
+#
+# Optional environment overrides:
+#   SOROBAN_RPC_URL      RPC endpoint      (default: from registry, else
+#                         https://soroban-testnet.stellar.org)
+#   NETWORK_PASSPHRASE   Network passphrase (default: from registry, else
+#                         "Test SDF Network ; September 2015")
+#   SMOKE_FN             Read-only function to call (default: get_fee_rate)
+#   SMOKE_SOURCE_ACCOUNT Public key used to build the simulated transaction
+#                         (default: a fixed placeholder G... address — no
+#                         secret key or funding required for a view call)
+#
+# Guard mode:
+#   If the `stellar` CLI is missing, or no contract ID is configured via
+#   either MARKET_CONTRACT_ID or the registry file, this prints a clear
+#   message and exits 0 rather than failing — this script is meant to be
+#   safely runnable (e.g. in CI or fresh checkouts) before any real testnet
+#   deployment exists.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REGISTRY_FILE="${ROOT_DIR}/deployments/testnet.json"
+
+SMOKE_FN="${SMOKE_FN:-get_fee_rate}"
+# Well-known placeholder public key (does not need to exist/be funded — the
+# call is simulated only via --send=no, never signed or submitted).
+SMOKE_SOURCE_ACCOUNT="${SMOKE_SOURCE_ACCOUNT:-GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF}"
+
+log() { printf '[testnet-smoke] %s\n' "$*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Read a dotted field out of deployments/testnet.json, preferring `jq` and
+# falling back to a small inline `node` one-liner. Prints an empty string
+# (not an error) if the file, tool, or field is missing.
+# ---------------------------------------------------------------------------
+read_registry_field() {
+  local jq_filter="$1"
+  local node_expr="$2"
+
+  if [[ ! -f "${REGISTRY_FILE}" ]]; then
+    echo ""
+    return 0
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    jq -r "${jq_filter} // empty" "${REGISTRY_FILE}" 2>/dev/null || echo ""
+    return 0
+  fi
+
+  if command -v node >/dev/null 2>&1; then
+    node -e "
+      try {
+        const fs = require('fs');
+        const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+        const val = (${node_expr});
+        if (val !== undefined && val !== null) process.stdout.write(String(val));
+      } catch (e) { /* ignore, treat as unset */ }
+    " "${REGISTRY_FILE}" 2>/dev/null || echo ""
+    return 0
+  fi
+
+  # Neither jq nor node available — degrade gracefully to "unset".
+  echo ""
+}
+
+# 1. Resolve the contract ID: env var wins, else registry file.
+CONTRACT_ID="${MARKET_CONTRACT_ID:-}"
+if [[ -z "${CONTRACT_ID}" ]]; then
+  CONTRACT_ID="$(read_registry_field '.contracts.market.contractId' 'data.contracts && data.contracts.market && data.contracts.market.contractId')"
+fi
+
+# 2. Resolve RPC URL and network passphrase: env var wins, else registry,
+#    else the well-known Stellar testnet defaults.
+RPC_URL="${SOROBAN_RPC_URL:-}"
+if [[ -z "${RPC_URL}" ]]; then
+  RPC_URL="$(read_registry_field '.rpcUrl' 'data.rpcUrl')"
+fi
+RPC_URL="${RPC_URL:-https://soroban-testnet.stellar.org}"
+
+PASSPHRASE="${NETWORK_PASSPHRASE:-}"
+if [[ -z "${PASSPHRASE}" ]]; then
+  PASSPHRASE="$(read_registry_field '.networkPassphrase' 'data.networkPassphrase')"
+fi
+PASSPHRASE="${PASSPHRASE:-Test SDF Network ; September 2015}"
+
+# 3. Guard mode: no contract ID configured anywhere.
+if [[ -z "${CONTRACT_ID}" ]]; then
+  log "No market contract ID configured — skipping smoke test (guard mode)."
+  log "Set MARKET_CONTRACT_ID, or fill in .contracts.market.contractId in"
+  log "${REGISTRY_FILE#"${ROOT_DIR}/"} (see deployments/README.md)."
+  exit 0
+fi
+
+# 4. Guard mode: stellar CLI missing.
+if ! command -v stellar >/dev/null 2>&1; then
+  log "'stellar' CLI not found on PATH — skipping smoke test (guard mode)."
+  log "Install it from https://developers.stellar.org/docs/tools/cli"
+  exit 0
+fi
+
+log "Smoke-invoking '${SMOKE_FN}' on contract ${CONTRACT_ID} (read-only, no signing)..."
+log "RPC URL: ${RPC_URL}"
+
+# --send=no simulates the call only; it is never signed or submitted, so no
+# secret key or funded account is required. --source-account only needs to be
+# a syntactically valid public key to build the simulated transaction.
+RESULT="$(
+  stellar contract invoke \
+    --id "${CONTRACT_ID}" \
+    --rpc-url "${RPC_URL}" \
+    --network-passphrase "${PASSPHRASE}" \
+    --source-account "${SMOKE_SOURCE_ACCOUNT}" \
+    --send=no \
+    -- "${SMOKE_FN}"
+)"
+
+log "Smoke invoke succeeded. ${SMOKE_FN} returned: ${RESULT:-<void>}"
+echo "${RESULT}"


### PR DESCRIPTION
## Summary

- Fail the `frontend` CI job if committed TypeScript bindings (`apps/web/lib/contracts/`) drift from what `pnpm build:bindings` regenerates, and document the regenerate flow in README (#509)
- Add `scripts/testnet-smoke.sh` (+ `pnpm testnet:smoke`), a read-only/simulate-only smoke invoke against a testnet contract with no signing or secrets required, guarding cleanly to a no-op when no contract ID or `stellar` CLI is available (#510)
- Add `deployments/testnet.json` + `deployments/README.md` as the single source of truth for testnet contract IDs (market/treasury/resolution/outcome-token), network passphrase, and RPC URL; point `apps/web/.env.local.example` and the smoke script at it (#511)
- Add `docs/events-reference.md`, a canonical table of every emitted event (topic, fields, when emitted) across market, treasury, resolution, and outcome-token contracts, linked from README, for off-chain indexers (#512)

## Notes
- `deployments/testnet.json` ships with placeholder empty-string contract IDs — fill in after a real deploy.
- Smoke test uses Market's `get_fee_rate()` read-only getter via `stellar contract invoke` in simulate-only mode.

## Test plan
- [ ] `bash -n scripts/testnet-smoke.sh` (shell syntax)
- [ ] `pnpm build:bindings && git diff --exit-code -- apps/web/lib/contracts` (bindings drift check passes on clean tree)
- [ ] `pnpm testnet:smoke` in guard mode (no contract configured) exits 0
- [ ] Review `docs/events-reference.md` for accuracy against `events.rs` files

Closes #509
closes  #510 
closes #511 
closes #512