### PR TITLE
Fix/error mapper ci storage docs admin cancel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,41 @@ jobs:
       - name: Invoke example (echo guard)
         run: bash scripts/invoke-example.sh
 
+  build-contracts:
+    name: Build all contract crates
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> target
+
+      # Focused compile check for every contract crate, run on every PR.
+      # Unlike the `ci` job's `stellar contract build` steps (which build
+      # release WASM artifacts as part of a longer pipeline), these steps
+      # are a fast, dedicated `cargo build -p <crate>` per crate so a
+      # compile error in any one contract fails CI red on its own, without
+      # depending on the rest of the test/lint pipeline succeeding first.
+      - name: Build market contract crate
+        run: cargo build -p vatix-market-contract
+
+      - name: Build treasury contract crate
+        run: cargo build -p vatix-treasury-contract
+
+      - name: Build resolution contract crate
+        run: cargo build -p vatix-resolution-contract
+
+      - name: Build outcome-token contract crate
+        run: cargo build -p vatix-outcome-token-contract
+
   frontend:
     name: Frontend (Next.js)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See [`docs/cross-contract-call-graph.md`](docs/cross-contract-call-graph.md) for
 The Market contract uses storage versioning to ensure data integrity across upgrades. See comprehensive documentation:
 
 - **[Storage Migration Guide](contracts/market/STORAGE_MIGRATION_GUIDE.md)** - Complete guide for handling storage version bumps, including:
+  - [Reviewer checklist for `StorageKey` table drift](contracts/market/STORAGE_MIGRATION_GUIDE.md#reviewer-checklist-storagekey-table-drift) - how to verify the `StorageKey` enum and the `lib.rs` storage table stay in sync
   - When to bump storage version
   - Step-by-step migration procedures (testnet & mainnet)
   - Testing strategies

--- a/apps/web/lib/errors.test.ts
+++ b/apps/web/lib/errors.test.ts
@@ -1,0 +1,61 @@
+// Unit tests for the market contract error mapper.
+//
+// Run with: `node --test --import tsx apps/web/lib/errors.test.ts`
+// (uses Node's built-in test runner; no extra test framework dependency).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseContractError, marketErrorMessage, MARKET_ERROR_MESSAGES } from "./errors";
+
+test("maps a deposit failure (MarketClosedToDeposits, #6) to clear copy", () => {
+  const err = new Error("Error(Contract, #6)");
+  assert.equal(parseContractError(err), MARKET_ERROR_MESSAGES[6]);
+});
+
+test("maps a deposit failure (BelowMinDeposit, #36) to clear copy", () => {
+  const err = new Error("Error(Contract, #36)");
+  assert.equal(parseContractError(err), MARKET_ERROR_MESSAGES[36]);
+});
+
+test("maps a withdraw failure (WithdrawCooldownActive, #7) to clear copy", () => {
+  const err = new Error("Error(Contract, #7)");
+  assert.equal(parseContractError(err), MARKET_ERROR_MESSAGES[7]);
+});
+
+test("maps a withdraw failure (InsufficientCollateral, #10) to clear copy", () => {
+  const err = new Error("Error(Contract, #10)");
+  assert.equal(parseContractError(err), MARKET_ERROR_MESSAGES[10]);
+});
+
+test("maps an auth failure (NotAdmin, #41) to clear copy", () => {
+  const err = new Error("Error(Contract, #41)");
+  assert.equal(parseContractError(err), MARKET_ERROR_MESSAGES[41]);
+});
+
+test("maps an auth failure (Unauthorized, #40) to clear copy", () => {
+  const err = new Error("Error(Contract, #40)");
+  assert.equal(parseContractError(err), MARKET_ERROR_MESSAGES[40]);
+});
+
+test("falls back to a generic message for an unmapped code", () => {
+  const err = new Error("Error(Contract, #9999)");
+  assert.equal(marketErrorMessage(9999), undefined);
+  assert.equal(
+    parseContractError(err),
+    "Contract rejected the transaction (error #9999)."
+  );
+});
+
+test("still surfaces simulation failures unrelated to a contract code", () => {
+  const err = new Error("Simulation failed: insufficient fee");
+  assert.equal(parseContractError(err), "Transaction would fail: insufficient fee");
+});
+
+test("still surfaces transaction failures unrelated to a contract code", () => {
+  const err = new Error("Transaction failed: bad sequence number");
+  assert.equal(parseContractError(err), "Transaction failed: bad sequence number");
+});
+
+test("still surfaces wallet rejections", () => {
+  const err = new Error("User denied access");
+  assert.equal(parseContractError(err), "Request was rejected in the wallet.");
+});

--- a/apps/web/lib/errors.ts
+++ b/apps/web/lib/errors.ts
@@ -2,6 +2,88 @@
  * Turns a thrown contract-invocation error into a short, user-facing
  * revert reason for display in a toast/inline alert.
  */
+
+/**
+ * Numeric discriminant -> human-readable copy for `vatix-market-contract`'s
+ * `ContractError` enum (see `contracts/market/src/error.rs`). Keep this in
+ * sync with that enum's discriminants; the numbers are stable ABI so a drift
+ * here just means a worse error message, not a broken build.
+ */
+export const MARKET_ERROR_MESSAGES: Record<number, string> = {
+  // Market errors (1-9)
+  1: "This market doesn't exist.",
+  2: "This market has already been resolved.",
+  3: "This market hasn't been resolved yet.",
+  4: "This market has expired and is no longer accepting trades.",
+  5: "This market isn't active right now.",
+  6: "Deposits are currently closed for this market.",
+  7: "You need to wait for the withdrawal cooldown to end before withdrawing again.",
+
+  // Position errors (10-19)
+  10: "You don't have enough collateral deposited to do that.",
+  11: "This position has already been settled.",
+  12: "You don't have a position in this market.",
+  13: "That share amount isn't valid.",
+
+  // Oracle errors (20-29)
+  20: "Oracle signature verification failed.",
+  21: "This address isn't authorized to resolve this market.",
+  22: "That resolution outcome isn't valid.",
+  23: "The price oracle didn't return a price for this asset. Try again shortly.",
+
+  // Validation errors (30-39)
+  30: "That price is out of range.",
+  31: "That quantity isn't valid.",
+  32: "That timestamp isn't valid.",
+  33: "That question isn't valid.",
+  34: "Markets must have exactly two outcomes.",
+  35: "That admin address isn't valid.",
+  36: "That deposit is below the minimum allowed amount.",
+  37: "That metadata URI is too long.",
+  38: "That fee rate isn't valid.",
+
+  // Authorization errors (40-49)
+  40: "You're not authorized to do that.",
+  41: "Only the contract admin can do that.",
+  42: "This contract has already been initialized.",
+  43: "There's no pending admin nomination to accept.",
+  44: "There's no pending renounce request to confirm.",
+  45: "An admin renounce request is already pending.",
+  46: "That fee rate exceeds the maximum allowed.",
+
+  // Token errors (50-59)
+  50: "The token transfer failed. Check your balance and try again.",
+
+  // Arithmetic errors (60-69)
+  60: "That operation would overflow — try a smaller amount.",
+
+  // Upgrade errors (70-79)
+  70: "This contract needs a migration before it can be used again.",
+
+  // Resolution errors (80-89)
+  80: "The resolution for this market hasn't been finalized yet.",
+
+  // Pause / initialization errors (90-99)
+  90: "This contract hasn't been initialized yet.",
+  91: "This contract is paused for maintenance. Please try again later.",
+
+  // Security errors (100-109)
+  100: "That action was blocked as a potential reentrant call. Please try again.",
+
+  // Timelock errors (110-119)
+  110: "There's no pending fee rate change to execute.",
+  111: "The fee rate change timelock hasn't elapsed yet.",
+};
+
+/**
+ * Looks up a Soroban contract error discriminant against the known market
+ * contract error codes, returning `undefined` for unrecognized codes so
+ * callers can fall back to a generic message.
+ */
+export function marketErrorMessage(code: number): string | undefined {
+  return MARKET_ERROR_MESSAGES[code];
+}
+
 export function parseContractError(err: unknown): string {
   const message = err instanceof Error ? err.message : String(err);
 
@@ -9,6 +91,11 @@ export function parseContractError(err: unknown): string {
   // SDK inside simulation/transaction failure messages.
   const contractError = message.match(/Error\(Contract,\s*#(\d+)\)/);
   if (contractError) {
+    const code = Number(contractError[1]);
+    const known = marketErrorMessage(code);
+    if (known) {
+      return known;
+    }
     return `Contract rejected the transaction (error #${contractError[1]}).`;
   }
 

--- a/contracts/market/STORAGE_MIGRATION_GUIDE.md
+++ b/contracts/market/STORAGE_MIGRATION_GUIDE.md
@@ -5,12 +5,13 @@
 ## Table of Contents
 
 1. [Overview](#overview)
-2. [When to Bump Storage Version](#when-to-bump-storage-version)
-3. [Migration Procedures](#migration-procedures)
-4. [Testing Migrations](#testing-migrations)
-5. [Rollback and Recovery](#rollback-and-recovery)
-6. [Common Pitfalls](#common-pitfalls)
-7. [Version History](#version-history)
+2. [Reviewer Checklist: StorageKey Table Drift](#reviewer-checklist-storagekey-table-drift)
+3. [When to Bump Storage Version](#when-to-bump-storage-version)
+4. [Migration Procedures](#migration-procedures)
+5. [Testing Migrations](#testing-migrations)
+6. [Rollback and Recovery](#rollback-and-recovery)
+7. [Common Pitfalls](#common-pitfalls)
+8. [Version History](#version-history)
 
 ---
 
@@ -39,6 +40,58 @@ Every storage operation calls `assert_version()` to verify the on-chain version 
 - Safe contract upgrades
 - Clear migration paths
 - Protection against accidental downgrades
+
+---
+
+## Reviewer Checklist: StorageKey Table Drift
+
+The contract has two independent descriptions of storage that must always
+agree:
+
+1. The **`StorageKey` enum** in `src/storage.rs` — the actual, compiled
+   source of truth for what can be written to storage.
+2. The **`## Storage layout` doc table** at the top of `src/lib.rs` — a
+   human-readable summary intended for reviewers and integrators.
+
+Nothing in the compiler enforces that these two stay in sync — the table is
+plain doc-comment prose, so it silently drifts whenever a `StorageKey`
+variant is added, removed, or renamed without a matching table edit. Check
+this on every PR that touches `src/storage.rs` or adds/removes a stored
+type:
+
+- [ ] **List every `StorageKey` variant.** Open `src/storage.rs` and read
+      the full `pub enum StorageKey { ... }` block.
+- [ ] **List every table row.** Open the `## Storage layout` table near the
+      top of `src/lib.rs` (in the crate-level `//!` doc comment).
+- [ ] **Diff the two lists by hand.** Every enum variant must have exactly
+      one corresponding table row (and vice versa — a table row for a key
+      that was removed from the enum is just as much drift as a missing
+      row).
+- [ ] **Check the `Type` and `Description` columns**, not just variant
+      names — a field-type change on a variant (e.g. `Address` -> `Vec<Address>`)
+      should also update the table's `Type` column.
+- [ ] **Cross-check against `STORAGE_VERSION` bumps** — see
+      [When to Bump Storage Version](#when-to-bump-storage-version). Most
+      changes that require a version bump also change what belongs in this
+      table.
+
+A quick local spot-check (not a substitute for reading both lists, but a
+useful smoke test) — count that both files mention the same number of
+variant identifiers:
+
+```bash
+# Enum variant names in storage.rs (rough count, ignores tuple payloads)
+grep -oE '^\s{4}[A-Z][A-Za-z]+' contracts/market/src/storage.rs | sort -u
+
+# Row labels in the lib.rs doc table
+grep -oE '\| `[A-Za-z]+' contracts/market/src/lib.rs | sort -u
+```
+
+**Known example this checklist caught:** as of this writing, `Paused`,
+`AdapterEnabled(AdapterType)`, and `DepositLock` exist in the `StorageKey`
+enum but were missing from the `lib.rs` table — now fixed alongside this
+checklist. Treat any future mismatch the same way: fix the table in the
+same PR that changes the enum, don't defer it.
 
 ---
 

--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -23,6 +23,7 @@
 //! | `TreasurySet`            | `treasury_set`                      |
 //! | `AdminTransferProposed`  | `admin_transfer_proposed`           |
 //! | `AdminTransferAccepted`  | `admin_transfer_accepted`           |
+//! | `AdminTransferCanceled`  | `admin_transfer_canceled`           |
 //!
 //! # Event schema versioning (Issue #500)
 //!
@@ -786,6 +787,32 @@ pub fn emit_admin_transfer_accepted(env: &Env, old_admin: &Address, new_admin: &
         old_admin: old_admin.clone(),
         new_admin: new_admin.clone(),
         accepted_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct AdminTransferCanceled {
+    #[topic]
+    pub version: u32,
+    #[topic]
+    pub current_admin: Address,
+    #[topic]
+    pub canceled_pending_admin: Address,
+    pub canceled_at: u64,
+}
+
+pub fn emit_admin_transfer_canceled(
+    env: &Env,
+    current_admin: &Address,
+    canceled_pending_admin: &Address,
+) {
+    AdminTransferCanceled {
+        version: EVENT_VERSION,
+        current_admin: current_admin.clone(),
+        canceled_pending_admin: canceled_pending_admin.clone(),
+        canceled_at: env.ledger().timestamp(),
     }
     .publish(env);
 }

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -240,6 +240,39 @@ impl MarketContract {
         Ok(())
     }
 
+    /// Cancel an outstanding two-step admin transfer nomination.
+    ///
+    /// Only the current admin may call this. Clears the pending nomination
+    /// set by [`propose_admin`] so it can no longer be accepted via
+    /// [`accept_admin`]. Safe to call at any time before acceptance; has no
+    /// effect on the current admin.
+    ///
+    /// # Arguments
+    /// * `env` - Contract environment
+    /// * `current_admin` - Current admin authorizing the cancellation
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] – contract is not initialized or `current_admin` is not the stored admin
+    /// - [`ContractError::NoPendingAdmin`] – no nomination is outstanding to cancel
+    pub fn cancel_admin_transfer(env: Env, current_admin: Address) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        if !storage::has_admin(&env) {
+            return Err(ContractError::NotAdmin);
+        }
+
+        let stored_admin = storage::get_admin(&env)?;
+        if current_admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        current_admin.require_auth();
+
+        let pending = storage::get_pending_admin(&env).ok_or(ContractError::NoPendingAdmin)?;
+        storage::clear_pending_admin(&env);
+        events::emit_admin_transfer_canceled(&env, &current_admin, &pending);
+
+        Ok(())
+    }
+
     pub fn initialize_market(
         env: Env,
         creator: Address,

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -54,6 +54,9 @@
 //! | `FeeWaivers`                        | `Vec<Address>`  | Admin-managed fee-exempt address list (#483)       |
 //! | `MarketParticipants(u32)`           | `Vec<Address>`  | Every address that ever held a position (#495)     |
 //! | `PendingFeeRate`                    | `PendingFeeRateChange` | Timelocked fee rate change awaiting execution (#496) |
+//! | `Paused`                            | `bool`          | Emergency pause flag; blocks state-mutating calls  |
+//! | `AdapterEnabled(AdapterType)`       | `bool`          | Whether the Reflector/Pyth adapter is live (#488)  |
+//! | `DepositLock`                       | `bool`          | Reentrancy lock for `deposit_collateral` (#501)    |
 
 mod deposit;
 mod error;

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -1112,6 +1112,79 @@ mod test {
         client.accept_admin(&attacker);
     }
 
+    // ========== cancel_admin_transfer tests ==========
+
+    #[test]
+    fn test_cancel_admin_transfer_clears_pending() {
+        let (env, admin, client, contract_id) = create_test_contract();
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+        client.cancel_admin_transfer(&admin);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(storage::get_pending_admin(&env), None);
+        });
+    }
+
+    #[test]
+    fn test_cancel_admin_transfer_emits_event() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+        env.events().all(); // drain proposed event before asserting on cancel
+        client.cancel_admin_transfer(&admin);
+
+        let events = env.events().all();
+        assert!(!events.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #41)")]
+    fn test_cancel_admin_transfer_non_admin_fails() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let new_admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+        client.cancel_admin_transfer(&attacker);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #43)")]
+    fn test_cancel_admin_transfer_with_no_pending_fails() {
+        let (_env, admin, client, _contract_id) = create_test_contract();
+
+        client.cancel_admin_transfer(&admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #43)")]
+    fn test_canceled_nomination_cannot_be_accepted() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+        client.cancel_admin_transfer(&admin);
+
+        // The nomination was canceled, so acceptance must fail with
+        // NoPendingAdmin (#43) rather than succeeding.
+        client.accept_admin(&new_admin);
+    }
+
+    #[test]
+    fn test_canceled_nomination_cannot_be_accepted_try_variant() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+        client.cancel_admin_transfer(&admin);
+
+        let result = client.try_accept_admin(&new_admin);
+        assert!(result.is_err());
+    }
+
     #[test]
     fn test_set_treasury_records_contract_address() {
         let (env, admin, client, contract_id) = create_test_contract();


### PR DESCRIPTION
closes #542
closes #543
closes #544 
closes #545

---
1. 7c93df9 — Surface ContractError codes in web error mapper

- apps/web/lib/errors.ts: added MARKET_ERROR_MESSAGES, a full numeric-code → human-copy table covering every variant of the market contract's ContractError enum (deposit failures like MarketClosedToDeposits/BelowMinDeposit, withdraw failures like WithdrawCooldownActive/InsufficientCollateral, auth failures like Unauthorized/NotAdmin/NoPendingAdmin, plus oracle/validation/timelock codes). parseContractError now checks this table before falling back to the generic "error #N" string.
- apps/web/lib/errors.test.ts (new): unit tests via Node's built-in node:test runner covering deposit/withdraw/auth mappings, the unknown-code fallback, and the existing simulation/tx/wallet-rejection branches.

2. 11ff8ca — CI job to build all contract crates

- .github/workflows/ci.yml: new build-contracts job that runs cargo build -p vatix-{market,treasury,resolution,outcome-token}-contract independently of the existing longer ci/frontend pipelines, so a compile error in any single crate fails the PR check red on its own.

3. dbb275b — Document StorageKey table drift check

- contracts/market/STORAGE_MIGRATION_GUIDE.md: new "Reviewer Checklist: StorageKey Table Drift" section explaining how to diff src/storage.rs's StorageKey enum against the ## Storage layout doc table in src/lib.rs, with a grep recipe reviewers can run.
- Fixed actual drift found while writing the checklist: Paused, AdapterEnabled(AdapterType), and DepositLock existed in the enum but were missing from the lib.rs table — added.
- README.md: linked the new checklist section.

4. 0e5b1ff — Cancel path for two-step admin transfer

- contracts/market/src/lib.rs: new cancel_admin_transfer(env, current_admin) — only the current admin can call it, requires auth, clears any pending nomination (reusing existing storage::clear_pending_admin), errors NotAdmin/NoPendingAdmin appropriately.
- contracts/market/src/events.rs: new AdminTransferCanceled event.
- contracts/market/src/test.rs: tests for clearing pending state, event emission, non-admin rejection, no-pending rejection, and — the acceptance-criteria case — that a canceled nomination cannot subsequently be accepted (propose → cancel → accept_admin fails with NoPendingAdmin).