### PR TITLE
test(treasury): add auth and event tests for withdraw_fees

### DIFF
--- a/contracts/treasury/src/test.rs
+++ b/contracts/treasury/src/test.rs
@@ -727,3 +727,119 @@ fn distribute_fees_blocked_while_paused() {
         .unwrap();
     assert_eq!(err, TreasuryError::ContractPaused);
 }
+
+// ── Issue #553: withdraw_fees auth + event ─────────────────────────────────────
+
+/// `withdraw_fees` must emit a `FeesWithdrawn` event with the correct fields:
+/// - topics: event name, token address, recipient address
+/// - data: amount withdrawn, remaining token balance after withdrawal
+#[test]
+fn withdraw_fees_emits_fees_withdrawn_event() {
+    use soroban_sdk::testutils::Events as _;
+    use soroban_sdk::{IntoVal, Map, Symbol, TryIntoVal, Val};
+
+    let s = setup();
+    let collected = 1_000_000i128;
+    let withdrawn = 400_000i128;
+    let expected_remaining = collected - withdrawn;
+
+    fund_treasury(&s, collected);
+    s.client.collect_fee(&s.market, &s.token, &1u32, &collected);
+
+    let recipient = Address::generate(&s.env);
+    s.client.withdraw_fees(&s.admin, &s.token, &recipient, &withdrawn);
+
+    let events = s.env.events().all();
+    // The last event must be FeesWithdrawn.
+    let ev = events.last().unwrap();
+
+    // ── topics ────────────────────────────────────────────────────────────────
+    // Soroban contractevent layout: [contract_address, event_name, ...#topic fields]
+    let topics = &ev.1;
+    let event_name: Symbol = topics.get(0).unwrap().into_val(&s.env);
+    assert_eq!(
+        event_name,
+        Symbol::new(&s.env, "fees_withdrawn"),
+        "event name topic must be 'fees_withdrawn'"
+    );
+    let token_topic: Address = topics.get(1).unwrap().into_val(&s.env);
+    assert_eq!(token_topic, s.token, "second topic must be the token address");
+    let to_topic: Address = topics.get(2).unwrap().into_val(&s.env);
+    assert_eq!(to_topic, recipient, "third topic must be the recipient address");
+
+    // ── data fields ───────────────────────────────────────────────────────────
+    let data: Map<Symbol, Val> = ev.2.try_into_val(&s.env).unwrap();
+
+    let amount_val: i128 = data
+        .get(Symbol::new(&s.env, "amount"))
+        .unwrap()
+        .into_val(&s.env);
+    assert_eq!(amount_val, withdrawn, "event 'amount' must equal the withdrawn amount");
+
+    let remaining_val: i128 = data
+        .get(Symbol::new(&s.env, "remaining_token_balance"))
+        .unwrap()
+        .into_val(&s.env);
+    assert_eq!(
+        remaining_val, expected_remaining,
+        "event 'remaining_token_balance' must equal balance after withdrawal"
+    );
+}
+
+/// `withdraw_fees` must call `require_auth` on the caller address before
+/// proceeding — calling it without the Soroban auth context must panic, not
+/// return `Unauthorized`. This verifies the auth gate sits at the entry point
+/// (before any business logic) rather than being implemented as a manual
+/// address comparison only.
+#[test]
+#[should_panic]
+fn withdraw_fees_panics_without_auth() {
+    // No mock_all_auths() — the env has no auth context at all.
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let market = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    let treasury_id = env.register(TreasuryContract, ());
+    let client = TreasuryContractClient::new(&env, &treasury_id);
+
+    // Bootstrap the treasury with auth mocked just for initialize.
+    env.mock_all_auths();
+    client.initialize(&admin, &market);
+    // Clear all mock authorizations — no auth context for subsequent calls.
+    env.set_auths(&[]);
+
+    let recipient = Address::generate(&env);
+    // require_auth() is unsatisfied → must panic
+    client.withdraw_fees(&admin, &token, &recipient, &1i128);
+}
+
+/// `withdraw_fees` called by a non-admin returns `TreasuryError::Unauthorized`.
+/// This is distinct from the auth check above: the non-admin caller *does*
+/// authorize themselves (mock auth), but the contract checks `caller == admin`
+/// and rejects. Ensures both layers of access control work together.
+#[test]
+fn withdraw_fees_non_admin_returns_unauthorized() {
+    let s = setup();
+    fund_treasury(&s, 100_000);
+    s.client.collect_fee(&s.market, &s.token, &1u32, &100_000i128);
+
+    let imposter = Address::generate(&s.env);
+    let recipient = Address::generate(&s.env);
+    let err = s
+        .client
+        .try_withdraw_fees(&imposter, &s.token, &recipient, &50_000i128)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        err,
+        TreasuryError::Unauthorized,
+        "a caller who is not the admin must receive Unauthorized even with valid auth"
+    );
+    // Verify no funds moved.
+    assert_eq!(s.client.token_balance(&s.token), 100_000);
+}


### PR DESCRIPTION
## Summary

Closes #553

`withdraw_fees` already has `require_auth`, the admin check, and `FeesWithdrawn` event emission in production code. This PR adds the three missing tests that verify all those layers are exercised correctly.

Tests-only change — no production code modified.

---

## Tests added (3)

### `withdraw_fees_emits_fees_withdrawn_event`

Full field-level assertion against the `FeesWithdrawn` `#[contractevent]`:

| Field | Assertion |
|---|---|
| `topics[0]` | `Symbol::new("fees_withdrawn")` (event name) |
| `topics[1]` | token address |
| `topics[2]` | recipient address |
| `data.amount` | equals the withdrawn amount |
| `data.remaining_token_balance` | equals balance after withdrawal |

Follows the same pattern as the existing `transfer_admin_emits_event` test.

### `withdraw_fees_panics_without_auth`

`#[should_panic]` test. Initializes the treasury under `mock_all_auths`, then clears the auth context via `env.set_auths(&[])` and calls `withdraw_fees`. Verifies that `require_auth()` fires at the function entry point — before the admin comparison — so an unauthenticated call panics rather than silently proceeding or returning a logic error.

### `withdraw_fees_non_admin_returns_unauthorized`

Verifies the post-auth admin guard: a caller who *does* have valid Soroban auth but is not the stored admin receives `TreasuryError::Unauthorized`. Also asserts that no funds moved as a side effect of the rejected call.

---

## Acceptance criteria

- ✅ Non-admin cannot withdraw fees — covered by `withdraw_fees_non_admin_returns_unauthorized` (and the pre-existing `withdraw_fees_rejects_non_admin`)
- ✅ Event observed in test — covered by `withdraw_fees_emits_fees_withdrawn_event`