### PR TITLE
Fix/resolution treasury outcometoken fee fuzz hardening

### DIFF
--- a/contracts/market/ISSUE_withdraw_fee_rounding_fuzz.md
+++ b/contracts/market/ISSUE_withdraw_fee_rounding_fuzz.md
@@ -1,0 +1,54 @@
+# Fuzz case for withdraw fee rounding
+
+## Issue
+
+> `fee_amount = amount * bps / 10_000` can round; fuzz edge amounts near zero
+> and max. Extend `withdraw_fuzz` or add cases. Assert `fee + payout == amount`
+> (or documented dust rule). No underflow/overflow on edge amounts. Rounding
+> rule documented.
+
+## What was added
+
+`contracts/market/src/withdraw_fuzz.rs` gets a new `fee_rounding_invariants`
+proptest module (2,000 cases per property) exercising
+`validation::calculate_fee(amount, fee_rate_bps)` — the function backing
+`withdraw_unused_collateral`'s fee step:
+
+- `prop_fee_rounding_never_overflows_or_exceeds_amount` — general case over
+  `amount in 1..=10_000_000_000` and the full `fee_rate_bps in 0..=10_000`
+  range: `0 <= fee_amount <= amount`, and the floor-division dust rule
+  `amount * bps == fee_amount * 10_000 + dust` with `0 <= dust < 10_000`.
+- `prop_fee_rounding_near_zero_amount` — `amount in 1..=1_000`: tiny amounts
+  below a rate's bps granularity floor `fee_amount` to exactly `0`.
+- `prop_fee_rounding_near_max_amount` — `amount` near
+  `validate_amount_reasonable`'s ceiling (`i128::MAX / 2`, the largest amount
+  the contract will ever accept). **This is where a real overflow edge case
+  lives**: at this magnitude, `amount * fee_rate_bps` itself can exceed
+  `i128::MAX` for any `fee_rate_bps` beyond single digits — the overflow
+  happens in the multiplication, before the division. The test asserts
+  `calculate_fee` fails closed with `ContractError::ArithmeticOverflow`
+  (via its existing `checked_mul`) in that case, rather than panicking or
+  wrapping to a bogus/negative fee; when the product does fit in `i128`, the
+  result must still floor-divide correctly.
+- `prop_fee_rounding_max_bps_equals_amount` — at 10_000 bps (100%),
+  `fee_amount == amount` exactly, no rounding loss at the boundary rate.
+- `prop_fee_rounding_zero_bps_is_always_zero` — at 0 bps, `fee_amount == 0`
+  for every amount up to the ceiling.
+
+## Rounding / dust rule (documented, per acceptance criteria)
+
+`withdraw_unused_collateral` does **not** carve the fee out of the requested
+`amount` — the user always receives exactly `amount`, and
+`amount + fee_amount` is deducted from `total_deposited` on top of it (see
+`withdraw.rs`'s existing `#377` module doc). So the relevant invariant isn't
+`fee + payout == amount`; it's:
+
+```
+fee_amount = floor(amount * fee_rate_bps / 10_000)
+amount * fee_rate_bps == fee_amount * 10_000 + dust,   0 <= dust < 10_000
+```
+
+Integer division floors, so up to `9_999` stroops of `amount * fee_rate_bps`
+can be lost to rounding on every withdrawal. That dust is never collected by
+the protocol and never charged to the user beyond the floored `fee_amount`
+— it simply disappears below the bps granularity, in the user's favor.

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -81,6 +81,7 @@ use crate::types::{AdapterType, Market, MarketStatus, Position};
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String};
 use vatix_outcome_token_contract::{OutcomeTokenContractClient, types::TokenKind};
 use vatix_resolution_contract::types::CandidateStatus as ResolutionCandidateStatus;
+use vatix_resolution_contract::ResolutionContractClient;
 
 /// Delay, in seconds, an admin-proposed fee rate change must wait before it
 /// can be applied via `execute_fee_rate_change` (Issue #496). 48 hours gives
@@ -392,6 +393,15 @@ impl MarketContract {
         if market.status == MarketStatus::Resolved {
             return Err(ContractError::MarketAlreadyResolved);
         }
+
+        // Step 1.5: When a resolution contract is registered for this
+        // contract (see `set_resolution_contract`), resolve_market may only
+        // be reached once that contract has finalized a matching candidate
+        // — i.e. its challenge-window lifecycle has run to completion. This
+        // is what lets `ResolutionContract::finalize`'s callback into
+        // `resolve_market` succeed while any other direct caller (oracle key
+        // holder, admin, etc.) is rejected until finalize() has run.
+        require_resolution_finalized(&env, market_id, outcome, &signature)?;
 
         // Step 2: Verify outcome using the configured adapter for this market.
         oracle::verify_market_outcome(
@@ -1227,9 +1237,30 @@ impl MarketContract {
     ///
     /// When set, `resolve_market` will call into this contract to verify that
     /// a finalized candidate exists for the market before accepting a resolution.
-    /// Pass `None` (by omitting the storage entry) to remove the gate.
+    /// Only the stored admin may call this.
+    pub fn set_resolution_contract(
+        env: Env,
+        admin: Address,
+        resolution_contract: Address,
+    ) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        storage::set_resolution_contract(&env, &resolution_contract);
+        Ok(())
+    }
+
+    /// Return the registered resolution contract address, if any.
     ///
-    
+    /// When `None`, `resolve_market` behaves as before this gate was added —
+    /// any valid oracle signature resolves the market directly.
+    pub fn get_resolution_contract(env: Env) -> Option<Address> {
+        storage::get_resolution_contract(&env)
+    }
+
     // ========== Trading Convenience Functions ==========
 
     /// Buy YES shares in a market at the specified price.
@@ -1496,4 +1527,46 @@ impl MarketContract {
         }
         Ok(result)
     }
+}
+
+/// Enforce the resolution-contract gate for `resolve_market`.
+///
+/// If no resolution contract is registered (`storage::get_resolution_contract`
+/// returns `None`), this is a no-op and `resolve_market` behaves exactly as
+/// it did before the gate existed — a valid oracle signature is sufficient.
+///
+/// When a resolution contract *is* registered, `resolve_market` may only
+/// succeed once that contract has recorded a `Finalized` candidate for
+/// `market_id` whose `outcome` and `signature` match this call. In practice
+/// that means the only caller that can push a resolved market past this
+/// check is `ResolutionContract::finalize` itself (it flips the candidate to
+/// `Finalized` in its own storage, then immediately invokes
+/// `resolve_market` in the same transaction) — any other direct caller
+/// (oracle key holder, admin, etc.) is rejected with
+/// `ContractError::ResolutionNotFinalized` until finalize() has run.
+fn require_resolution_finalized(
+    env: &Env,
+    market_id: u32,
+    outcome: bool,
+    signature: &BytesN<64>,
+) -> Result<(), ContractError> {
+    let Some(resolution_contract) = storage::get_resolution_contract(env) else {
+        return Ok(());
+    };
+
+    let client = ResolutionContractClient::new(env, &resolution_contract);
+    let candidate_id = client
+        .get_candidate_id_for_market(&market_id)
+        .ok_or(ContractError::ResolutionNotFinalized)?;
+    let candidate = client
+        .get_candidate(&candidate_id)
+        .ok_or(ContractError::ResolutionNotFinalized)?;
+
+    if candidate.status != ResolutionCandidateStatus::Finalized
+        || candidate.outcome != outcome
+        || &candidate.signature != signature
+    {
+        return Err(ContractError::ResolutionNotFinalized);
+    }
+    Ok(())
 }

--- a/contracts/market/src/withdraw_fuzz.rs
+++ b/contracts/market/src/withdraw_fuzz.rs
@@ -8,10 +8,17 @@
 //! 2. **Available Non-Negative**: `available = total_deposited - locked_collateral >= 0`
 //! 3. **Withdraw Validation**: Withdraw fails when `amount > available`
 //! 4. **Success Preserves Invariant**: Successful withdraw maintains `locked <= total_deposited`
+//! 5. **Fee Rounding**: `fee_amount = floor(amount * fee_rate_bps / 10_000)` never
+//!    over/underflows and never exceeds `amount` itself, across the full
+//!    `fee_rate_bps` range (0–10_000) and edge `amount`s near zero and near the
+//!    `validate_amount_reasonable` ceiling (`i128::MAX / 2`) — see the
+//!    "Dust rule" note on [`validation::calculate_fee`] fuzz coverage below.
 
+use crate::error::ContractError;
 use crate::positions;
 use crate::storage;
 use crate::types::{Market, MarketStatus, Position};
+use crate::validation;
 use crate::withdraw::withdraw_unused_collateral;
 use proptest::prelude::*;
 use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
@@ -339,6 +346,142 @@ mod share_collateral_invariants {
                 prop_assert_eq!(pos.locked_collateral, expected_locked,
                     "locked mismatch: expected={}, got={}", expected_locked, pos.locked_collateral);
             }
+        }
+    }
+}
+
+/// Withdrawal fee rounding invariants.
+///
+/// `fee_amount = floor(amount * fee_rate_bps / 10_000)` (`validation::calculate_fee`).
+/// Withdraw itself never carves the fee out of `amount` — the user always
+/// receives exactly `amount`, and `amount + fee_amount` is deducted from
+/// `total_deposited` on top (see `withdraw.rs`'s module doc, #377). So the
+/// invariant under test isn't "fee + payout == amount"; it's the pair that
+/// actually holds here:
+///
+/// **Dust rule**: integer division floors, so up to `9999` stroops of
+/// `amount * fee_rate_bps` can be lost to rounding on every withdrawal. That
+/// dust is never collected by the protocol and never charged to the user
+/// beyond the floored `fee_amount` — it simply vanishes below the bps
+/// granularity. Formally: `amount * fee_rate_bps == fee_amount * 10_000 + dust`
+/// with `0 <= dust < 10_000`, and `0 <= fee_amount <= amount`.
+mod fee_rounding_invariants {
+    use super::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2_000))]
+
+        /// General case: fee never overflows, never exceeds `amount`, and the
+        /// floor-division dust rule holds for the full valid amount/bps range.
+        #[test]
+        fn prop_fee_rounding_never_overflows_or_exceeds_amount(
+            amount in 1i128..=10_000_000_000i128,
+            fee_rate_bps in 0i128..=10_000i128,
+        ) {
+            let fee_amount = validation::calculate_fee(amount, fee_rate_bps)
+                .expect("calculate_fee must not error for valid inputs");
+
+            prop_assert!(fee_amount >= 0, "fee_amount={fee_amount} negative");
+            prop_assert!(fee_amount <= amount,
+                "fee_amount={fee_amount} exceeds amount={amount} at bps={fee_rate_bps}");
+
+            let product = amount.checked_mul(fee_rate_bps)
+                .expect("amount * fee_rate_bps must not overflow in this range");
+            let dust = product - fee_amount * 10_000;
+            prop_assert!((0..10_000).contains(&dust),
+                "dust={dust} out of [0, 10_000) for amount={amount} bps={fee_rate_bps}");
+
+            // The amount actually deducted from a position (amount + fee) must
+            // itself be representable without overflow (#377's on-top-of model).
+            let total_required = amount.checked_add(fee_amount);
+            prop_assert!(total_required.is_some(),
+                "amount + fee_amount overflowed for amount={amount} fee={fee_amount}");
+        }
+
+        /// Edge case: amounts near the smallest possible positive withdrawal
+        /// (1..=1000 stroops) — where floor-division dust is proportionally
+        /// largest and `fee_amount` most often rounds down to exactly zero.
+        #[test]
+        fn prop_fee_rounding_near_zero_amount(
+            amount in 1i128..=1_000i128,
+            fee_rate_bps in 0i128..=10_000i128,
+        ) {
+            let fee_amount = validation::calculate_fee(amount, fee_rate_bps)
+                .expect("calculate_fee must not error for valid inputs");
+            prop_assert!(fee_amount >= 0);
+            prop_assert!(fee_amount <= amount);
+
+            // At 1 bps (the smallest nonzero rate) any amount below 10_000
+            // stroops floors the fee to zero entirely — that's the dust rule,
+            // not a bug: the protocol simply forgoes fees below its bps
+            // granularity rather than rounding up in its own favor.
+            if fee_rate_bps > 0 && amount < 10_000 / fee_rate_bps.max(1) {
+                prop_assert_eq!(fee_amount, 0,
+                    "expected fee to floor to 0 for tiny amount={amount} at bps={fee_rate_bps}");
+            }
+        }
+
+        /// Edge case: amounts near `validate_amount_reasonable`'s ceiling
+        /// (`i128::MAX / 2`, ~8.5e37) crossed with the full bps range. At
+        /// this magnitude `amount * fee_rate_bps` itself can exceed
+        /// `i128::MAX` for any bps beyond single digits — well before the
+        /// division step. `calculate_fee` must fail closed with
+        /// `ArithmeticOverflow` in that case (via `checked_mul`), never
+        /// panic or silently wrap to a bogus/negative fee; when the product
+        /// *does* fit, the result must still floor-divide correctly.
+        #[test]
+        fn prop_fee_rounding_near_max_amount(
+            amount in (i128::MAX / 2 - 10_000_000_000i128)..=(i128::MAX / 2),
+            fee_rate_bps in 0i128..=10_000i128,
+        ) {
+            validation::validate_collateral_amount(amount)
+                .expect("amount must be within the validated reasonable range");
+
+            let result = validation::calculate_fee(amount, fee_rate_bps);
+
+            match amount.checked_mul(fee_rate_bps) {
+                Some(product) => {
+                    let fee_amount = result
+                        .expect("calculate_fee must succeed when amount * fee_rate_bps fits in i128");
+                    prop_assert!(fee_amount >= 0 && fee_amount <= amount);
+                    prop_assert_eq!(fee_amount, product / 10_000);
+
+                    // amount + fee_amount can exceed i128::MAX/2 (fee is
+                    // additive, #377), but must stay within i128 itself.
+                    let total_required = amount.checked_add(fee_amount);
+                    prop_assert!(total_required.is_some(),
+                        "amount + fee_amount overflowed near the amount ceiling: amount={amount} fee={fee_amount}");
+                }
+                None => {
+                    prop_assert_eq!(result, Err(ContractError::ArithmeticOverflow),
+                        "expected graceful ArithmeticOverflow (not a panic/wrap) for amount={amount} bps={fee_rate_bps}, got {:?}",
+                        result);
+                }
+            }
+        }
+
+        /// At the maximum fee rate (10_000 bps = 100%), fee_amount must equal
+        /// amount exactly (no rounding loss at the boundary rate).
+        #[test]
+        fn prop_fee_rounding_max_bps_equals_amount(
+            amount in 1i128..=10_000_000_000i128,
+        ) {
+            let fee_amount = validation::calculate_fee(amount, 10_000i128)
+                .expect("calculate_fee must not error for valid inputs");
+            prop_assert_eq!(fee_amount, amount,
+                "expected fee_amount == amount at 10_000 bps, got fee={fee_amount} amount={amount}");
+        }
+
+        /// At a zero fee rate, fee_amount must always be exactly zero
+        /// regardless of amount (including near the amount ceiling).
+        #[test]
+        fn prop_fee_rounding_zero_bps_is_always_zero(
+            amount in 1i128..=(i128::MAX / 2),
+        ) {
+            let fee_amount = validation::calculate_fee(amount, 0i128)
+                .expect("calculate_fee must not error for valid inputs");
+            prop_assert_eq!(fee_amount, 0,
+                "expected fee_amount == 0 at 0 bps, got fee={fee_amount} for amount={amount}");
         }
     }
 }

--- a/contracts/outcome-token/ISSUE_mint_burn_market_only_auth.md
+++ b/contracts/outcome-token/ISSUE_mint_burn_market_only_auth.md
@@ -1,0 +1,45 @@
+# Outcome-token mint/burn market-only authorization
+
+## Issue
+
+> outcome-token must enforce market-only auth on mint/burn.
+> require_auth / invoker checks on mint and burn. Tests. External EOAs
+> cannot mint. Market contract path succeeds in test harness.
+
+## Findings
+
+`contracts/outcome-token/src/lib.rs` already gates both `mint` (line ~118)
+and `burn` (line ~148) with `config.market_contract.require_auth()` before
+touching any balance — only the registered market contract address can
+satisfy that check, so the production authorization logic already matched
+the issue's request.
+
+The gap was in test coverage, not production code: every existing test in
+`contracts/outcome-token/src/test.rs` runs through the shared `setup()`
+helper, which calls `env.mock_all_auths()`. That switches the whole test
+environment into "recording" mode where *every* `require_auth()` call
+succeeds unconditionally, regardless of who's actually calling. That means
+none of the existing `mint`/`burn` tests actually exercised the
+`market_contract.require_auth()` gate — they would keep passing even if that
+line were deleted.
+
+## What this change adds
+
+No production code changes were needed. `contracts/outcome-token/src/test.rs`
+gains:
+
+- `setup_unmocked` — a second test harness that does *not* call
+  `mock_all_auths()`, instead using `env.mock_auths(&[...])` scoped to just
+  the `initialize` call so the contract can still be bootstrapped.
+- `mint_succeeds_when_authorized_by_market_contract` /
+  `burn_succeeds_when_authorized_by_market_contract` — mock a `MockAuth`
+  entry for exactly the registered `market_contract` address and the exact
+  `mint`/`burn` invocation, and assert the call succeeds and balances update.
+  This is the "market contract path succeeds" acceptance criterion.
+- `mint_fails_without_market_contract_authorization` /
+  `burn_fails_without_market_contract_authorization` — call `mint`/`burn`
+  with *no* mocked auth at all and assert (`#[should_panic]`) that the call
+  panics, since nothing can satisfy `market_contract.require_auth()` without
+  holding that contract's authorization. This is the "external EOAs cannot
+  mint" acceptance criterion — a bare `Address::generate` caller has no way
+  to produce a valid authorization for the market contract's address.

--- a/contracts/outcome-token/src/test.rs
+++ b/contracts/outcome-token/src/test.rs
@@ -1,6 +1,9 @@
 use crate::types::TokenKind;
 use crate::{ContractError, OutcomeTokenContract, OutcomeTokenContractClient};
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal, String,
+};
 
 fn setup(env: &Env) -> (OutcomeTokenContractClient<'_>, Address, Address) {
     env.mock_all_auths();
@@ -184,6 +187,128 @@ fn burn_full_balance_brings_to_zero() {
 
     assert_eq!(client.balance(&2, &user, &TokenKind::Yes), 0);
     assert_eq!(client.total_supply(&2, &TokenKind::Yes), 0);
+}
+
+// ── mint/burn authorization ─────────────────────────────────────────────────
+//
+// The tests above all run under `setup()`'s `env.mock_all_auths()`, which
+// makes every `require_auth()` call succeed unconditionally — so they never
+// actually exercise the `config.market_contract.require_auth()` gate inside
+// `mint`/`burn`. The tests below build their own environment without blanket
+// auth mocking so that gate is genuinely exercised: `mint`/`burn` must
+// succeed when (and only when) the call carries a valid authorization for
+// the registered market contract.
+
+fn setup_unmocked(env: &Env) -> (OutcomeTokenContractClient<'_>, Address, Address, Address) {
+    let contract_id = env.register(OutcomeTokenContract, ());
+    let client = OutcomeTokenContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let market_contract = Address::generate(env);
+    let name = String::from_str(env, "Vatix YES Token");
+    let symbol = String::from_str(env, "vYES");
+
+    // `initialize` only needs the admin's own auth, mocked for this one call.
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "initialize",
+            args: (&admin, &market_contract, &name, &symbol).into_val(env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.initialize(&admin, &market_contract, &name, &symbol);
+
+    (client, admin, market_contract, contract_id)
+}
+
+#[test]
+fn mint_succeeds_when_authorized_by_market_contract() {
+    let env = Env::default();
+    let (client, _admin, market_contract, contract_id) = setup_unmocked(&env);
+    let user = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &market_contract,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "mint",
+            args: (&1u32, &user, &TokenKind::Yes, &500i128).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.mint(&1, &user, &TokenKind::Yes, &500);
+
+    assert_eq!(client.balance(&1, &user, &TokenKind::Yes), 500);
+}
+
+#[test]
+#[should_panic]
+fn mint_fails_without_market_contract_authorization() {
+    // No auths are mocked at all here (unlike every other test in this file),
+    // so `config.market_contract.require_auth()` inside `mint` has nothing to
+    // satisfy it with — this is what stops an external EOA (or any caller
+    // other than the registered market contract) from minting tokens.
+    let env = Env::default();
+    let (client, _admin, _market_contract, _contract_id) = setup_unmocked(&env);
+    let user = Address::generate(&env);
+
+    client.mint(&1, &user, &TokenKind::Yes, &500);
+}
+
+#[test]
+fn burn_succeeds_when_authorized_by_market_contract() {
+    let env = Env::default();
+    let (client, _admin, market_contract, contract_id) = setup_unmocked(&env);
+    let user = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &market_contract,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "mint",
+            args: (&1u32, &user, &TokenKind::Yes, &500i128).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.mint(&1, &user, &TokenKind::Yes, &500);
+
+    env.mock_auths(&[MockAuth {
+        address: &market_contract,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "burn",
+            args: (&1u32, &user, &TokenKind::Yes, &200i128).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.burn(&1, &user, &TokenKind::Yes, &200);
+
+    assert_eq!(client.balance(&1, &user, &TokenKind::Yes), 300);
+}
+
+#[test]
+#[should_panic]
+fn burn_fails_without_market_contract_authorization() {
+    let env = Env::default();
+    let (client, _admin, market_contract, contract_id) = setup_unmocked(&env);
+    let user = Address::generate(&env);
+
+    // Fund the user first (this one mint call is authorized) so the burn
+    // attempt below fails on the auth gate itself, not InsufficientBalance.
+    env.mock_auths(&[MockAuth {
+        address: &market_contract,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "mint",
+            args: (&1u32, &user, &TokenKind::Yes, &500i128).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.mint(&1, &user, &TokenKind::Yes, &500);
+
+    // No mocked auth for this call — an unauthorized burn must panic.
+    client.burn(&1, &user, &TokenKind::Yes, &200);
 }
 
 // ── market isolation ────────────────────────────────────────────────────────

--- a/contracts/treasury/ISSUE_collect_fee_authorization.md
+++ b/contracts/treasury/ISSUE_collect_fee_authorization.md
@@ -1,0 +1,46 @@
+# Treasury `collect_fee` authorized-market enforcement
+
+## Issue
+
+> `collect_fee` must only accept registered/authorized market contracts.
+> Enforce authorized market registry check. Tests for authorized vs stranger
+> caller. Unauthorized `collect_fee` fails; authorized path updates balances.
+
+## Findings
+
+Auditing `contracts/treasury/src/lib.rs` and `contracts/treasury/src/storage.rs`
+shows the authorized-market registry gate on `collect_fee` was already fully
+implemented (storage doc comment even labels it "v2: Completed the
+multi-market `AuthorizedMarkets` registry"):
+
+- `TreasuryContract::collect_fee` (`lib.rs:83-134`) calls
+  `storage::is_authorized_market(&env, &caller)` and returns
+  `TreasuryError::CallerNotMarket` when the caller isn't in the registry,
+  before touching any balance.
+- The registry itself (`AuthorizedMarkets`, a `Vec<Address>`) is managed by
+  admin-only `add_market` / `remove_market` / `set_market_contract`, and can
+  be inspected via `is_authorized_market` / `list_markets`.
+- `contracts/market/src/withdraw.rs:104-124` — the only production caller —
+  already invokes `collect_fee` passing the market contract's own address as
+  `caller`, which self-authorizes via Soroban's contract sub-invocation auth
+  (no signature possible for a contract address, so only that exact
+  contract can satisfy `caller.require_auth()`).
+- Test coverage already existed for both acceptance criteria:
+  `collect_fee_rejects_unauthorized_caller` /
+  `collect_fee_updates_balance_and_cumulative` /
+  `removed_market_cannot_collect_fee` /
+  `multiple_markets_can_each_collect_fees` (`contracts/treasury/src/test.rs`).
+
+## What this change adds
+
+No production code changes were needed — the gate and its primary tests
+were already correct and in place. This change adds two additional edge-case
+regression tests to `contracts/treasury/src/test.rs` to close small gaps in
+existing coverage:
+
+- `re_added_market_can_collect_fee_again` — confirms that removing then
+  re-adding a market via `remove_market` / `add_market` correctly restores
+  `collect_fee` access (no stale registry state left behind by removal).
+- `collect_fee_rejects_caller_never_registered` — confirms a caller that was
+  *never* registered (as distinct from one that was registered and later
+  removed) is rejected identically, and leaves the token balance untouched.

--- a/contracts/treasury/src/test.rs
+++ b/contracts/treasury/src/test.rs
@@ -424,6 +424,40 @@ fn removed_market_cannot_collect_fee() {
 }
 
 #[test]
+fn re_added_market_can_collect_fee_again() {
+    // Round-trip: a market removed from the registry and later re-added must
+    // regain collect_fee access exactly like any other authorized market —
+    // removal must not leave stale state that blocks re-registration.
+    let s = setup();
+    let market2 = Address::generate(&s.env);
+    s.client.add_market(&s.admin, &market2);
+    s.client.remove_market(&s.admin, &market2);
+    assert!(!s.client.is_authorized_market(&market2));
+
+    s.client.add_market(&s.admin, &market2);
+    assert!(s.client.is_authorized_market(&market2));
+
+    s.client.collect_fee(&market2, &s.token, &7u32, &42_000i128);
+    assert_eq!(s.client.token_balance(&s.token), 42_000i128);
+}
+
+#[test]
+fn collect_fee_rejects_caller_never_registered() {
+    // A caller that was never part of the authorized-markets registry (as
+    // opposed to one that was registered and later removed) must be
+    // rejected the same way, via the same error.
+    let s = setup();
+    let never_registered = Address::generate(&s.env);
+    let err = s
+        .client
+        .try_collect_fee(&never_registered, &s.token, &1u32, &10i128)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, TreasuryError::CallerNotMarket);
+    assert_eq!(s.client.token_balance(&s.token), 0);
+}
+
+#[test]
 fn multiple_markets_can_each_collect_fees() {
     let s = setup();
     let market2 = Address::generate(&s.env);


### PR DESCRIPTION
Closes #538
Closes #539
Closes #540
Closes #541


---
1. Resolution contract gates resolve_market (27c612b)

contracts/market/src/lib.rs had a half-finished feature: storage::get/set_resolution_contract existed, the ResolutionNotFinalized error existed, and vatix_resolution_contract::types::CandidateStatus was already imported — but nothing wired them together, and set_resolution_contract was a doc comment with no function body.

Completed it:
- Filled in set_resolution_contract (admin-only) and added a get_resolution_contract getter.
- Added require_resolution_finalized(...), called at the top of resolve_market: when a resolution contract is registered, it cross-calls get_candidate_id_for_market / get_candidate and requires a Finalized candidate whose outcome and signature match the call, else returns ResolutionNotFinalized.
- Net effect: once a ResolutionContract is registered, the only path to a resolved market is ResolutionContract::finalize's own callback into resolve_market (it flips the candidate to Finalized in the same transaction before invoking). Any other direct caller — oracle key holder, admin, etc. — is rejected until finalize() has run.
- When no resolution contract is registered, behavior is unchanged (direct oracle-signature resolution still works).

Acceptance criteria: ungated resolve blocked when resolution address set ✅ · unset resolution keeps current behavior ✅.

2. Treasury collect_fee authorized-market check (840ed63)

Audited contracts/treasury/src/lib.rs and storage.rs: the authorized-market registry gate was already fully implemented (collect_fee checks storage::is_authorized_market and returns CallerNotMarket otherwise; add_market/remove_market/set_market_contract are admin-only; the only production caller, market/src/withdraw.rs, self-authorizes correctly via Soroban's contract sub-invocation auth). Primary tests for both acceptance criteria already existed.

No production changes needed. Added two edge-case regression tests to contracts/treasury/src/test.rs:
- re_added_market_can_collect_fee_again — removal doesn't leave stale state blocking re-registration.
- collect_fee_rejects_caller_never_registered — a caller that was never registered (vs. registered-then-removed) is rejected the same way.

Findings documented in contracts/treasury/ISSUE_collect_fee_authorization.md.

Acceptance criteria: unauthorized collect_fee fails ✅ (pre-existing) · authorized path updates balances ✅ (pre-existing).

3. Outcome-token mint/burn market-only auth (e87fff9)

Audited contracts/outcome-token/src/lib.rs: mint and burn already call config.market_contract.require_auth() before touching any balance. But every existing test ran through the shared setup() helper, which calls env.mock_all_auths() — that makes every require_auth() call succeed unconditionally, so none of the existing tests actually exercised the auth gate (they'd keep passing even if that line were deleted).

No production changes needed. Added setup_unmocked (uses scoped env.mock_auths(...) only for initialize, leaving the real auth check live) plus four tests in contracts/outcome-token/src/test.rs:
- mint_succeeds_when_authorized_by_market_contract / burn_succeeds_when_authorized_by_market_contract — mock a MockAuth entry for exactly the registered market contract and the exact call, assert it succeeds.
- mint_fails_without_market_contract_authorization / burn_fails_without_market_contract_authorization (#[should_panic]) — no mocked auth at all, call must panic, since a bare EOA has no way to produce authorization for the market contract's address.

Findings documented in contracts/outcome-token/ISSUE_mint_burn_market_only_auth.md.

Acceptance criteria: external EOAs cannot mint ✅ · market contract path succeeds in test harness ✅.

4. Fuzz case for withdraw fee rounding (f1b5d8d)

Added a fee_rounding_invariants proptest module (2,000 cases/property) to contracts/market/src/withdraw_fuzz.rs, covering validation::calculate_fee(amount, fee_rate_bps) across the full fee_rate_bps range (0–10,000) and edge amounts near zero and near the validate_amount_reasonable ceiling (i128::MAX / 2):

- General case: 0 <= fee_amount <= amount, dust rule holds, amount + fee_amount doesn't overflow.
- Near-zero amounts: fee correctly floors to 0 below a rate's bps granularity.
- Near-max amounts (the real find): at amount ≈ i128::MAX / 2, amount * fee_rate_bps itself can exceed i128::MAX for any fee_rate_bps beyond single digits — the overflow happens in the multiplication, before the division. Asserts calculate_fee fails closed with ContractError::ArithmeticOverflow (via its existing checked_mul) rather than panicking or wrapping to a bogus/negative fee; when the product does fit, asserts correct floor-division.
- Boundary rates: 10,000 bps (100%) → fee_amount == amount exactly; 0 bps → fee_amount == 0 always.

Rounding/dust rule (documented): withdraw_unused_collateral doesn't carve the fee out of amount — the user receives exactly amount, and amount + fee_amount is deducted from total_deposited on top (existing #377 design). So the invariant isn't fee + payout == amount; it's amount * fee_rate_bps == fee_amount * 10_000 + dust with 0 <= dust < 10_000 — up to 9,999 stroops of rounding dust per withdrawal is never collected, in the user's favor. Full rule in contracts/market/ISSUE_withdraw_fee_rounding_fuzz.md.

Acceptance criteria: no underflow/overflow on edge amounts ✅ · rounding rule documented ✅.

---
Test plan

- [ ] cargo test -p vatix-market-contract (resolve_market gate, withdraw fee fuzz)
- [ ] cargo test -p vatix-treasury-contract (collect_fee registry tests)
- [ ] cargo test -p vatix-outcome-token-contract (mint/burn auth tests)
- [ ] cargo test --workspace for a full regression pass
