### PR TITLE
feat:  fix: issues 502, 503, 504, 513 — audit event, workspace CI, math corpus, contributing guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,13 @@ jobs:
       # To auto-fix locally before pushing, run: cd contracts/market && cargo fmt
       #
       # See contracts/market/rustfmt.toml for the option reference and planned rules.
+      # Cross-crate workspace compile check (#503): runs `cargo check` across
+      # every crate in the workspace (market, treasury, resolution,
+      # outcome-token) in one pass so a break in one crate can't slip through
+      # while another crate's individually-scoped steps stay green.
+      - name: Workspace compile check
+        run: cargo check --workspace --all-targets
+
       - name: Format check
         run: cd contracts/market && cargo fmt --check
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to vatix-contract
+
+Guide for adding a new contract crate or working on an existing one
+(`market`, `treasury`, `resolution`, `outcome-token`).
+
+## Workspace layout
+
+- Each contract lives under `contracts/<name>/` as its own crate with its
+  own `Cargo.toml`, `src/lib.rs`, `src/test.rs` (or inline `#[cfg(test)]`
+  modules), and `rustfmt.toml`/`Makefile` where needed.
+- Root `Cargo.toml` uses `members = ["contracts/*"]`, so any new directory
+  under `contracts/` is picked up automatically — no manual registration
+  needed. Shared workspace dependency versions (e.g. `soroban-sdk`,
+  `ed25519-dalek`) are pinned once in `[workspace.dependencies]`; prefer
+  `{ workspace = true }` over restating a version in the crate's own
+  `Cargo.toml`.
+- Cross-contract integration tests live at the repo root under `tests/`
+  and are compiled as the `vatix-contract-tests` package (see root
+  `Cargo.toml`).
+
+## Soroban contract patterns
+
+- `#![no_std]` at the crate root; use `soroban_sdk` types (`Vec`, `String`,
+  `Address`, ...) instead of `std` equivalents in contract code. `std` is
+  only pulled in inside `#[cfg(test)]` modules that need it (e.g. to read
+  a fixture file).
+- Public contract functions return `Result<T, ContractError>` — add new
+  error variants to `error.rs` rather than panicking.
+- Emit a `#[contractevent]` (see `events.rs` in any contract) for state
+  changes that off-chain indexers care about, following the existing
+  `EVENT_VERSION` topic-versioning pattern.
+- Validate inputs in `validation.rs` and keep math (fees, shares, payouts)
+  in small, pure, unit-testable functions.
+
+## Before opening a PR
+
+```bash
+# Format (per contract, uses that contract's rustfmt.toml)
+cd contracts/<name> && cargo fmt --check
+
+# Lint
+cd contracts/<name> && cargo clippy -- -D warnings
+
+# Unit tests for the crate you touched
+cd contracts/<name> && cargo test
+
+# Workspace-wide compile check — catches drift between crates (#503)
+cargo check --workspace --all-targets
+
+# Workspace integration tests
+cargo test --workspace --tests
+```
+
+See [README.md § Workspace compile check](README.md#workspace-compile-check)
+for what that job guards against, [README.md § Clippy Lints](README.md#clippy-lints)
+for the lint policy, and `contracts/market/STORAGE_MIGRATION_GUIDE.md` /
+`contracts/market/MIGRATION.md` if your change touches persistent storage
+shape. If you add a regression test vector for math logic, add it to
+`test-vectors/` alongside a Rust test that loads and asserts it (see
+`contracts/market/src/tests_vectors.rs` for the pattern).
+
+## PR / issue hygiene
+
+- Keep PRs scoped to one issue; note in the PR description which
+  acceptance criteria it satisfies.
+- If an issue's scope is unclear, ask in the issue thread before
+  implementing.
+- Don't fix unrelated pre-existing issues in the same PR — file/flag them
+  separately instead.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ cd ../outcome-token && cargo build
 cd ../resolution && cargo build
 ```
 
+### Workspace compile check
+
+CI runs `cargo check --workspace --all-targets` in one job (`.github/workflows/ci.yml`) so a break in any single crate (`contracts/market`, `contracts/treasury`, `contracts/resolution`, `contracts/outcome-token`) fails the build immediately, even if that crate isn't otherwise touched by the PR. Run it locally before pushing:
+
+```bash
+cargo check --workspace --all-targets
+```
+
 ### Contributor issues
 
 Generate **375** onboarding issues (125 per repo) — see [`scripts/issues/README.md`](scripts/issues/README.md).
@@ -375,7 +383,10 @@ Smart contract security is critical. All contracts will undergo:
 
 ## Contributing
 
-Contribution guidelines coming soon. For now, check out [vatix-docs](https://github.com/vatix-protocol/vatix-docs) for project information.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for workspace layout, Soroban contract
+patterns, and the build/lint/test commands to run before opening a PR. For
+broader project information, check out
+[vatix-docs](https://github.com/vatix-protocol/vatix-docs).
 
 ## License
 

--- a/contracts/market/Cargo.toml
+++ b/contracts/market/Cargo.toml
@@ -27,3 +27,5 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 vatix-treasury-contract = { path = "../treasury" }
 rand = "0.8"
 proptest = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -12,6 +12,7 @@
 //! | `MarketCreated`          | `market_created`                    |
 //! | `CollateralDeposited`    | `collateral_deposited`              |
 //! | `CollateralWithdrawn`    | `collateral_withdrawn`              |
+//! | `LargeWithdraw`          | `large_withdraw`                    |
 //! | `WithdrawEdgeCase`       | `withdraw_edge_case`                |
 //! | `MarketResolved`         | `market_resolved`                   |
 //! | `MarketCanceled`         | `market_canceled`                   |
@@ -130,6 +131,19 @@ pub struct CollateralWithdrawn {
 
 #[contractevent]
 #[derive(Clone, Debug)]
+pub struct LargeWithdraw {
+    #[topic]
+    pub version: u32,
+    #[topic]
+    pub user: Address,
+    #[topic]
+    pub market_id: u32,
+    pub amount: i128,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
 pub struct WithdrawEdgeCase {
     #[topic]
     pub version: u32,
@@ -204,6 +218,27 @@ pub fn emit_collateral_withdrawn(
         market_id,
         amount,
         new_total,
+    }
+    .publish(env);
+}
+
+/// Publishes a [`LargeWithdraw`] audit event when a withdrawal reaches the
+/// large-withdraw threshold (#502), so operators/indexers can flag unusual
+/// outflows without parsing every `CollateralWithdrawn` event.
+///
+/// # Arguments
+/// * env - Soroban environment
+/// * user - User's address
+/// * market_id - Market identifier
+/// * amount - Amount withdrawn in stroops
+/// * timestamp - Ledger timestamp of the withdrawal
+pub fn emit_large_withdraw(env: &Env, user: &Address, market_id: u32, amount: i128, timestamp: u64) {
+    LargeWithdraw {
+        version: EVENT_VERSION,
+        user: user.clone(),
+        market_id,
+        amount,
+        timestamp,
     }
     .publish(env);
 }

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -72,6 +72,8 @@ pub mod storage;
 mod test;
 #[cfg(test)]
 mod withdraw_fuzz;
+#[cfg(test)]
+mod tests_vectors;
 pub mod types;
 #[allow(dead_code)]
 mod validation;

--- a/contracts/market/src/tests_vectors.rs
+++ b/contracts/market/src/tests_vectors.rs
@@ -1,0 +1,93 @@
+//! Regression corpus for share/fee/payout math (#504).
+//!
+//! Loads `test-vectors/fee-math.json` at test time and replays every case
+//! through `validation::calculate_fee`, so a reintroduced rounding/overflow
+//! bug fails this test instead of surfacing later in production.
+
+use crate::error::ContractError;
+use crate::validation::calculate_fee;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Corpus {
+    vectors: std::vec::Vec<Vector>,
+}
+
+#[derive(Deserialize)]
+struct Vector {
+    id: std::string::String,
+    #[allow(dead_code)]
+    description: std::string::String,
+    amount: std::string::String,
+    fee_rate_bps: i128,
+    expected: Expected,
+}
+
+#[derive(Deserialize)]
+struct Expected {
+    ok: Option<std::string::String>,
+    error: Option<std::string::String>,
+}
+
+fn error_name(err: ContractError) -> &'static str {
+    match err {
+        ContractError::InvalidQuantity => "InvalidQuantity",
+        ContractError::InvalidPrice => "InvalidPrice",
+        ContractError::ArithmeticOverflow => "ArithmeticOverflow",
+        _ => "Other",
+    }
+}
+
+#[test]
+fn fee_math_regression_corpus() {
+    let raw = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../test-vectors/fee-math.json"
+    ))
+    .expect("read test-vectors/fee-math.json");
+    let corpus: Corpus = serde_json::from_str(&raw).expect("parse fee-math.json");
+
+    assert!(
+        corpus.vectors.len() >= 5,
+        "corpus must document at least 5 cases"
+    );
+
+    for vector in &corpus.vectors {
+        let amount: i128 = vector
+            .amount
+            .parse()
+            .unwrap_or_else(|_| panic!("vector {}: invalid amount", vector.id));
+        let result = calculate_fee(amount, vector.fee_rate_bps);
+
+        match (&vector.expected.ok, &vector.expected.error) {
+            (Some(expected_ok), None) => {
+                let expected: i128 = expected_ok
+                    .parse()
+                    .unwrap_or_else(|_| panic!("vector {}: invalid expected.ok", vector.id));
+                assert_eq!(
+                    result,
+                    Ok(expected),
+                    "vector {}: unexpected fee result",
+                    vector.id
+                );
+            }
+            (None, Some(expected_err)) => {
+                let err = result.expect_err(&std::format!(
+                    "vector {}: expected error {}, got Ok",
+                    vector.id,
+                    expected_err
+                ));
+                assert_eq!(
+                    error_name(err),
+                    expected_err.as_str(),
+                    "vector {}: wrong error variant",
+                    vector.id
+                );
+            }
+            _ => panic!(
+                "vector {}: expected must have exactly one of ok/error",
+                vector.id
+            ),
+        }
+    }
+}

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -13,7 +13,9 @@
 //! invariant `available = total_deposited - locked_collateral` is preserved.
 
 use crate::error::ContractError;
-use crate::events::{emit_collateral_withdrawn, emit_fee_calculated, emit_withdraw_edge_case};
+use crate::events::{
+    emit_collateral_withdrawn, emit_fee_calculated, emit_large_withdraw, emit_withdraw_edge_case,
+};
 use crate::storage;
 use crate::types::{MarketStatus, Position};
 use crate::validation;
@@ -23,6 +25,10 @@ use soroban_sdk::{Address, Env, IntoVal, Symbol, Val, Vec};
 
 /// Seconds a user must wait after their last deposit before withdrawing (issue #413).
 const WITHDRAW_COOLDOWN_SECONDS: u64 = 3_600;
+
+/// Withdrawn amount (in stroops) at or above which a dedicated audit event is
+/// emitted so operators/indexers can flag unusual outflows (#502).
+pub const LARGE_WITHDRAW_THRESHOLD: i128 = 1_000_000_0000000;
 
 /// Withdraw `amount` of unused (unlocked) collateral from a market.
 ///
@@ -140,6 +146,13 @@ pub fn withdraw_unused_collateral(
     token_client.transfer(&contract_address, &user, &amount);
 
     emit_collateral_withdrawn(&env, &user, market_id, amount, position.total_deposited);
+
+    // Audit log for large withdraws (#502): flagged independently of the fee
+    // path so operators/indexers can spot unusual outflows without parsing
+    // every CollateralWithdrawn event.
+    if amount >= LARGE_WITHDRAW_THRESHOLD {
+        emit_large_withdraw(&env, &user, market_id, amount, env.ledger().timestamp());
+    }
 
     Ok(())
 }
@@ -486,5 +499,83 @@ mod tests {
             withdraw_unused_collateral(env.clone(), user.clone(), market_id, 1)
         });
         assert_eq!(result, Err(ContractError::InsufficientCollateral));
+    }
+
+    /// #502: withdrawals below the large-withdraw threshold must not emit the
+    /// audit event (only the regular CollateralWithdrawn event fires).
+    #[test]
+    fn test_withdraw_below_threshold_no_audit_event() {
+        use soroban_sdk::token::StellarAssetClient;
+        let env = setup_env();
+        let user = Address::generate(&env);
+        let market_id = 1u32;
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin).address();
+        let contract_id = env.register(crate::MarketContract, ());
+        let market = create_test_market(&env, market_id, &token);
+        let amount = LARGE_WITHDRAW_THRESHOLD - 1;
+        let position = Position {
+            market_id, user: user.clone(),
+            yes_shares: 0, no_shares: 0,
+            locked_collateral: 0, total_deposited: amount, is_settled: false,
+        };
+        env.as_contract(&contract_id, || {
+            storage::set_version(&env);
+            storage::set_market(&env, market_id, &market).unwrap();
+            storage::set_position(&env, market_id, &user, &position).unwrap();
+        });
+        env.mock_all_auths();
+        StellarAssetClient::new(&env, &token).mint(&contract_id, &amount);
+        env.events().all(); // clear setup events
+        let result = env.as_contract(&contract_id, || {
+            withdraw_unused_collateral(env.clone(), user.clone(), market_id, amount)
+        });
+        assert!(result.is_ok());
+        let events = env.events().all();
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.topics.iter().any(|t| t.to_string().contains("large_withdraw"))),
+            "LargeWithdraw audit event should not be emitted below threshold"
+        );
+    }
+
+    /// #502: withdrawals at/above the large-withdraw threshold must emit the
+    /// dedicated audit event alongside the regular withdraw event.
+    #[test]
+    fn test_withdraw_above_threshold_emits_audit_event() {
+        use soroban_sdk::token::StellarAssetClient;
+        let env = setup_env();
+        let user = Address::generate(&env);
+        let market_id = 1u32;
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin).address();
+        let contract_id = env.register(crate::MarketContract, ());
+        let market = create_test_market(&env, market_id, &token);
+        let amount = LARGE_WITHDRAW_THRESHOLD;
+        let position = Position {
+            market_id, user: user.clone(),
+            yes_shares: 0, no_shares: 0,
+            locked_collateral: 0, total_deposited: amount, is_settled: false,
+        };
+        env.as_contract(&contract_id, || {
+            storage::set_version(&env);
+            storage::set_market(&env, market_id, &market).unwrap();
+            storage::set_position(&env, market_id, &user, &position).unwrap();
+        });
+        env.mock_all_auths();
+        StellarAssetClient::new(&env, &token).mint(&contract_id, &amount);
+        env.events().all(); // clear setup events
+        let result = env.as_contract(&contract_id, || {
+            withdraw_unused_collateral(env.clone(), user.clone(), market_id, amount)
+        });
+        assert!(result.is_ok());
+        let events = env.events().all();
+        assert!(
+            events
+                .iter()
+                .any(|e| e.topics.iter().any(|t| t.to_string().contains("large_withdraw"))),
+            "LargeWithdraw audit event should be emitted at/above threshold"
+        );
     }
 }

--- a/test-vectors/fee-math.json
+++ b/test-vectors/fee-math.json
@@ -1,0 +1,54 @@
+{
+  "description": "Regression corpus for validation::calculate_fee (withdraw fee path). Each case documents intent so a future change that reintroduces a rounding/overflow/edge bug fails CI immediately. See contracts/market/src/validation.rs::calculate_fee and the loader test in contracts/market/src/tests_vectors.rs.",
+  "vectors": [
+    {
+      "id": "zero-fee-rate",
+      "description": "0 bps fee rate on a normal deposit yields no fee at all.",
+      "amount": "1000000",
+      "fee_rate_bps": 0,
+      "expected": { "ok": "0" }
+    },
+    {
+      "id": "rounding-floors-down",
+      "description": "999 * 25 / 10000 = 2.4975, must floor to 2, never round up.",
+      "amount": "999",
+      "fee_rate_bps": 25,
+      "expected": { "ok": "2" }
+    },
+    {
+      "id": "sub-unit-rounds-to-zero",
+      "description": "Small amount at low bps rounds down to a zero fee rather than erroring.",
+      "amount": "3",
+      "fee_rate_bps": 1,
+      "expected": { "ok": "0" }
+    },
+    {
+      "id": "max-fee-rate-full-amount",
+      "description": "10000 bps (100%) is the maximum allowed rate; the entire amount becomes the fee.",
+      "amount": "500",
+      "fee_rate_bps": 10000,
+      "expected": { "ok": "500" }
+    },
+    {
+      "id": "amount-overflow",
+      "description": "i128::MAX * 2 bps overflows checked_mul and must error, never wrap or panic.",
+      "amount": "170141183460469231731687303715884105727",
+      "fee_rate_bps": 2,
+      "expected": { "error": "ArithmeticOverflow" }
+    },
+    {
+      "id": "negative-amount-rejected",
+      "description": "Historical bug shape: a negative withdrawal amount must be rejected up front, not silently produce a negative fee.",
+      "amount": "-100",
+      "fee_rate_bps": 500,
+      "expected": { "error": "InvalidQuantity" }
+    },
+    {
+      "id": "fee-rate-out-of-range",
+      "description": "fee_rate_bps above 10000 (100%) must be rejected as an invalid price/rate.",
+      "amount": "100",
+      "fee_rate_bps": 10001,
+      "expected": { "error": "InvalidPrice" }
+    }
+  ]
+}


### PR DESCRIPTION
Title:


Body:


## Summary
- **#502** Emits a dedicated `LargeWithdraw` audit event from `withdraw_unused_collateral` when the withdrawn amount ≥ `LARGE_WITHDRAW_THRESHOLD`, carrying `market_id`, `user`, `amount`, and `timestamp` — without touching the existing fee/withdraw path.
- **#503** Adds a `Workspace compile check` CI step (`cargo check --workspace --all-targets`) so a broken crate (market/treasury/resolution/outcome-token) fails CI even if its own job stays green, documented in the README.
- **#504** Adds a checked-in regression corpus (`test-vectors/fee-math.json`, 7 vectors: rounding, zero, sub-unit, max-rate, overflow, negative-amount, out-of-range-rate) loaded and asserted by a new Rust test (`contracts/market/src/tests_vectors.rs`).
- **#513** Adds `CONTRIBUTING.md` (workspace layout, Soroban patterns, pre-PR commands) linked from the README's Contributing section.

## Notes
- The new workspace compile-check step surfaces a **pre-existing, unrelated** compile error in `contracts/treasury/src/lib.rs::list_markets` (returns a bare `Vec` instead of `Result<Vec, TreasuryError>`). Left untouched per scope — will need its own fix before this CI job is fully green.
- Local `cargo test` (not `cargo check`) is currently blocked in this environment by a pre-existing `ed25519-dalek`/`rand_chacha` version conflict inside `soroban-env-host`'s testutils, unrelated to these changes (reproduced on a clean `git stash`). The new #504 test logic was verified independently against the real `calculate_fee` function in an isolated scratch crate before being added.

## Test plan
- [x] `cargo check -p vatix-market-contract` — clean (pre-existing warnings only)
- [x] `cargo check --workspace --all-targets` — surfaces the pre-existing treasury issue noted above, otherwise as expected
- [x] Fee-math corpus vectors independently verified against `calculate_fee` logic
- [ ] Full `cargo test` — blocked locally by the pre-existing dependency conflict noted above; should be re-verified in CI
Want me to actually commit these changes and open the PR (gh pr create), or are you handling that yourself?


closes  #502
closes #503 
closes  #504 
closes #513 