### PR TITLE
test(resolution): add window boundary tests for propose/challenge/finalize

### DIFF
--- a/contracts/resolution/src/test.rs
+++ b/contracts/resolution/src/test.rs
@@ -211,3 +211,329 @@ fn set_default_challenge_window_rejects_out_of_bounds() {
         Err(Ok(ContractError::InvalidChallengeWindow))
     );
 }
+
+// ── Issue #552: challenge_window boundary tests at propose ─────────────────────
+//
+// Constants (from lib.rs):
+//   MIN_CHALLENGE_WINDOW_SECONDS = 60
+//   MAX_CHALLENGE_WINDOW_SECONDS = 14 * 24 * 60 * 60  (1_209_600)
+//
+// validate_challenge_window uses a Range::contains check equivalent to:
+//   MIN..=MAX — so both endpoints are valid.
+
+const MIN_WINDOW: u64 = 60;
+const MAX_WINDOW: u64 = 14 * 24 * 60 * 60; // 1_209_600
+const BOND: i128 = 10_000_000;
+
+/// challenge_window == MIN (60 s) is accepted.
+#[test]
+fn propose_accepts_challenge_window_at_min() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let expiry = env.ledger().timestamp() + MIN_WINDOW + 3600;
+    let result = client.try_propose(
+        &proposer, &1u32, &true, &signature(&env), &expiry,
+        &evidence(&env), &MIN_WINDOW, &BOND,
+    );
+    assert!(result.is_ok(), "MIN window should be accepted, got: {:?}", result);
+}
+
+/// challenge_window == MAX (14 days) is accepted.
+#[test]
+fn propose_accepts_challenge_window_at_max() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let expiry = env.ledger().timestamp() + MAX_WINDOW + 3600;
+    let result = client.try_propose(
+        &proposer, &1u32, &true, &signature(&env), &expiry,
+        &evidence(&env), &MAX_WINDOW, &BOND,
+    );
+    assert!(result.is_ok(), "MAX window should be accepted, got: {:?}", result);
+}
+
+/// challenge_window == MIN - 1 (59 s) is rejected with InvalidChallengeWindow.
+#[test]
+fn propose_rejects_challenge_window_below_min() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let expiry = env.ledger().timestamp() + 3600;
+    let result = client.try_propose(
+        &proposer, &1u32, &true, &signature(&env), &expiry,
+        &evidence(&env), &(MIN_WINDOW - 1), &BOND,
+    );
+    assert_eq!(result, Err(Ok(ContractError::InvalidChallengeWindow)));
+}
+
+/// challenge_window == MAX + 1 is rejected with InvalidChallengeWindow.
+#[test]
+fn propose_rejects_challenge_window_above_max() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let expiry = env.ledger().timestamp() + MAX_WINDOW + 3600;
+    let result = client.try_propose(
+        &proposer, &1u32, &true, &signature(&env), &expiry,
+        &evidence(&env), &(MAX_WINDOW + 1), &BOND,
+    );
+    assert_eq!(result, Err(Ok(ContractError::InvalidChallengeWindow)));
+}
+
+// ── Issue #552: signature_expiry boundary tests at propose ────────────────────
+//
+// From lib.rs `propose`:
+//   if signature_expiry < proposed_at  → InvalidSignatureExpiry
+//   if signature_expiry == proposed_at → accepted (>= is valid)
+
+/// signature_expiry == proposed_at is accepted (equal is the boundary minimum).
+#[test]
+fn propose_accepts_signature_expiry_equal_to_proposed_at() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    // expiry == ledger timestamp at call time
+    let expiry = env.ledger().timestamp();
+    let result = client.try_propose(
+        &proposer, &1u32, &true, &signature(&env), &expiry,
+        &evidence(&env), &MIN_WINDOW, &BOND,
+    );
+    assert!(result.is_ok(), "expiry == proposed_at should be accepted, got: {:?}", result);
+}
+
+/// signature_expiry < proposed_at is rejected with InvalidSignatureExpiry.
+#[test]
+fn propose_rejects_signature_expiry_before_proposed_at() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    // expiry is one second before ledger time
+    let expiry = env.ledger().timestamp() - 1;
+    let result = client.try_propose(
+        &proposer, &1u32, &true, &signature(&env), &expiry,
+        &evidence(&env), &MIN_WINDOW, &BOND,
+    );
+    assert_eq!(result, Err(Ok(ContractError::InvalidSignatureExpiry)));
+}
+
+// ── Issue #552: challenge window boundary tests at challenge ──────────────────
+//
+// From lib.rs `challenge`:
+//   if timestamp > challenge_deadline  → ChallengeWindowClosed
+//
+// Key off-by-one cases:
+//   timestamp == deadline     → > is false  → window CLOSED (error)
+//   timestamp == deadline - 1 → > is false  → window OPEN   (accepted)
+//
+// Wait — re-read: `> deadline` means equal is NOT greater, so:
+//   timestamp == deadline     → NOT > deadline → window still open → accepted
+//   timestamp == deadline + 1 → > deadline     → ChallengeWindowClosed
+
+/// challenge at exactly the deadline (t == deadline) is still accepted —
+/// the guard is strictly `>`, so the boundary second is inside the window.
+#[test]
+fn challenge_accepted_at_exactly_deadline() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let window = 300u64;
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env),
+        &(env.ledger().timestamp() + window + 3600),
+        &evidence(&env), &window, &BOND,
+    );
+    // challenge_deadline == 1_000 + 300 == 1_300
+    // Set time to exactly the deadline.
+    set_time(&env, 1_300);
+
+    let challenger = Address::generate(&env);
+    let uri = String::from_str(&env, "ipfs://at-deadline");
+    let result = client.try_challenge(&challenger, &candidate_id, &uri);
+    assert!(result.is_ok(), "challenge at deadline boundary should be accepted (guard is >)");
+}
+
+/// challenge one second after the deadline is rejected with ChallengeWindowClosed.
+#[test]
+fn challenge_rejected_one_second_after_deadline() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let window = 300u64;
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env),
+        &(env.ledger().timestamp() + window + 3600),
+        &evidence(&env), &window, &BOND,
+    );
+    // challenge_deadline == 1_300; advance to 1_301
+    set_time(&env, 1_301);
+
+    let challenger = Address::generate(&env);
+    let uri = String::from_str(&env, "ipfs://past-deadline");
+    assert_eq!(
+        client.try_challenge(&challenger, &candidate_id, &uri),
+        Err(Ok(ContractError::ChallengeWindowClosed))
+    );
+}
+
+/// challenge one second before the deadline is accepted.
+#[test]
+fn challenge_accepted_one_second_before_deadline() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let window = 300u64;
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env),
+        &(env.ledger().timestamp() + window + 3600),
+        &evidence(&env), &window, &BOND,
+    );
+    // challenge_deadline == 1_300; advance to 1_299
+    set_time(&env, 1_299);
+
+    let challenger = Address::generate(&env);
+    let uri = String::from_str(&env, "ipfs://just-before-deadline");
+    let result = client.try_challenge(&challenger, &candidate_id, &uri);
+    assert!(result.is_ok(), "challenge one second before deadline should be accepted");
+}
+
+// ── Issue #552: finalize window boundary tests ────────────────────────────────
+//
+// From lib.rs `finalize`:
+//   if timestamp <= challenge_deadline  → ChallengeWindowOpen
+//
+// Key off-by-one cases:
+//   timestamp == deadline     → <= is true → window OPEN  → ChallengeWindowOpen
+//   timestamp == deadline + 1 → <= is false → window CLOSED → accepted
+
+/// finalize at exactly the deadline is rejected — the window is still open
+/// because the guard is `<=`.
+#[test]
+fn finalize_rejected_at_exactly_deadline() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let window = 300u64;
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env),
+        &(env.ledger().timestamp() + window + 3600),
+        &evidence(&env), &window, &BOND,
+    );
+    // challenge_deadline == 1_300; attempt finalize at exactly 1_300
+    set_time(&env, 1_300);
+
+    let finalizer = Address::generate(&env);
+    assert_eq!(
+        client.try_finalize(&finalizer, &candidate_id),
+        Err(Ok(ContractError::ChallengeWindowOpen))
+    );
+}
+
+/// finalize one second after the deadline succeeds.
+#[test]
+fn finalize_accepted_one_second_after_deadline() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let window = 300u64;
+    // signature_expiry well in the future so it doesn't interfere
+    let expiry = env.ledger().timestamp() + window + 7200;
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env), &expiry,
+        &evidence(&env), &window, &BOND,
+    );
+    // challenge_deadline == 1_300; advance to 1_301
+    set_time(&env, 1_301);
+
+    let finalizer = Address::generate(&env);
+    let result = client.try_finalize(&finalizer, &candidate_id);
+    assert!(result.is_ok(), "finalize one second after deadline should succeed, got: {:?}", result);
+}
+
+// ── Issue #552: signature_expiry boundary tests at finalize ───────────────────
+//
+// From lib.rs `finalize`:
+//   if timestamp > signature_expiry  → SignatureExpired
+//
+// Key off-by-one cases:
+//   timestamp == expiry     → NOT > expiry → still valid  → accepted
+//   timestamp == expiry + 1 → > expiry     → SignatureExpired
+
+/// finalize at exactly signature_expiry (t == expiry) is accepted —
+/// the guard is strictly `>`, so the boundary second is still valid.
+#[test]
+fn finalize_accepted_at_exactly_signature_expiry() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let window = 300u64;
+    // Set expiry to exactly deadline + 1 so there's a valid finalize window
+    // that starts at 1_301 and the expiry is also exactly 1_301.
+    let expiry = 1_301u64;
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env), &expiry,
+        &evidence(&env), &window, &BOND,
+    );
+
+    // Advance to the expiry second (which is also one second past the deadline)
+    set_time(&env, expiry);
+
+    let finalizer = Address::generate(&env);
+    let result = client.try_finalize(&finalizer, &candidate_id);
+    assert!(
+        result.is_ok(),
+        "finalize at exactly signature_expiry should be accepted (guard is >), got: {:?}",
+        result
+    );
+}
+
+/// finalize one second after signature_expiry is rejected with SignatureExpired.
+#[test]
+fn finalize_rejected_one_second_after_signature_expiry() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    let window = 300u64;
+    // expiry is challenge_deadline + 1, so it's right at the edge of being
+    // finalizeable. We'll advance one second past it to trigger SignatureExpired.
+    let expiry = 1_301u64;
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env), &expiry,
+        &evidence(&env), &window, &BOND,
+    );
+
+    // Advance to expiry + 1
+    set_time(&env, expiry + 1);
+
+    let finalizer = Address::generate(&env);
+    assert_eq!(
+        client.try_finalize(&finalizer, &candidate_id),
+        Err(Ok(ContractError::SignatureExpired))
+    );
+}


### PR DESCRIPTION
## Summary

Closes #552

Documents and tests every off-by-one boundary condition for the challenge window and `signature_expiry` fields across the three lifecycle steps of the Resolution contract (`propose`, `challenge`, `finalize`).

No production code is changed — this PR is tests-only.

---

## Guard semantics (documented by the tests)

| Step | Field | Guard in lib.rs | Boundary |
|---|---|---|---|
| `propose` | `challenge_window_seconds` | `MIN..=MAX` range | MIN=60 s, MAX=1_209_600 s (14 days) |
| `propose` | `signature_expiry` | `< proposed_at` → error | equal is valid; one second before is invalid |
| `challenge` | ledger timestamp | `> deadline` → closed | equal is still open; +1 s is closed |
| `finalize` | ledger timestamp | `<= deadline` → open | equal is still open; +1 s is closed |
| `finalize` | `signature_expiry` | `> expiry` → expired | equal is still valid; +1 s is expired |

---

## Tests added (12)

### `propose` — `challenge_window` boundaries
| Test | Input | Expected |
|---|---|---|
| `propose_accepts_challenge_window_at_min` | window = 60 | `Ok` |
| `propose_accepts_challenge_window_at_max` | window = 1_209_600 | `Ok` |
| `propose_rejects_challenge_window_below_min` | window = 59 | `InvalidChallengeWindow` |
| `propose_rejects_challenge_window_above_max` | window = 1_209_601 | `InvalidChallengeWindow` |

### `propose` — `signature_expiry` boundaries
| Test | Input | Expected |
|---|---|---|
| `propose_accepts_signature_expiry_equal_to_proposed_at` | expiry == now | `Ok` |
| `propose_rejects_signature_expiry_before_proposed_at` | expiry == now - 1 | `InvalidSignatureExpiry` |

### `challenge` — window boundary (guard: `timestamp > deadline`)
| Test | Timestamp | Expected |
|---|---|---|
| `challenge_accepted_one_second_before_deadline` | deadline - 1 | `Ok` |
| `challenge_accepted_at_exactly_deadline` | deadline | `Ok` (guard is strictly `>`) |
| `challenge_rejected_one_second_after_deadline` | deadline + 1 | `ChallengeWindowClosed` |

### `finalize` — window boundary (guard: `timestamp <= deadline`)
| Test | Timestamp | Expected |
|---|---|---|
| `finalize_rejected_at_exactly_deadline` | deadline | `ChallengeWindowOpen` (guard is `<=`) |
| `finalize_accepted_one_second_after_deadline` | deadline + 1 | `Ok` |

### `finalize` — `signature_expiry` boundary (guard: `timestamp > expiry`)
| Test | Timestamp | Expected |
|---|---|---|
| `finalize_accepted_at_exactly_signature_expiry` | expiry | `Ok` (guard is strictly `>`) |
| `finalize_rejected_one_second_after_signature_expiry` | expiry + 1 | `SignatureExpired` |

---

## Notes

- Each test is self-contained with a fresh `Env` and uses the existing `setup` / `set_time` / `signature` / `evidence` helpers.
- Constants `MIN_WINDOW`, `MAX_WINDOW`, and `BOND` are inlined as module-level `const` values that mirror `MIN_CHALLENGE_WINDOW_SECONDS`, `MAX_CHALLENGE_WINDOW_SECONDS`, and `MIN_BOND_AMOUNT` from `lib.rs` — if those values change, the tests will need updating (intentional coupling).
- No new dependencies introduced.