### PR TITLE
feat(contracts/market): emit MarketClosedToDeposits event (#559)

### DIFF
--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -35,6 +35,7 @@
 //! | `update_market_oracle`             | admin                           |
 //! | `add_fee_waiver` / `remove_fee_waiver` | admin                       |
 //! | `pause` / `unpause`                | admin                           |
+//! | `close_market_to_deposits`         | admin                           |
 //! | `set_resolution_contract`          | admin                           |
 //! | `set_fee_cap`                      | admin                           |
 //!
@@ -1668,6 +1669,65 @@ impl MarketContract {
             i += 1;
         }
         Ok(result)
+    }
+
+    /// Prevent new collateral deposits into a market while preserving all
+    /// other functionality (trading, withdrawals, and settlement).
+    ///
+    /// Once closed, any call to [`deposit_collateral`] for this market will
+    /// return [`ContractError::MarketClosedToDeposits`]. The flag is
+    /// idempotent — calling this on an already-closed market is a no-op and
+    /// succeeds without error.
+    ///
+    /// # Use cases
+    /// - Lock down a market approaching its expiry to prevent last-minute
+    ///   position changes.
+    /// - Halt new deposits during a resolution or dispute window.
+    ///
+    /// # Arguments
+    /// * `env`       – Soroban contract environment
+    /// * `admin`     – Address that must match the stored contract admin
+    /// * `market_id` – Unique identifier of the market to close
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] – contract has not been initialised yet
+    /// - [`ContractError::NotAdmin`]       – `admin` is not the stored admin
+    /// - [`ContractError::MarketNotFound`] – no market with `market_id` exists
+    ///
+    /// # Events
+    /// Emits [`events::MarketClosedToDepositsEvent`] with `market_id`,
+    /// `admin`, and `closed_at` timestamp so off-chain indexers can track
+    /// when a market was locked.
+    pub fn close_market_to_deposits(
+        env: Env,
+        admin: Address,
+        market_id: u32,
+    ) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        admin.require_auth();
+
+        // Only the stored admin may close a market to deposits.
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+
+        // Load the market — returns MarketNotFound for an unknown market_id.
+        let mut market =
+            storage::get_market(&env, market_id)?.ok_or(ContractError::MarketNotFound)?;
+
+        // Idempotent: if already closed, nothing to do.
+        if !market.closed_to_deposits {
+            market.closed_to_deposits = true;
+            storage::set_market(&env, market_id, &market)?;
+        }
+
+        // Always emit the event so indexers can observe every admin call,
+        // including redundant ones (useful for audit trails).
+        let closed_at = env.ledger().timestamp();
+        events::emit_market_closed_to_deposits(&env, market_id, &admin, closed_at);
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #559

Adds the missing `close_market_to_deposits` admin entrypoint to `MarketContract` and wires it to emit the `MarketClosedToDepositsEvent` that off-chain indexers rely on.

## Problem

The `MarketClosedToDepositsEvent` struct and its `emit_market_closed_to_deposits` helper already existed in `contracts/market/src/events.rs`, and `deposit.rs` already guarded the deposit path against `market.closed_to_deposits == true`. However, there was **no public `close_market_to_deposits` function** in `lib.rs` to actually set that flag and emit the event — making the entire feature unusable from the outside.

## Changes

### `contracts/market/src/lib.rs`
- Added `pub fn close_market_to_deposits(env, admin, market_id)` to `#[contractimpl] impl MarketContract`
- Authorization: requires `admin.require_auth()` + checks stored admin via `storage::get_admin`
- Validation: `validation::require_initialized` + `storage::get_market` (returns `MarketNotFound` for unknown IDs)
- State update: sets `market.closed_to_deposits = true` and persists via `storage::set_market`
- **Idempotent**: if the market is already closed the storage write is skipped, but the event is always emitted for audit-trail completeness
- Emits `MarketClosedToDepositsEvent` with `market_id`, `admin`, and `closed_at` (ledger timestamp)
- Updated the authorization-model table in the module doc comment

## Event schema (unchanged)

```
topic[0]: "market_closed_to_deposits_event"  (auto-generated name)
topic[1]: version: u32
topic[2]: market_id: u32
data:     { admin: Address, closed_at: u64 }
```

## Acceptance criteria

- [x] Event includes `market_id` and actor (`admin`)
- [x] Only the stored admin can invoke the function
- [x] Closing a non-existent market returns `MarketNotFound`
- [x] Existing tests in `tests/close_market_test.rs` (which call `client.close_market_to_deposits`) now compile and pass

## Testing

Existing integration tests in `tests/close_market_test.rs` cover:
- `close_market_to_deposits_succeeds` — verifies flag and event
- `deposit_fails_when_market_closed_to_deposits`
- `withdrawal_succeeds_when_market_closed_to_deposits`
- `close_market_to_deposits_idempotent`
- `unauthorized_close_market_to_deposits_fails`
- `close_nonexistent_market_to_deposits_fails`

## Notes

- Keeps PR focused on issue #559 only
- Follows existing admin-function patterns (pause/unpause, cancel_market)
- No storage schema changes required — `closed_to_deposits` field already exists on `Market`