### PR TITLE
Fix/market hardening pause settlement auth feecap

### DIFF
--- a/AUTH_TABLE.md
+++ b/AUTH_TABLE.md
@@ -1,0 +1,80 @@
+# Admin Authorization Audit
+
+Inventory of every admin-gated mutator across the `market`, `treasury`, and
+`resolution` contracts, and the check each one performs. Produced as part of
+the auth-hardening pass; keep this in sync whenever an admin entrypoint is
+added, removed, or renamed.
+
+Every row below follows the same two-step pattern unless noted otherwise:
+
+1. `caller.require_auth()` — cryptographic proof the caller signed the call.
+2. `caller == stored_admin` — proof the signer is *the* admin, not merely
+   *some* authenticated address. Step 1 alone is insufficient: a caller can
+   authenticate as themselves but must still be rejected if they are not the
+   admin.
+
+## Market contract (`contracts/market/src/lib.rs`)
+
+| Entrypoint                     | require_auth | admin-equality check | Notes |
+|---------------------------------|:---:|:---:|-------|
+| `initialize`                   | ✅ | n/a (bootstraps admin) | Guarded by `AlreadyInitialized` instead. |
+| `propose_admin`                 | — | ✅ (`storage::get_admin`) | Auth deferred to `accept_admin`. |
+| `accept_admin`                  | ✅ | ✅ (must match `PendingAdmin`) | Two-step transfer. |
+| `initialize_market`             | ✅ | ✅ | |
+| `cancel_market`                 | ✅ | ✅ | |
+| `set_adapter_enabled`           | ✅ | ✅ | |
+| `update_market_oracle`          | ✅ | ✅ | |
+| `set_threshold_signers`         | ✅ | ✅ | |
+| `set_treasury_contract`         | ✅ | ✅ | |
+| `set_outcome_token_contract`    | ✅ | ✅ | |
+| `set_resolution_contract`       | ✅ | ✅ | **Was missing entirely** — storage helpers and tests existed but no contract entrypoint called them; added by this pass. |
+| `add_fee_waiver`                | ✅ | ✅ | |
+| `remove_fee_waiver`             | ✅ | ✅ | |
+| `set_fee_rate`                  | ✅ | ✅ | Also enforces the fee cap at propose time. |
+| `pause`                         | ✅ | ✅ | **Was missing entirely** — `Paused` storage and every `require_not_paused` gate existed, but no entrypoint could ever set the flag. Added by this pass. |
+| `unpause`                       | ✅ | ✅ | Added alongside `pause`. |
+| `execute_fee_rate_change`       | — | n/a (intentionally public) | Access control is the timelock (`effective_at`), not caller identity — anyone may trigger it once due. |
+
+## Treasury contract (`contracts/treasury/src/lib.rs`)
+
+| Entrypoint            | require_auth | admin-equality check |
+|------------------------|:---:|:---:|
+| `initialize`           | ✅ | n/a (bootstraps admin) |
+| `withdraw_fees`        | ✅ | ✅ |
+| `transfer_admin`       | ✅ | ✅ |
+| `add_market`           | ✅ | ✅ |
+| `remove_market`        | ✅ | ✅ |
+| `set_market_contract`  | ✅ | ✅ |
+| `pause`                | ✅ | ✅ |
+| `unpause`              | ✅ | ✅ |
+| `set_stakeholders`     | ✅ | ✅ |
+| `distribute_fees`      | ✅ | ✅ |
+
+`collect_fee` requires auth from `caller` but intentionally checks
+*registered-market* membership (`is_authorized_market`) rather than admin
+identity — it is a market-contract-facing entrypoint, not an admin mutator.
+
+## Resolution contract (`contracts/resolution/src/lib.rs`)
+
+| Entrypoint                     | require_auth | admin-equality check |
+|---------------------------------|:---:|:---:|
+| `initialize`                   | ✅ | n/a (bootstraps admin) |
+| `set_default_challenge_window`  | ✅ | ✅ (`require_admin`) |
+| `set_factory`                   | ✅ | ✅ (`require_admin`) |
+| `set_market_contract`           | ✅ | ✅ (`require_admin`) |
+| `slash_collateral`              | ✅ | ✅ (`require_admin`) |
+
+`propose`, `challenge`, `appeal`, `finalize`, and `deposit_collateral` all
+`require_auth()` the acting party (proposer/challenger/finalizer) but are
+deliberately open to any caller — the bond, challenge window, and finalize
+conditions are the access control, not an admin check.
+
+## Conclusion
+
+Every admin mutator in `treasury` and `resolution` already performed both
+checks. `market` had one entrypoint that was entirely absent
+(`set_resolution_contract` — storage helpers and tests already existed for
+it, but no contract entrypoint ever called them) and one storage flag with
+no way to ever be set (`pause`/`unpause`) — those are the gaps this audit
+closed. No admin mutator was found calling `require_auth()` without also
+verifying the caller against the stored admin.

--- a/AUTH_TABLE.md
+++ b/AUTH_TABLE.md
@@ -30,10 +30,11 @@ Every row below follows the same two-step pattern unless noted otherwise:
 | `set_resolution_contract`       | ✅ | ✅ | **Was missing entirely** — storage helpers and tests existed but no contract entrypoint called them; added by this pass. |
 | `add_fee_waiver`                | ✅ | ✅ | |
 | `remove_fee_waiver`             | ✅ | ✅ | |
-| `set_fee_rate`                  | ✅ | ✅ | Also enforces the fee cap at propose time. |
+| `set_fee_rate`                  | ✅ | ✅ | Enforces the fee cap at propose time. |
+| `set_fee_cap`                   | ✅ | ✅ | **Was missing entirely** — `FeeCap` storage existed but was unreachable, so the cap could never differ from the default (`MAX_FEE_RATE_BPS`). Added by this pass. |
 | `pause`                         | ✅ | ✅ | **Was missing entirely** — `Paused` storage and every `require_not_paused` gate existed, but no entrypoint could ever set the flag. Added by this pass. |
 | `unpause`                       | ✅ | ✅ | Added alongside `pause`. |
-| `execute_fee_rate_change`       | — | n/a (intentionally public) | Access control is the timelock (`effective_at`), not caller identity — anyone may trigger it once due. |
+| `execute_fee_rate_change`       | — | n/a (intentionally public) | Access control is the timelock (`effective_at`), not caller identity — anyone may trigger it once due. Now also re-checks the fee cap at execution time, not just at proposal time, so a cap lowered while a change is in flight can't let a stale rate through. |
 
 ## Treasury contract (`contracts/treasury/src/lib.rs`)
 
@@ -72,9 +73,8 @@ conditions are the access control, not an admin check.
 ## Conclusion
 
 Every admin mutator in `treasury` and `resolution` already performed both
-checks. `market` had one entrypoint that was entirely absent
-(`set_resolution_contract` — storage helpers and tests already existed for
-it, but no contract entrypoint ever called them) and one storage flag with
-no way to ever be set (`pause`/`unpause`) — those are the gaps this audit
-closed. No admin mutator was found calling `require_auth()` without also
-verifying the caller against the stored admin.
+checks. `market` had two entrypoints that were entirely absent
+(`set_resolution_contract`, `set_fee_cap`) and one storage flag with no way
+to ever be set (`pause`/`unpause`) — those are the gaps this audit closed.
+No admin mutator was found calling `require_auth()` without also verifying
+the caller against the stored admin.

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -36,6 +36,7 @@
 //! | `add_fee_waiver` / `remove_fee_waiver` | admin                       |
 //! | `pause` / `unpause`                | admin                           |
 //! | `set_resolution_contract`          | admin                           |
+//! | `set_fee_cap`                      | admin                           |
 //!
 //! ## Storage layout
 //!
@@ -979,16 +980,46 @@ impl MarketContract {
     /// # Errors
     /// - [`ContractError::NoPendingFeeChange`] — no change is currently pending.
     /// - [`ContractError::TimelockNotElapsed`] — `effective_at` has not passed yet.
+    /// - [`ContractError::FeeCapExceeded`] — the pending rate exceeds the
+    ///   *current* fee cap. The cap is re-checked here (not just at proposal
+    ///   time in [`Self::set_fee_rate`]) so a cap lowered by the admin while a
+    ///   change is in flight cannot let a stale, now-excessive rate through.
     pub fn execute_fee_rate_change(env: Env) -> Result<i128, ContractError> {
         let pending = storage::get_pending_fee_rate_change(&env)
             .ok_or(ContractError::NoPendingFeeChange)?;
         if env.ledger().timestamp() < pending.effective_at {
             return Err(ContractError::TimelockNotElapsed);
         }
+        let cap = storage::get_fee_cap_bps(&env);
+        if pending.new_rate_bps > cap {
+            return Err(ContractError::FeeCapExceeded);
+        }
         storage::set_fee_rate_bps(&env, pending.new_rate_bps);
         storage::clear_pending_fee_rate_change(&env);
         events::emit_fee_rate_change_executed(&env, pending.new_rate_bps, env.ledger().timestamp());
         Ok(pending.new_rate_bps)
+    }
+
+    /// Set the hard upper bound on the withdrawal fee rate, in basis points
+    /// (0–10_000). Enforced both when a new rate is proposed
+    /// ([`Self::set_fee_rate`]) and when a pending change is applied
+    /// ([`Self::execute_fee_rate_change`]).
+    ///
+    /// Only the stored admin may call this.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] — `admin` is not the stored admin.
+    /// - [`ContractError::InvalidPrice`] — `cap_bps` is outside 0–10_000.
+    pub fn set_fee_cap(env: Env, admin: Address, cap_bps: i128) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        validation::validate_fee_rate_bps(cap_bps)?;
+        storage::set_fee_cap_bps(&env, cap_bps);
+        Ok(())
     }
 
     /// Return the currently pending fee rate change, if any (Issue #496).

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -35,6 +35,7 @@
 //! | `update_market_oracle`             | admin                           |
 //! | `add_fee_waiver` / `remove_fee_waiver` | admin                       |
 //! | `pause` / `unpause`                | admin                           |
+//! | `set_resolution_contract`          | admin                           |
 //!
 //! ## Storage layout
 //!
@@ -1273,9 +1274,31 @@ impl MarketContract {
     ///
     /// When set, `resolve_market` will call into this contract to verify that
     /// a finalized candidate exists for the market before accepting a resolution.
-    /// Pass `None` (by omitting the storage entry) to remove the gate.
     ///
-    
+    /// Only the stored admin may call this.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] – `admin` is not the stored admin.
+    pub fn set_resolution_contract(
+        env: Env,
+        admin: Address,
+        resolution_contract: Address,
+    ) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        storage::set_resolution_contract(&env, &resolution_contract);
+        Ok(())
+    }
+
+    /// Return the registered resolution contract address, if any.
+    pub fn get_resolution_contract(env: Env) -> Option<Address> {
+        storage::get_resolution_contract(&env)
+    }
+
     // ========== Trading Convenience Functions ==========
 
     /// Buy YES shares in a market at the specified price.

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -34,6 +34,7 @@
 //! | `settle_position` / `batch_settle` | any user (resolved market)      |
 //! | `update_market_oracle`             | admin                           |
 //! | `add_fee_waiver` / `remove_fee_waiver` | admin                       |
+//! | `pause` / `unpause`                | admin                           |
 //!
 //! ## Storage layout
 //!
@@ -491,6 +492,51 @@ impl MarketContract {
     /// Return whether the given oracle adapter type is currently enabled (#488).
     pub fn is_adapter_enabled(env: Env, adapter_type: AdapterType) -> bool {
         storage::is_adapter_enabled(&env, &adapter_type)
+    }
+
+    /// Pause the contract for emergency maintenance.
+    ///
+    /// While paused, `deposit_collateral`, `withdraw_unused_collateral`,
+    /// `update_position`, `initialize_market`, `cancel_market`,
+    /// `resolve_market`, and `resolve_market_threshold` all reject with
+    /// [`ContractError::ContractPaused`] via [`validation::require_not_paused`].
+    /// Only the stored admin may call this.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] — `admin` is not the stored admin.
+    pub fn pause(env: Env, admin: Address) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        storage::set_paused(&env, true);
+        events::emit_emergency_pause_toggled(&env, true);
+        Ok(())
+    }
+
+    /// Unpause the contract, restoring normal operation.
+    ///
+    /// Only the stored admin may call this.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] — `admin` is not the stored admin.
+    pub fn unpause(env: Env, admin: Address) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        storage::set_paused(&env, false);
+        events::emit_emergency_pause_toggled(&env, false);
+        Ok(())
+    }
+
+    /// Return whether the contract is currently paused for emergency maintenance.
+    pub fn is_paused(env: Env) -> bool {
+        storage::is_paused(&env)
     }
 
     /// Cancel a market before it is resolved, halting all further trading.

--- a/contracts/market/src/settlement.rs
+++ b/contracts/market/src/settlement.rs
@@ -982,4 +982,90 @@ mod tests {
         });
         assert_eq!(second, Ok(0));
     }
+
+    // --- Settlement guard hardening: reject non-Resolved markets ---
+    //
+    // `settle_position`, `batch_settle_positions`, and `settle_positions_page`
+    // must all refuse to pay out unless MarketStatus::Resolved. Beyond the
+    // existing Active-market coverage above, these cover the Canceled case
+    // explicitly (there is no separate "Closed" status in this protocol —
+    // Active and Canceled are the only non-Resolved states) plus the
+    // previously-untested paginated settlement path.
+
+    #[test]
+    fn test_validate_settlement_rejects_canceled_market() {
+        let env = Env::default();
+        let market = create_test_market(&env, MarketStatus::Canceled, None);
+        let pos = create_test_position(&env, 100, 0, false);
+
+        let result = validate_settlement_eligibility(&pos, &market);
+        assert_eq!(result, Err(ContractError::MarketNotResolved));
+    }
+
+    #[test]
+    fn test_batch_settle_rejects_canceled_market() {
+        let env = Env::default();
+        let contract_id = env.register(crate::MarketContract, ());
+        let market = create_test_market(&env, MarketStatus::Canceled, None);
+        env.as_contract(&contract_id, || {
+            storage::set_version(&env);
+            storage::set_market(&env, market.id, &market).unwrap();
+        });
+
+        let users: Vec<Address> = Vec::new(&env);
+        let result = env.as_contract(&contract_id, || {
+            batch_settle_positions(&env, market.id, users)
+        });
+        assert_eq!(result, Err(ContractError::MarketNotResolved));
+    }
+
+    #[test]
+    fn test_settle_positions_page_rejects_active_market() {
+        let env = Env::default();
+        let contract_id = env.register(crate::MarketContract, ());
+        let market = create_test_market(&env, MarketStatus::Active, None);
+        env.as_contract(&contract_id, || {
+            storage::set_version(&env);
+            storage::set_market(&env, market.id, &market).unwrap();
+        });
+
+        let result = env.as_contract(&contract_id, || {
+            settle_positions_page(&env, market.id, 0, 10)
+        });
+        assert_eq!(result, Err(ContractError::MarketNotResolved));
+    }
+
+    #[test]
+    fn test_settle_positions_page_rejects_canceled_market() {
+        let env = Env::default();
+        let contract_id = env.register(crate::MarketContract, ());
+        let market = create_test_market(&env, MarketStatus::Canceled, None);
+        env.as_contract(&contract_id, || {
+            storage::set_version(&env);
+            storage::set_market(&env, market.id, &market).unwrap();
+        });
+
+        let result = env.as_contract(&contract_id, || {
+            settle_positions_page(&env, market.id, 0, 10)
+        });
+        assert_eq!(result, Err(ContractError::MarketNotResolved));
+    }
+
+    #[test]
+    fn test_settle_positions_page_pays_out_resolved_market() {
+        let (env, contract_id, market_id, collateral_token) = setup_resolved_market();
+
+        // Fund the contract so the page-settle payout transfer succeeds.
+        soroban_sdk::token::StellarAssetClient::new(&env, &collateral_token)
+            .mint(&contract_id, &(1_000_000_000i128));
+
+        let (total_payout, next_index, is_complete) = env.as_contract(&contract_id, || {
+            settle_positions_page(&env, market_id, 0, 10)
+        })
+        .expect("resolved market should settle successfully");
+
+        assert!(total_payout > 0, "resolved market page-settle must pay out");
+        assert!(is_complete);
+        assert_eq!(next_index, 2); // two participants were set up by setup_resolved_market
+    }
 }

--- a/contracts/market/src/storage.rs
+++ b/contracts/market/src/storage.rs
@@ -472,6 +472,11 @@ pub fn get_fee_cap_bps(env: &Env) -> i128 {
         .unwrap_or(MAX_FEE_RATE_BPS)
 }
 
+/// Set the hard upper bound on the fee rate (admin-gated in `lib.rs`).
+pub fn set_fee_cap_bps(env: &Env, cap_bps: i128) {
+    env.storage().persistent().set(&StorageKey::FeeCap, &cap_bps);
+}
+
 /// Alias for `get_all_market_ids` used by `list_markets`.
 pub fn get_market_ids(env: &Env) -> Vec<u32> {
     get_all_market_ids(env)

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -1817,6 +1817,10 @@ mod test {
             client.try_set_resolution_contract(&stranger, &stranger),
             Err(Ok(ContractError::NotAdmin))
         );
+        assert_eq!(
+            client.try_set_fee_cap(&stranger, &100i128),
+            Err(Ok(ContractError::NotAdmin))
+        );
     }
 
     #[test]
@@ -1827,5 +1831,67 @@ mod test {
         client.set_resolution_contract(&admin, &resolution_contract);
 
         assert_eq!(client.get_resolution_contract(), Some(resolution_contract));
+    }
+
+    // ========== Fee cap hardening: set-time and execute-time enforcement ==========
+
+    #[test]
+    fn test_set_fee_rate_rejects_over_cap() {
+        use crate::error::ContractError;
+
+        let (_env, admin, client, _contract_id) = create_test_contract();
+
+        client.set_fee_cap(&admin, &500i128);
+        let result = client.try_set_fee_rate(&admin, &501i128);
+        assert_eq!(result, Err(Ok(ContractError::FeeCapExceeded)));
+    }
+
+    #[test]
+    fn test_set_fee_rate_accepts_at_cap() {
+        let (_env, admin, client, _contract_id) = create_test_contract();
+
+        client.set_fee_cap(&admin, &500i128);
+        client.set_fee_rate(&admin, &500i128);
+
+        let pending = client
+            .get_pending_fee_rate_change()
+            .expect("pending change should exist");
+        assert_eq!(pending.new_rate_bps, 500);
+    }
+
+    #[test]
+    fn test_execute_fee_rate_change_rejects_when_cap_lowered_after_proposal() {
+        use crate::error::ContractError;
+
+        let (env, admin, client, _contract_id) = create_test_contract();
+
+        // Propose a rate that is valid under the (default, permissive) cap.
+        client.set_fee_rate(&admin, &9_000i128);
+
+        // Admin tightens the cap below the pending rate before it takes effect.
+        client.set_fee_cap(&admin, &1_000i128);
+
+        // Advance past the timelock.
+        let now = env.ledger().timestamp();
+        env.ledger()
+            .set_timestamp(now + crate::FEE_RATE_TIMELOCK_SECONDS + 1);
+
+        let result = client.try_execute_fee_rate_change();
+        assert_eq!(result, Err(Ok(ContractError::FeeCapExceeded)));
+    }
+
+    #[test]
+    fn test_execute_fee_rate_change_accepts_at_cap() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+
+        client.set_fee_cap(&admin, &1_000i128);
+        client.set_fee_rate(&admin, &1_000i128);
+
+        let now = env.ledger().timestamp();
+        env.ledger()
+            .set_timestamp(now + crate::FEE_RATE_TIMELOCK_SECONDS + 1);
+
+        let applied = client.execute_fee_rate_change();
+        assert_eq!(applied, 1_000);
     }
 }

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -1695,4 +1695,67 @@ mod test {
             "position_updated_event missing after withdraw_canceled_collateral"
         );
     }
+
+    // ========== Pause blocks deposit and withdraw entrypoints ==========
+
+    #[test]
+    fn test_pause_blocks_deposit_collateral() {
+        use crate::error::ContractError;
+        use soroban_sdk::token::StellarAssetClient;
+
+        let (env, admin, user, client, _contract_id, market_id, collateral_token) =
+            setup_admin_market_with_deposit(1_000);
+
+        client.pause(&admin);
+        assert!(client.is_paused());
+
+        StellarAssetClient::new(&env, &collateral_token).mint(&user, &500);
+        let result = client.try_deposit_collateral(&user, &market_id, &500);
+        assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+    }
+
+    #[test]
+    fn test_pause_blocks_withdraw_unused_collateral() {
+        use crate::error::ContractError;
+
+        let (env, admin, user, client, _contract_id, market_id, _token) =
+            setup_admin_market_with_deposit(1_000);
+
+        client.pause(&admin);
+
+        let result = client.try_withdraw_unused_collateral(&user, &market_id, &100);
+        assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+    }
+
+    #[test]
+    fn test_unpause_restores_deposit_and_withdraw() {
+        use soroban_sdk::token::StellarAssetClient;
+
+        let (env, admin, user, client, _contract_id, market_id, collateral_token) =
+            setup_admin_market_with_deposit(1_000);
+
+        client.pause(&admin);
+        client.unpause(&admin);
+        assert!(!client.is_paused());
+
+        // Advance past the withdraw cooldown so the restored path can be exercised.
+        let now = env.ledger().timestamp();
+        env.ledger().set_timestamp(now + 3_601);
+        client.withdraw_unused_collateral(&user, &market_id, &1);
+
+        StellarAssetClient::new(&env, &collateral_token).mint(&user, &500);
+        client.deposit_collateral(&user, &market_id, &500);
+    }
+
+    #[test]
+    fn test_non_admin_cannot_pause_or_unpause() {
+        use crate::error::ContractError;
+
+        let (env, _admin, _user, client, _contract_id, _market_id, _token) =
+            setup_admin_market_with_deposit(1_000);
+        let stranger = Address::generate(&env);
+
+        assert_eq!(client.try_pause(&stranger), Err(Ok(ContractError::NotAdmin)));
+        assert_eq!(client.try_unpause(&stranger), Err(Ok(ContractError::NotAdmin)));
+    }
 }

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -1758,4 +1758,74 @@ mod test {
         assert_eq!(client.try_pause(&stranger), Err(Ok(ContractError::NotAdmin)));
         assert_eq!(client.try_unpause(&stranger), Err(Ok(ContractError::NotAdmin)));
     }
+
+    // ========== Admin auth audit: missing/insufficiently-checked mutators ==========
+
+    #[test]
+    fn test_non_admin_cannot_call_admin_mutators() {
+        use crate::error::ContractError;
+        use crate::types::AdapterType;
+
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let stranger = Address::generate(&env);
+
+        let question = String::from_str(&env, "Stranger cannot admin?");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let oracle_pubkey = BytesN::from_array(&env, &[7u8; 32]);
+        let collateral_token = Address::generate(&env);
+        let market_id = client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &collateral_token,
+        );
+
+        assert_eq!(
+            client.try_cancel_market(&stranger, &market_id),
+            Err(Ok(ContractError::NotAdmin))
+        );
+        assert_eq!(
+            client.try_set_adapter_enabled(&stranger, &AdapterType::Ed25519, &true),
+            Err(Ok(ContractError::NotAdmin))
+        );
+        assert_eq!(
+            client.try_update_market_oracle(
+                &stranger,
+                &market_id,
+                &BytesN::from_array(&env, &[9u8; 32])
+            ),
+            Err(Ok(ContractError::NotAdmin))
+        );
+        assert_eq!(
+            client.try_set_threshold_signers(&stranger, &soroban_sdk::Vec::new(&env), &1u32),
+            Err(Ok(ContractError::NotAdmin))
+        );
+        assert_eq!(
+            client.try_add_fee_waiver(&stranger, &stranger),
+            Err(Ok(ContractError::NotAdmin))
+        );
+        assert_eq!(
+            client.try_remove_fee_waiver(&stranger, &stranger),
+            Err(Ok(ContractError::NotAdmin))
+        );
+        assert_eq!(
+            client.try_set_fee_rate(&stranger, &100i128),
+            Err(Ok(ContractError::NotAdmin))
+        );
+        assert_eq!(
+            client.try_set_resolution_contract(&stranger, &stranger),
+            Err(Ok(ContractError::NotAdmin))
+        );
+    }
+
+    #[test]
+    fn test_set_resolution_contract_records_address() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let resolution_contract = Address::generate(&env);
+
+        client.set_resolution_contract(&admin, &resolution_contract);
+
+        assert_eq!(client.get_resolution_contract(), Some(resolution_contract));
+    }
 }


### PR DESCRIPTION
closes #526
closes #527
closes #528
closes #529

## Summary

Hardens four security/correctness gaps in the market contract, closing out Issues 1–4. Each issue was audited against the actual code (not assumed), and two of the four turned out to be missing entrypoints rather than logic bugs — those are called out explicitly below.

- **Issue 1 — Pause enforcement**: `deposit_collateral` and `withdraw_unused_collateral` were already gated on the `Paused` flag via `validation::require_not_paused`, but the contract had **no way to ever set that flag** — `pause`/`unpause` entrypoints didn't exist. Added them, admin-gated, wired to the existing `emit_emergency_pause_toggled` event.
- **Issue 2 — Settlement guard**: `settle_position` / `batch_settle_positions` / `settle_positions_page` already reject any market whose status isn't `Resolved` (via `validate_settlement_eligibility`). Coverage existed for `Active` markets but not `Canceled` (there's no separate "Closed" status in this protocol), and `settle_positions_page` had no rejection tests at all. Added the missing negative tests plus a page-settle happy-path test confirming resolved markets still pay out.
- **Issue 3 — Admin auth audit**: Audited every admin mutator across `market`, `treasury`, and `resolution` for `require_auth()` + caller-equals-stored-admin checks. Treasury and resolution were fully covered already. Market was missing `set_resolution_contract` **entirely** — the storage helpers (`storage::set_resolution_contract`/`get_resolution_contract`) and even tests referencing `client.set_resolution_contract` already existed, but no contract entrypoint ever called them, so the resolution gate could never actually be configured. Added the admin-gated setter/getter and a consolidated non-admin-rejection test. Full audit results documented in `AUTH_TABLE.md`.
- **Issue 4 — Fee cap hardening**: Two gaps made the fee cap toothless: (1) there was no `set_fee_cap` entrypoint at all, so the cap could never differ from its default (`MAX_FEE_RATE_BPS` = 10,000 bps = 100%), making the cap check at `set_fee_rate` time a no-op in practice; (2) `execute_fee_rate_change` applied a previously-approved pending rate without re-checking it against the *current* cap, so lowering the cap after a proposal but before its timelock elapsed wouldn't stop a stale, now-excessive rate from landing. Added `set_fee_cap` (admin-gated) and a cap re-check inside `execute_fee_rate_change`.

## Changes

- `contracts/market/src/lib.rs` — `pause`, `unpause`, `is_paused`, `set_resolution_contract`, `get_resolution_contract`, `set_fee_cap` entrypoints; cap re-check in `execute_fee_rate_change`; updated module-level auth doc table.
- `contracts/market/src/storage.rs` — `set_fee_cap_bps` helper.
- `contracts/market/src/settlement.rs` — negative tests for `Canceled` markets and `settle_positions_page`.
- `contracts/market/src/test.rs` — pause/unpause tests, non-admin-rejection tests, fee-cap set/execute tests.
- `AUTH_TABLE.md` (new) — full admin-entrypoint auth audit across market/treasury/resolution.

## Test plan

- [x] Paused market rejects `deposit_collateral` and `withdraw_unused_collateral`; unpaused paths unchanged; non-admin cannot pause/unpause.
- [x] `settle_position`/`batch_settle_positions`/`settle_positions_page` reject `Active` and `Canceled` markets; resolved path still pays out (page-settle included).
- [x] Non-admin calls fail (`NotAdmin`) across the audited admin mutator set, including the newly-added `set_resolution_contract`; `AUTH_TABLE.md` matches code.
- [x] Over-cap rates rejected with `FeeCapExceeded` at both `set_fee_rate` (propose) time and `execute_fee_rate_change` (execute) time; at-cap rates accepted at both.

Scope is limited to these four issues — no unrelated refactors.