### PR TITLE
feat(settlement): harden batch_settle_positions against empty and oversized batches

### DIFF
--- a/contracts/market/src/error.rs
+++ b/contracts/market/src/error.rs
@@ -82,6 +82,11 @@ pub enum ContractError {
     /// Share amounts must be non-negative, and at least one side must be positive.
     InvalidShareAmount = 13,
 
+    /// The batch supplied to `batch_settle_positions` was either empty or exceeded
+    /// `MAX_BATCH_SETTLE_SIZE`. Empty batches are rejected to surface caller bugs
+    /// early; oversized batches are rejected to prevent gas-griefing attacks.
+    BatchTooLarge = 14,
+
     // ========== Oracle Errors (20-29) ==========
     /// Oracle signature verification failed.
     ///
@@ -249,6 +254,7 @@ mod tests {
         assert_eq!(ContractError::PositionAlreadySettled as u32, 11);
         assert_eq!(ContractError::NoPositionFound as u32, 12);
         assert_eq!(ContractError::InvalidShareAmount as u32, 13);
+        assert_eq!(ContractError::BatchTooLarge as u32, 14);
         assert_eq!(ContractError::InvalidSignature as u32, 20);
         assert_eq!(ContractError::UnauthorizedOracle as u32, 21);
         assert_eq!(ContractError::InvalidOutcome as u32, 22);
@@ -315,6 +321,7 @@ mod tests {
             (ContractError::PositionAlreadySettled, 11),
             (ContractError::NoPositionFound, 12),
             (ContractError::InvalidShareAmount, 13),
+            (ContractError::BatchTooLarge, 14),
             (ContractError::InvalidSignature, 20),
             (ContractError::UnauthorizedOracle, 21),
             (ContractError::InvalidOutcome, 22),

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -96,6 +96,15 @@ use vatix_resolution_contract::ResolutionContractClient;
 /// integrators and users advance notice of a fee change before it lands.
 pub const FEE_RATE_TIMELOCK_SECONDS: u64 = 172_800;
 
+/// Maximum number of addresses that a single `batch_settle_positions` call may
+/// process (Issue #551). Callers who need to settle more positions should either
+/// use the paginated `settle_positions_page` endpoint, or split their list into
+/// multiple calls of at most this many addresses.
+///
+/// The cap prevents gas-griefing: a malicious or buggy caller cannot force the
+/// contract to iterate an unbounded list in one transaction.
+pub const MAX_BATCH_SETTLE_SIZE: u32 = 100;
+
 #[contract]
 pub struct MarketContract;
 

--- a/contracts/market/src/settlement.rs
+++ b/contracts/market/src/settlement.rs
@@ -220,6 +220,18 @@ pub fn batch_settle_positions(
     market_id: u32,
     users: Vec<Address>,
 ) -> Result<i128, ContractError> {
+    // Guard: reject empty batches immediately to surface caller bugs early
+    // rather than silently returning 0 with no indication anything was wrong.
+    if users.is_empty() {
+        return Err(ContractError::BatchTooLarge);
+    }
+
+    // Guard: cap batch size to prevent gas-griefing. Callers with more users
+    // should use the paginated `settle_positions_page` endpoint instead.
+    if users.len() > crate::MAX_BATCH_SETTLE_SIZE {
+        return Err(ContractError::BatchTooLarge);
+    }
+
     // Validate the market once before iterating users.
     let market = storage::get_market(env, market_id)?.ok_or(ContractError::MarketNotFound)?;
     if market.status != MarketStatus::Resolved {
@@ -899,7 +911,10 @@ mod tests {
         let market_id =
             client.initialize_market(&admin, &question, &end_time, &oracle_pubkey, &collateral_token);
 
-        let users: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+        // Pass a non-empty list so the market-status guard (not the empty-batch guard)
+        // is the first thing that fires.
+        let mut users: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+        users.push_back(Address::generate(&env));
         let result = env.as_contract(&contract_id, || {
             batch_settle_positions(&env, market_id, users)
         });
@@ -915,7 +930,8 @@ mod tests {
             storage::set_version(&env);
         });
 
-        let users: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+        let mut users: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+        users.push_back(Address::generate(&env));
         let result = env.as_contract(&contract_id, || {
             batch_settle_positions(&env, 999, users)
         });
@@ -1109,7 +1125,8 @@ mod tests {
             storage::set_market(&env, market.id, &market).unwrap();
         });
 
-        let users: Vec<Address> = Vec::new(&env);
+        let mut users: Vec<Address> = Vec::new(&env);
+        users.push_back(Address::generate(&env));
         let result = env.as_contract(&contract_id, || {
             batch_settle_positions(&env, market.id, users)
         });
@@ -1164,5 +1181,58 @@ mod tests {
         assert!(total_payout > 0, "resolved market page-settle must pay out");
         assert!(is_complete);
         assert_eq!(next_index, 2); // two participants were set up by setup_resolved_market
+    }
+
+    // --- Issue #551: batch size hardening ---
+
+    /// An empty user list must be rejected immediately with `BatchTooLarge`.
+    /// This surfaces caller bugs early rather than silently returning 0.
+    #[test]
+    fn test_batch_settle_rejects_empty_batch() {
+        let (env, contract_id, market_id, _) = setup_resolved_market();
+
+        let users: Vec<Address> = Vec::new(&env);
+        let result = env.as_contract(&contract_id, || {
+            batch_settle_positions(&env, market_id, users)
+        });
+        assert_eq!(result, Err(ContractError::BatchTooLarge));
+    }
+
+    /// A user list whose length exceeds `MAX_BATCH_SETTLE_SIZE` must be
+    /// rejected with `BatchTooLarge` to prevent gas-griefing.
+    #[test]
+    fn test_batch_settle_rejects_oversized_batch() {
+        let (env, contract_id, market_id, _) = setup_resolved_market();
+
+        // Build a list that is exactly one over the limit.
+        let mut users: Vec<Address> = Vec::new(&env);
+        for _ in 0..=crate::MAX_BATCH_SETTLE_SIZE {
+            users.push_back(Address::generate(&env));
+        }
+
+        let result = env.as_contract(&contract_id, || {
+            batch_settle_positions(&env, market_id, users)
+        });
+        assert_eq!(result, Err(ContractError::BatchTooLarge));
+    }
+
+    /// A list that is exactly `MAX_BATCH_SETTLE_SIZE` entries long must be
+    /// accepted — the guard must be `>`, not `>=`.
+    /// Users with no position are skipped, so total payout is 0 here (all
+    /// addresses are freshly generated ghosts), but the call must not error.
+    #[test]
+    fn test_batch_settle_accepts_batch_at_max_size() {
+        let (env, contract_id, market_id, _) = setup_resolved_market();
+
+        let mut users: Vec<Address> = Vec::new(&env);
+        for _ in 0..crate::MAX_BATCH_SETTLE_SIZE {
+            users.push_back(Address::generate(&env));
+        }
+
+        let result = env.as_contract(&contract_id, || {
+            batch_settle_positions(&env, market_id, users)
+        });
+        // No positions exist for any ghost address — payout is 0, not an error.
+        assert_eq!(result, Ok(0));
     }
 }


### PR DESCRIPTION
## Summary

Closes #551

Hardens `batch_settle_positions` by rejecting empty user lists (surfaces caller bugs) and lists that exceed `MAX_BATCH_SETTLE_SIZE` (prevents gas-griefing). Both scenarios now return `ContractError::BatchTooLarge` immediately, before any iteration or storage access.

---

## Changes

### `contracts/market/src/error.rs`

Added **`BatchTooLarge = 14`** to the Position Errors group (10-19):

```rust
/// The batch supplied to `batch_settle_positions` was either empty or exceeded
/// `MAX_BATCH_SETTLE_SIZE`. Empty batches are rejected to surface caller bugs
/// early; oversized batches are rejected to prevent gas-griefing attacks.
BatchTooLarge = 14,
```

Updated:
- `test_error_discriminants` to assert `BatchTooLarge as u32 == 14`
- `test_no_duplicate_discriminants` to include the new variant in the exhaustive pair-check

### `contracts/market/src/lib.rs`

Added **`MAX_BATCH_SETTLE_SIZE`** module constant:

```rust
/// Maximum number of addresses that a single `batch_settle_positions` call may
/// process (Issue #551). Callers who need to settle more positions should either
/// use the paginated `settle_positions_page` endpoint, or split their list into
/// multiple calls of at most this many addresses.
pub const MAX_BATCH_SETTLE_SIZE: u32 = 100;
```

Grouped with `FEE_RATE_TIMELOCK_SECONDS` at the module level for visibility.

### `contracts/market/src/settlement.rs`

#### Guards added to `batch_settle_positions`

```rust
// Guard: reject empty batches immediately to surface caller bugs early
if users.is_empty() {
    return Err(ContractError::BatchTooLarge);
}

// Guard: cap batch size to prevent gas-griefing
if users.len() > crate::MAX_BATCH_SETTLE_SIZE {
    return Err(ContractError::BatchTooLarge);
}
```

Both guards fire **before** the market lookup and before any iteration, so gas consumption is minimal even when rejecting.

#### Tests added

| Test | Purpose |
|---|---|
| `test_batch_settle_rejects_empty_batch` | Empty vec → `BatchTooLarge` |
| `test_batch_settle_rejects_oversized_batch` | `len == MAX + 1` → `BatchTooLarge` |
| `test_batch_settle_accepts_batch_at_max_size` | `len == MAX` → `Ok(0)` (no error) |

#### Pre-existing tests fixed

Three existing tests passed empty `Vec<Address>` and asserted on **market-level** errors (`MarketNotResolved`, `MarketNotFound`). With the new guards, the empty-batch error fires first. Updated each to pass a **1-element list** so the market-status guard still fires and the original test intent is preserved:

- `test_batch_settle_rejects_unresolved_market`
- `test_batch_settle_returns_market_not_found_for_missing_market`
- `test_batch_settle_rejects_canceled_market`

---

## Testing

- All 3 acceptance criteria covered: empty batch errors, oversized batch errors, valid batch (at-limit) settles
- No new dependencies
- No changes to public API semantics — only input validation at the boundary
- Follows existing error-code and constant patterns