### PR TITLE
feat(market): add get_market view and completeness test

### DIFF
--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -1349,6 +1349,18 @@ impl MarketContract {
             .collateral_token
     }
 
+    /// Return the full [`Market`] struct for a given market ID.
+    ///
+    /// This is the canonical read endpoint for off-chain consumers (indexers,
+    /// the web app, and companion contracts) that need the complete market
+    /// snapshot — status, fees, `closed_to_deposits`, price, resolver, etc.
+    ///
+    /// # Errors
+    /// - [`ContractError::MarketNotFound`] – no market exists for `market_id`.
+    pub fn get_market(env: Env, market_id: u32) -> Result<Market, ContractError> {
+        storage::get_market(&env, market_id)?.ok_or(ContractError::MarketNotFound)
+    }
+
     /// Return the registered outcome-token contract address, if any.
     pub fn get_outcome_token_contract(env: Env) -> Option<Address> {
         storage::get_outcome_token_contract(&env)

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -1967,4 +1967,151 @@ mod test {
         let applied = client.execute_fee_rate_change();
         assert_eq!(applied, 1_000);
     }
+
+    // ========== get_market view completeness tests (Issue #550) ==========
+
+    /// Verify that `get_market` returns an error when the market does not exist.
+    #[test]
+    fn test_get_market_not_found() {
+        use crate::error::ContractError;
+
+        let (_env, _admin, client, _contract_id) = create_test_contract();
+
+        let result = client.try_get_market(&999u32);
+        assert_eq!(result, Err(Ok(ContractError::MarketNotFound)));
+    }
+
+    /// Snapshot-assert every field of the returned [`Market`] struct.
+    ///
+    /// This test is intentionally exhaustive: it uses a destructuring let to
+    /// bind every field by name so that adding a new field to `Market` without
+    /// updating this test causes a compile-time "missing field" error — the
+    /// acceptance criterion for Issue #550.
+    #[test]
+    fn test_get_market_returns_all_fields() {
+        use crate::types::{AdapterType, MarketStatus};
+
+        let (env, admin, client, _contract_id) = create_test_contract();
+
+        let question = String::from_str(&env, "Will ETH reach $10k by end of year?");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let oracle_pubkey = BytesN::from_array(&env, &[2u8; 32]);
+        let collateral_token = Address::generate(&env);
+        let created_at = env.ledger().timestamp();
+
+        let market_id = client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &collateral_token,
+        );
+
+        let market = client.get_market(&market_id);
+
+        // Destructure every field — adding a new field to `Market` without
+        // updating this pattern produces a compile error, which is exactly the
+        // desired "test fails if a new public field is omitted" behaviour.
+        let crate::types::Market {
+            id,
+            question: market_question,
+            end_time: market_end_time,
+            oracle_pubkey: market_oracle_pubkey,
+            status,
+            result,
+            creator,
+            created_at: market_created_at,
+            collateral_token: market_collateral_token,
+            price_bps,
+            resolver,
+            resolved_at,
+            adapter_type,
+            outcome_count,
+            closed_to_deposits,
+        } = market;
+
+        assert_eq!(id, market_id);
+        assert_eq!(market_question, question);
+        assert_eq!(market_end_time, end_time);
+        assert_eq!(market_oracle_pubkey, oracle_pubkey);
+        assert_eq!(status, MarketStatus::Active);
+        assert_eq!(result, None);
+        assert_eq!(creator, admin);
+        assert_eq!(market_created_at, created_at);
+        assert_eq!(market_collateral_token, collateral_token);
+        // Initial price is 50 % (5 000 bps) as set by initialize_market.
+        assert_eq!(price_bps, 5_000i128);
+        // Resolver and resolved_at are only populated after resolution.
+        assert_eq!(resolver, None);
+        assert_eq!(resolved_at, None);
+        // Default adapter for new markets is Ed25519.
+        assert_eq!(adapter_type, AdapterType::Ed25519);
+        // Binary markets always have exactly two outcomes.
+        assert_eq!(outcome_count, 2u32);
+        // Markets are open to deposits at creation.
+        assert!(!closed_to_deposits);
+    }
+
+    /// Verify that `get_market` reflects `closed_to_deposits` after
+    /// `close_market_to_deposits` is called.
+    #[test]
+    fn test_get_market_reflects_closed_to_deposits() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+
+        let question = String::from_str(&env, "Closed-deposits test market");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let oracle_pubkey = BytesN::from_array(&env, &[3u8; 32]);
+        let collateral_token = Address::generate(&env);
+
+        let market_id = client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &collateral_token,
+        );
+
+        // Initially open to deposits.
+        assert!(!client.get_market(&market_id).closed_to_deposits);
+
+        client.close_market_to_deposits(&admin, &market_id);
+
+        // After closing, the flag must be reflected by get_market.
+        assert!(client.get_market(&market_id).closed_to_deposits);
+    }
+
+    /// Verify that `get_market` reflects `status` and `resolver` / `resolved_at`
+    /// after a successful resolution.
+    #[test]
+    fn test_get_market_reflects_resolved_status() {
+        use crate::types::MarketStatus;
+
+        let (env, admin, client, _contract_id) = create_test_contract();
+
+        let question = String::from_str(&env, "Resolution status test market");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let (oracle_pubkey, signature) =
+            generate_test_keypair_and_sign(&env, 1, true);
+        let collateral_token = Address::generate(&env);
+
+        let market_id = client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &collateral_token,
+        );
+
+        // Advance time past end_time so the market can be resolved.
+        env.ledger().set_timestamp(end_time + 1);
+
+        client.resolve_market(&market_id, &true, &signature);
+
+        let market = client.get_market(&market_id);
+        assert_eq!(market.status, MarketStatus::Resolved);
+        assert_eq!(market.result, Some(true));
+        // resolver and resolved_at are populated after resolution.
+        assert!(market.resolver.is_some());
+        assert!(market.resolved_at.is_some());
+    }
 }


### PR DESCRIPTION
## Summary

Closes #550

Adds a public `get_market` view function and an exhaustive test suite that guarantees every field of the `Market` struct is covered. The test is designed so that adding a new field to `Market` without updating the test produces a **compile-time error**, satisfying the acceptance criterion.

---

## Changes

### `contracts/market/src/lib.rs`

Added `get_market` as a canonical read endpoint, grouped with the existing lightweight views (`get_market_status`, `get_collateral_token`):

```rust
pub fn get_market(env: Env, market_id: u32) -> Result<Market, ContractError> {
    storage::get_market(&env, market_id)?.ok_or(ContractError::MarketNotFound)
}
```

Previously, off-chain consumers had to call `list_markets` (pagination overhead) or reach into internal storage. This gives a direct, properly-erroring endpoint for the full struct.

### `contracts/market/src/test.rs`

Four new tests under `// ========== get_market view completeness tests (Issue #550) ==========`:

| Test | What it verifies |
|---|---|
| `test_get_market_not_found` | Returns `ContractError::MarketNotFound` for an unknown ID |
| `test_get_market_returns_all_fields` | Exhaustive destructuring of all 15 `Market` fields with individual `assert_eq!` per field |
| `test_get_market_reflects_closed_to_deposits` | `closed_to_deposits` toggles correctly after `close_market_to_deposits` |
| `test_get_market_reflects_resolved_status` | `status`, `result`, `resolver`, `resolved_at` reflect correctly after `resolve_market` |

#### How the completeness gate works

`test_get_market_returns_all_fields` uses an exhaustive struct pattern:

```rust
let crate::types::Market {
    id,
    question: market_question,
    end_time: market_end_time,
    oracle_pubkey: market_oracle_pubkey,
    status,
    result,
    creator,
    created_at: market_created_at,
    collateral_token: market_collateral_token,
    price_bps,
    resolver,
    resolved_at,
    adapter_type,
    outcome_count,
    closed_to_deposits,
} = market;
```

Rust struct patterns are exhaustive by default — adding a new field to `Market` without updating this destructuring causes a **missing field** compile error. No runtime logic required.

---

## Testing

- Follows existing patterns in `src/test.rs` (same `create_test_contract` helper, same `mock_all_auths` setup)
- No new dependencies introduced
- Clippy-clean (no new allows added)