### PR TITLE
fix(#593,#592,#591,#590): pause gate, oracle expiry, position refresh…, dry-run docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,13 @@ target/
 Cargo.lock
 **/*.rs.bk
 
+# Rust test / coverage artifacts
+*.profraw
+*.profdata
+lcov.info
+tarpaulin-report.html
+tarpaulin-report.json
+
 # IDE
 .vscode/
 .idea/
@@ -22,8 +29,10 @@ Thumbs.db
 *.dylib
 *.dll
 
+# Soroban / WASM test snapshots — regenerate with `cargo test`
 contracts/*/test_snapshots
 /test_snapshots/
+**/*.snap
 
 # Node / Next.js
 node_modules/
@@ -33,8 +42,15 @@ apps/web/out/
 dist/
 apps/web/tsconfig.tsbuildinfo
 
+# Jest / Vitest snapshots
+**/__snapshots__/
+
 # Generated issue exports (regenerate with pnpm issues:generate)
 scripts/issues/generated/
+
+# Local environment overrides (keep .env.local.example committed)
+.env.local
+.env.*.local
 
 # Personal notes
 vrickish.md

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The Market contract uses storage versioning to ensure data integrity across upgr
   
 - **[Migration History](contracts/market/MIGRATION.md)** - Specific changes and data migration notes
 
+- **[Upgrade Dry-Run Guide](docs/upgrade-dry-run.md)** - How to simulate a contract upgrade and storage migration with `--send=no` before applying to testnet or mainnet. Includes a ready-to-run script stub (`scripts/upgrade-dry-run.sh`).
+
 **Quick Reference:**
 - Current storage version: `3`
 - Always bump version for: field changes, type changes, semantic changes to stored data

--- a/apps/web/components/PositionPanel.tsx
+++ b/apps/web/components/PositionPanel.tsx
@@ -88,7 +88,12 @@ export function PositionPanel({ marketId }: PositionPanelProps) {
         <div ref={depositFormRef}>
           <DepositForm marketId={marketId} />
         </div>
-        <WithdrawForm />
+        {/*
+         * Pass `refresh` as `onSuccess` so the position panel refetches
+         * on-chain state immediately after a successful withdrawal, keeping
+         * the UI in sync without a full page reload (#591).
+         */}
+        <WithdrawForm onSuccess={refresh} />
       </div>
 
       <div className="rounded-lg border border-slate-200 p-4 dark:border-slate-700 sm:p-6">

--- a/apps/web/components/WithdrawForm.tsx
+++ b/apps/web/components/WithdrawForm.tsx
@@ -7,7 +7,15 @@ import { TxResult } from "@/components/TxResult";
 import { useToast } from "@/context/ToastContext";
 import { parseContractError } from "@/lib/errors";
 
-export function WithdrawForm() {
+interface WithdrawFormProps {
+  /**
+   * Optional callback invoked after a successful withdrawal transaction.
+   * Use this to trigger a position refetch in the parent (e.g. PositionPanel).
+   */
+  onSuccess?: () => void;
+}
+
+export function WithdrawForm({ onSuccess }: WithdrawFormProps) {
   const { address } = useWallet();
   const { showToast } = useToast();
   const [amount, setAmount] = useState("");
@@ -53,6 +61,10 @@ export function WithdrawForm() {
 
       setTxHash(result.hash);
       setAmount("");
+
+      // Notify parent so it can refetch the position and reflect the updated
+      // on-chain state without requiring a full page reload (#591).
+      onSuccess?.();
     } catch (err) {
       console.error("Withdrawal error:", err);
       const reason = parseContractError(err);

--- a/contracts/market/src/error.rs
+++ b/contracts/market/src/error.rs
@@ -110,6 +110,11 @@ pub enum ContractError {
     /// node network may be temporarily disconnected.
     OraclePriceUnavailable = 23,
 
+    /// The oracle message has an `expires_at` deadline that has already
+    /// passed. Signed outcomes cannot be replayed after their stated
+    /// deadline — submit a freshly signed message instead.
+    OracleMessageExpired = 24,
+
     // ========== Validation Errors (30-39) ==========
     /// Price is out of valid range (must be between 0 and 1).
     ///
@@ -259,6 +264,7 @@ mod tests {
         assert_eq!(ContractError::UnauthorizedOracle as u32, 21);
         assert_eq!(ContractError::InvalidOutcome as u32, 22);
         assert_eq!(ContractError::OraclePriceUnavailable as u32, 23);
+        assert_eq!(ContractError::OracleMessageExpired as u32, 24);
         assert_eq!(ContractError::InvalidPrice as u32, 30);
         assert_eq!(ContractError::InvalidQuantity as u32, 31);
         assert_eq!(ContractError::InvalidTimestamp as u32, 32);
@@ -326,6 +332,7 @@ mod tests {
             (ContractError::UnauthorizedOracle, 21),
             (ContractError::InvalidOutcome, 22),
             (ContractError::OraclePriceUnavailable, 23),
+            (ContractError::OracleMessageExpired, 24),
             (ContractError::InvalidPrice, 30),
             (ContractError::InvalidQuantity, 31),
             (ContractError::InvalidTimestamp, 32),

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -416,6 +416,10 @@ impl MarketContract {
     /// * `market_id` - Market to resolve (decimal string, e.g. "1")
     /// * `outcome` - Outcome (true = YES won, false = NO won)
     /// * `signature` - Oracle's Ed25519 signature (64 bytes)
+    /// * `expires_at` - Unix timestamp deadline after which this signed message
+    ///   is no longer valid. Pass `0` to disable expiry enforcement (backwards
+    ///   compatible with callers that do not supply a deadline). A non-zero
+    ///   value that is in the past returns [`ContractError::OracleMessageExpired`].
     ///
     /// # Returns
     /// Unit (success)
@@ -423,6 +427,7 @@ impl MarketContract {
     /// # Errors
     /// - MarketNotFound
     /// - MarketAlreadyResolved
+    /// - OracleMessageExpired: The oracle message deadline has passed
     /// - InvalidSignature: Signature verification failed
     /// - UnauthorizedOracle: Wrong oracle pubkey
     ///
@@ -434,6 +439,7 @@ impl MarketContract {
         market_id: String,
         outcome: bool,
         signature: BytesN<64>,
+        expires_at: u64,
     ) -> Result<(), ContractError> {
         validation::require_not_paused(&env)?;
         resolver.require_auth();
@@ -445,7 +451,16 @@ impl MarketContract {
             return Err(ContractError::MarketAlreadyResolved);
         }
 
-        // Step 1.5: When a resolution contract is registered for this
+        // Step 1.5 (expiry): Reject stale oracle messages. A non-zero
+        // `expires_at` that is strictly less than the current ledger timestamp
+        // means the signed payload has outlived its intended window and must
+        // not be applied — prevents long-lived signatures being replayed weeks
+        // or months after they were originally produced.
+        if expires_at != 0 && env.ledger().timestamp() > expires_at {
+            return Err(ContractError::OracleMessageExpired);
+        }
+
+        // Step 1.6: When a resolution contract is registered for this
         // contract (see `set_resolution_contract`), resolve_market may only
         // be reached once that contract has finalized a matching candidate
         // — i.e. its challenge-window lifecycle has run to completion. This

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -546,7 +546,7 @@ mod test {
         let outcome = true;
         let invalid_signature = BytesN::from_array(&env, &[0u8; 64]);
 
-        client.resolve_market(&resolver, &non_existent_market_id, &outcome, &invalid_signature);
+        client.resolve_market(&resolver, &non_existent_market_id, &outcome, &invalid_signature, &0u64);
     }
 
     #[test]
@@ -582,7 +582,7 @@ mod test {
         let outcome = true;
         let invalid_signature = BytesN::from_array(&env, &[0u8; 64]);
         let market_id_str = String::from_str(&env, "1");
-        client.resolve_market(&resolver, &market_id_str, &outcome, &invalid_signature);
+        client.resolve_market(&resolver, &market_id_str, &outcome, &invalid_signature, &0u64);
     }
 
     #[test]
@@ -611,7 +611,7 @@ mod test {
         let outcome = true;
         let invalid_signature = BytesN::random(&env);
         let market_id_str = String::from_str(&env, "1");
-        client.resolve_market(&resolver, &market_id_str, &outcome, &invalid_signature);
+        client.resolve_market(&resolver, &market_id_str, &outcome, &invalid_signature, &0u64);
     }
 
     #[test]
@@ -636,7 +636,7 @@ mod test {
         let outcome = true;
         let invalid_signature = BytesN::random(&env);
         let market_id_str = String::from_str(&env, "1");
-        let result = client.try_resolve_market(&resolver, &market_id_str, &outcome, &invalid_signature);
+        let result = client.try_resolve_market(&resolver, &market_id_str, &outcome, &invalid_signature, &0u64);
 
         assert_eq!(
             result,
@@ -681,7 +681,7 @@ mod test {
         // Resolve market with valid signature
         let resolver = Address::generate(&env);
         let market_id_str = String::from_str(&env, "1");
-        client.resolve_market(&resolver, &market_id_str, &outcome, &signature);
+        client.resolve_market(&resolver, &market_id_str, &outcome, &signature, &0u64);
 
         // Verify market is now Resolved
         let market_after = get_market_from_storage(&env, &contract_id, market_id);
@@ -747,7 +747,7 @@ mod test {
         // Resolve market with valid signature
         let resolver = Address::generate(&env);
         let market_id_str = String::from_str(&env, "1");
-        client.resolve_market(&resolver, &market_id_str, &outcome, &signature);
+        client.resolve_market(&resolver, &market_id_str, &outcome, &signature, &0u64);
 
         // Verify event was emitted
         let events = env.events().all();
@@ -758,6 +758,188 @@ mod test {
         assert_eq!(market.status, MarketStatus::Resolved);
         assert_eq!(market.result, Some(outcome));
         assert_eq!(market.resolver, Some(resolver));
+    }
+
+    // ── #592: resolve_market rejects expired oracle messages ──────────────────
+
+    /// An oracle message with `expires_at` in the past must be rejected with
+    /// `OracleMessageExpired` (#24) so stale signatures cannot be replayed.
+    #[test]
+    fn resolve_market_rejects_expired_oracle_message() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+
+        let question = String::from_str(&env, "Expiry test market");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let market_id = 1u32;
+        let outcome = true;
+        let (oracle_pubkey, signature) = generate_test_keypair_and_sign(&env, market_id, outcome);
+
+        client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &Address::generate(&env),
+            &None,
+        );
+
+        // Advance the ledger past the expires_at deadline.
+        let expires_at: u64 = env.ledger().timestamp() + 60;
+        env.ledger().set_timestamp(expires_at + 1);
+
+        let resolver = Address::generate(&env);
+        let market_id_str = String::from_str(&env, "1");
+        let err = client
+            .try_resolve_market(&resolver, &market_id_str, &outcome, &signature, &expires_at)
+            .unwrap_err()
+            .unwrap();
+
+        assert_eq!(
+            err,
+            crate::error::ContractError::OracleMessageExpired,
+            "expired oracle message must return OracleMessageExpired (#24)"
+        );
+    }
+
+    /// A message with `expires_at` still in the future must be accepted normally.
+    #[test]
+    fn resolve_market_accepts_non_expired_oracle_message() {
+        let (env, admin, client, contract_id) = create_test_contract();
+
+        let question = String::from_str(&env, "Non-expired expiry test");
+        let current_time = env.ledger().timestamp();
+        let end_time = current_time + 86_400;
+        let market_id = 1u32;
+        let outcome = true;
+        let (oracle_pubkey, signature) = generate_test_keypair_and_sign(&env, market_id, outcome);
+
+        client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &Address::generate(&env),
+            &None,
+        );
+
+        // expires_at is in the future — must succeed.
+        let expires_at: u64 = current_time + 3_600;
+        let resolver = Address::generate(&env);
+        let market_id_str = String::from_str(&env, "1");
+        client.resolve_market(&resolver, &market_id_str, &outcome, &signature, &expires_at);
+
+        let market = get_market_from_storage(&env, &contract_id, market_id);
+        assert_eq!(
+            market.status,
+            crate::types::MarketStatus::Resolved,
+            "market must be resolved when expires_at is still in the future"
+        );
+    }
+
+    /// Passing `expires_at = 0` disables expiry enforcement — the call must
+    /// succeed regardless of the current ledger timestamp (backwards compat).
+    #[test]
+    fn resolve_market_zero_expires_at_disables_expiry_check() {
+        let (env, admin, client, contract_id) = create_test_contract();
+
+        let question = String::from_str(&env, "Zero expires_at test");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let market_id = 1u32;
+        let outcome = false;
+        let (oracle_pubkey, signature) = generate_test_keypair_and_sign(&env, market_id, outcome);
+
+        client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &Address::generate(&env),
+            &None,
+        );
+
+        // Advance ledger far into the future — expires_at=0 means no check.
+        env.ledger().set_timestamp(u64::MAX / 2);
+
+        let resolver = Address::generate(&env);
+        let market_id_str = String::from_str(&env, "1");
+        // expires_at=0 → no expiry enforcement, must succeed.
+        client.resolve_market(&resolver, &market_id_str, &outcome, &signature, &0u64);
+
+        let market = get_market_from_storage(&env, &contract_id, market_id);
+        assert_eq!(market.status, crate::types::MarketStatus::Resolved);
+    }
+
+    /// Expiry check fires BEFORE signature verification so the error is always
+    /// `OracleMessageExpired` rather than `InvalidSignature` when both are wrong.
+    #[test]
+    fn resolve_market_expiry_checked_before_signature() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+
+        let question = String::from_str(&env, "Expiry order test");
+        let end_time = env.ledger().timestamp() + 86_400;
+
+        client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &BytesN::from_array(&env, &[1u8; 32]),
+            &Address::generate(&env),
+            &None,
+        );
+
+        // Advance past expiry; also use an invalid signature — expiry must win.
+        let expires_at: u64 = env.ledger().timestamp() + 10;
+        env.ledger().set_timestamp(expires_at + 100);
+
+        let resolver = Address::generate(&env);
+        let market_id_str = String::from_str(&env, "1");
+        let bad_sig = BytesN::from_array(&env, &[0u8; 64]);
+        let err = client
+            .try_resolve_market(&resolver, &market_id_str, &true, &bad_sig, &expires_at)
+            .unwrap_err()
+            .unwrap();
+
+        assert_eq!(err, crate::error::ContractError::OracleMessageExpired);
+    }
+
+    /// Market must remain `Active` (no state mutation) when `resolve_market`
+    /// returns `OracleMessageExpired`.
+    #[test]
+    fn resolve_market_expired_message_leaves_market_unchanged() {
+        let (env, admin, client, contract_id) = create_test_contract();
+
+        let question = String::from_str(&env, "State mutation test");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let market_id = 1u32;
+        let outcome = true;
+        let (oracle_pubkey, signature) = generate_test_keypair_and_sign(&env, market_id, outcome);
+
+        client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &Address::generate(&env),
+            &None,
+        );
+
+        let expires_at: u64 = env.ledger().timestamp() + 30;
+        env.ledger().set_timestamp(expires_at + 1);
+
+        let resolver = Address::generate(&env);
+        let market_id_str = String::from_str(&env, "1");
+        let _ = client.try_resolve_market(
+            &resolver,
+            &market_id_str,
+            &outcome,
+            &signature,
+            &expires_at,
+        );
+
+        let market = get_market_from_storage(&env, &contract_id, market_id);
+        assert_eq!(market.status, crate::types::MarketStatus::Active);
+        assert_eq!(market.result, None);
+        assert_eq!(market.resolver, None);
     }
 
     #[test]
@@ -1424,7 +1606,7 @@ mod test {
         let resolver = Address::generate(&env);
         let market_id_str = String::from_str(&env, &market_id.to_string());
         assert_eq!(
-            client.try_resolve_market(&resolver, &market_id_str, &true, &signature),
+            client.try_resolve_market(&resolver, &market_id_str, &true, &signature, &0u64),
             Err(Ok(ContractError::ResolutionNotFinalized))
         );
     }
@@ -1860,7 +2042,8 @@ mod test {
             storage::set_market(&env, market_id, &market).unwrap();
         });
         let market_id_str = String::from_str(&env, "1");
-        client.resolve_market(&market_id_str, &true, &signature);
+        let resolver = Address::generate(&env);
+        client.resolve_market(&resolver, &market_id_str, &true, &signature, &0u64);
 
         // Make sure the contract holds enough tokens to pay out.
         let stored_market = env.as_contract(&contract_id, || {
@@ -2020,12 +2203,12 @@ mod test {
         client.update_market_oracle(&admin, &market_id, &new_oracle_pubkey);
 
         let market_id_str = String::from_str(&env, "1");
-        let old_result = client.try_resolve_market(&resolver, &market_id_str, &true, &old_signature);
+        let old_result = client.try_resolve_market(&resolver, &market_id_str, &true, &old_signature, &0u64);
         assert_eq!(old_result, Err(Ok(ContractError::InvalidSignature)));
 
         let message = crate::oracle::construct_oracle_message(&env, market_id, true);
         let new_signature = BytesN::from_array(&env, &new_signing_key.sign(message.to_array().as_slice()).to_bytes());
-        let new_result = client.try_resolve_market(&resolver, &market_id_str, &true, &new_signature);
+        let new_result = client.try_resolve_market(&resolver, &market_id_str, &true, &new_signature, &0u64);
         assert_eq!(new_result, Ok(Ok(())));
 
         let market = env.as_contract(&contract_id, || storage::get_market(&env, market_id).unwrap().unwrap());
@@ -2304,7 +2487,9 @@ mod test {
         // Advance time past end_time so the market can be resolved.
         env.ledger().set_timestamp(end_time + 1);
 
-        client.resolve_market(&market_id, &true, &signature);
+        let resolver = Address::generate(&env);
+        let market_id_str = String::from_str(&env, "1");
+        client.resolve_market(&resolver, &market_id_str, &true, &signature, &0u64);
 
         let market = client.get_market(&market_id);
         assert_eq!(market.status, MarketStatus::Resolved);

--- a/contracts/treasury/src/test.rs
+++ b/contracts/treasury/src/test.rs
@@ -604,6 +604,86 @@ fn unpause_rejects_non_admin() {
     assert_eq!(err, TreasuryError::Unauthorized);
 }
 
+// ── #593: collect_fee pause gate ─────────────────────────────────────────────
+
+/// `collect_fee` must be blocked while the treasury is paused and must return
+/// `ContractPaused` (#50) — not succeed, not panic, not return a different error.
+#[test]
+fn collect_fee_paused_returns_contract_paused() {
+    let s = setup();
+    s.client.pause(&s.admin);
+
+    let err = s
+        .client
+        .try_collect_fee(&s.market, &s.token, &42u32, &1_000i128)
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TreasuryError::ContractPaused,
+        "collect_fee must return ContractPaused while treasury is paused"
+    );
+}
+
+/// The pause gate is checked before the authorised-market check, so even a
+/// caller that is NOT a registered market gets `ContractPaused` rather than
+/// `CallerNotMarket` while the treasury is paused.
+#[test]
+fn collect_fee_paused_before_market_auth_check() {
+    let s = setup();
+    s.client.pause(&s.admin);
+
+    let rogue = Address::generate(&s.env);
+    let err = s
+        .client
+        .try_collect_fee(&rogue, &s.token, &1u32, &500i128)
+        .unwrap_err()
+        .unwrap();
+
+    // The pause gate fires before the market-registry check.
+    assert_eq!(err, TreasuryError::ContractPaused);
+}
+
+/// Balances must remain unchanged after a rejected `collect_fee` during pause.
+/// No state must be mutated when the call returns `ContractPaused`.
+#[test]
+fn collect_fee_paused_leaves_balances_unchanged() {
+    let s = setup();
+    // Collect some fees before pausing so we have a non-zero baseline.
+    s.client.collect_fee(&s.market, &s.token, &1u32, &200_000i128);
+    let balance_before = s.client.token_balance(&s.token);
+    let cumulative_before = s.client.get_cumulative_fees(&s.token);
+    let total_before = s.client.total_collected();
+
+    s.client.pause(&s.admin);
+
+    // Attempt a second collection while paused — must be rejected.
+    let _ = s
+        .client
+        .try_collect_fee(&s.market, &s.token, &2u32, &100_000i128);
+
+    // All counters must be unchanged.
+    assert_eq!(s.client.token_balance(&s.token), balance_before);
+    assert_eq!(s.client.get_cumulative_fees(&s.token), cumulative_before);
+    assert_eq!(s.client.total_collected(), total_before);
+}
+
+/// After unpausing, `collect_fee` should succeed and update all counters as
+/// normal — proving the gate does not leave permanent side effects.
+#[test]
+fn collect_fee_resumes_after_unpause() {
+    let s = setup();
+    s.client.pause(&s.admin);
+    s.client.unpause(&s.admin);
+
+    s.client.collect_fee(&s.market, &s.token, &7u32, &50_000i128);
+
+    assert_eq!(s.client.token_balance(&s.token), 50_000);
+    assert_eq!(s.client.get_cumulative_fees(&s.token), 50_000);
+    assert_eq!(s.client.total_collected(), 50_000);
+}
+
 // ── stakeholder fee distribution (#485) ───────────────────────────────────────
 
 #[test]

--- a/docs/upgrade-dry-run.md
+++ b/docs/upgrade-dry-run.md
@@ -1,0 +1,170 @@
+# Upgrade Dry-Run Guide
+
+> **Purpose:** Validate a contract upgrade and its storage migrations in a safe,
+> non-destructive way before applying changes to testnet or mainnet.
+
+---
+
+## Overview
+
+A "dry-run" upgrade simulates the `stellar contract deploy` + `initialize` flow
+against a locally-forked or simulation-mode ledger so you can confirm:
+
+- The new WASM builds and passes the host's size/fee checks.
+- The on-chain storage version is incremented correctly.
+- `assert_version()` rejects the old layout and accepts the new one.
+- No existing storage keys silently disappear or change meaning.
+
+This guide covers the full dry-run workflow using the Stellar CLI's
+`--send=no` (simulate-only) flag, a local testnet fork, and the provided
+script stub.
+
+---
+
+## Prerequisites
+
+| Tool | Minimum version | Install |
+|------|----------------|---------|
+| `stellar` CLI | v21.4.0+ | [developers.stellar.org/docs/tools/cli](https://developers.stellar.org/docs/tools/cli) |
+| Rust toolchain | stable | `rustup update stable` |
+| `wasm32v1-none` target | — | `rustup target add wasm32v1-none` |
+| Funded testnet account | — | [friendbot.stellar.org](https://friendbot.stellar.org) |
+
+---
+
+## Step-by-step dry-run procedure
+
+### 1. Bump the storage version (if required)
+
+Before building, verify whether the storage layout changed.  
+Follow the **[Reviewer Checklist: StorageKey Table Drift](../contracts/market/STORAGE_MIGRATION_GUIDE.md#reviewer-checklist-storagekey-table-drift)** and, if needed, increment `STORAGE_VERSION` in `contracts/market/src/storage.rs`.
+
+```bash
+# Quick check: list StorageKey variants
+grep -oE '^\s{4}[A-Z][A-Za-z]+' contracts/market/src/storage.rs | sort -u
+
+# Current version
+grep 'STORAGE_VERSION' contracts/market/src/storage.rs
+```
+
+Document the change in [`contracts/market/MIGRATION.md`](../contracts/market/MIGRATION.md).
+
+### 2. Build the upgraded WASM
+
+```bash
+cd contracts/market
+stellar contract build
+# Artifact: ../../target/wasm32v1-none/release/vatix_market_contract.wasm
+```
+
+Verify the hash matches what CI produces:
+
+```bash
+bash scripts/verify-wasm-hash.sh contracts/market
+```
+
+### 3. Simulate the upload (no broadcast)
+
+```bash
+stellar contract upload \
+  --wasm target/wasm32v1-none/release/vatix_market_contract.wasm \
+  --source $TESTNET_SECRET_KEY \
+  --network testnet \
+  --send=no
+```
+
+`--send=no` runs full simulation (fee estimation, preflight, host-level
+validation) without submitting the transaction. A clean exit here confirms
+the WASM is within byte-size and cost limits.
+
+### 4. Simulate the upgrade call
+
+```bash
+stellar contract invoke \
+  --id $OLD_CONTRACT_ID \
+  --source $TESTNET_SECRET_KEY \
+  --network testnet \
+  --send=no \
+  -- upgrade \
+  --new_wasm_hash <HASH_FROM_STEP_3>
+```
+
+Again, `--send=no` exercises the `upgrade` entry-point's preflight without
+mutating ledger state.
+
+### 5. Verify storage version acceptance
+
+After a real upgrade (not dry-run), call a read function that routes through
+`assert_version()` — `get_admin` is a simple, safe choice:
+
+```bash
+stellar contract invoke \
+  --id $NEW_CONTRACT_ID \
+  --network testnet \
+  --send=no \
+  -- get_admin
+```
+
+A successful return confirms the new version is written and accepted.  
+An `UpgradeRequired` error (#70) means `initialize` or the migration step
+was not run yet.
+
+### 6. Confirm old deployment is locked (testnet only)
+
+```bash
+stellar contract invoke \
+  --id $OLD_CONTRACT_ID \
+  --network testnet \
+  --send=no \
+  -- get_admin
+# Expected: Error(Contract, #70) — UpgradeRequired
+```
+
+This verifies that old clients cannot continue calling the stale contract.
+
+---
+
+## Automated dry-run script
+
+[`scripts/upgrade-dry-run.sh`](../scripts/upgrade-dry-run.sh) wraps the
+steps above in a single command. It is intentionally simulation-only
+(`--send=no` throughout) and safe to run in CI or locally against a funded
+testnet account.
+
+```bash
+# Required env vars
+export TESTNET_SECRET_KEY="S..."
+export OLD_CONTRACT_ID="C..."   # existing deployment to verify lockout
+export CONTRACT_DIR="contracts/market"   # default
+
+bash scripts/upgrade-dry-run.sh
+```
+
+The script exits non-zero if any simulation step fails, making it suitable
+as a pre-deploy CI gate.
+
+---
+
+## Checklist for contributors
+
+Before opening a PR that touches storage:
+
+- [ ] `STORAGE_VERSION` bumped (if storage layout changed)
+- [ ] `MIGRATION.md` updated with what changed and why
+- [ ] `StorageKey` enum and `lib.rs` doc table kept in sync
+  (see [Reviewer Checklist](../contracts/market/STORAGE_MIGRATION_GUIDE.md#reviewer-checklist-storagekey-table-drift))
+- [ ] `assert_version()` tests pass locally
+- [ ] Dry-run simulation succeeds (`bash scripts/upgrade-dry-run.sh`)
+- [ ] WASM hash documented in PR description
+
+---
+
+## Related documentation
+
+- [Storage Migration Guide](../contracts/market/STORAGE_MIGRATION_GUIDE.md) —
+  full procedures for testnet and mainnet, rollback plans, and common pitfalls.
+- [Migration History](../contracts/market/MIGRATION.md) — per-version changelog.
+- [Build Verification](../README.md#build-verification) — how to confirm your
+  WASM hash matches CI.
+- [Testnet Smoke Test](../README.md#testnet-smoke-test) — lightweight
+  read-only check after deployment.

--- a/scripts/upgrade-dry-run.sh
+++ b/scripts/upgrade-dry-run.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# scripts/upgrade-dry-run.sh
+#
+# Dry-run upgrade simulation for a Vatix Soroban contract.
+#
+# Runs all upgrade steps with --send=no (simulate-only) so no ledger state
+# is mutated. Safe to run in CI or locally against a funded testnet account.
+#
+# See docs/upgrade-dry-run.md for the full step-by-step guide and checklist.
+#
+# Required environment variables:
+#   TESTNET_SECRET_KEY   — Funded testnet account secret key (S...)
+#   OLD_CONTRACT_ID      — Deployed contract ID to verify version-lockout on
+#
+# Optional environment variables:
+#   CONTRACT_DIR         — Contract directory to build (default: contracts/market)
+#   SOROBAN_NETWORK      — Network name (default: testnet)
+#   SOROBAN_RPC_URL      — Custom RPC URL (overrides network default)
+#   NETWORK_PASSPHRASE   — Custom network passphrase
+
+set -euo pipefail
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+
+CONTRACT_DIR="${CONTRACT_DIR:-contracts/market}"
+NETWORK="${SOROBAN_NETWORK:-testnet}"
+
+if [[ -z "${TESTNET_SECRET_KEY:-}" ]]; then
+  echo "ERROR: TESTNET_SECRET_KEY is not set." >&2
+  echo "       Export a funded testnet account secret key before running." >&2
+  exit 1
+fi
+
+# ── Step 1: Build ──────────────────────────────────────────────────────────────
+
+echo "==> [1/4] Building contract WASM in ${CONTRACT_DIR} ..."
+(cd "${CONTRACT_DIR}" && stellar contract build)
+
+# Locate the WASM artifact
+WASM_PATH="$(find target/wasm32v1-none/release -name '*.wasm' | head -1)"
+if [[ -z "${WASM_PATH}" ]]; then
+  echo "ERROR: No WASM artifact found under target/wasm32v1-none/release/" >&2
+  exit 1
+fi
+echo "    WASM: ${WASM_PATH}"
+
+# ── Step 2: Simulate upload ────────────────────────────────────────────────────
+
+echo "==> [2/4] Simulating contract upload (--send=no) ..."
+UPLOAD_OUTPUT=$(stellar contract upload \
+  --wasm "${WASM_PATH}" \
+  --source "${TESTNET_SECRET_KEY}" \
+  --network "${NETWORK}" \
+  --send=no 2>&1)
+echo "${UPLOAD_OUTPUT}"
+
+# Extract WASM hash from simulation output (preflight returns it in the result).
+WASM_HASH=$(echo "${UPLOAD_OUTPUT}" | grep -oE '[0-9a-f]{64}' | head -1 || true)
+if [[ -z "${WASM_HASH}" ]]; then
+  echo "WARN: Could not extract WASM hash from simulation output."
+  echo "      Skipping upgrade simulation step."
+else
+  echo "    WASM hash (simulated): ${WASM_HASH}"
+
+  # ── Step 3: Simulate upgrade call ───────────────────────────────────────────
+
+  if [[ -n "${OLD_CONTRACT_ID:-}" ]]; then
+    echo "==> [3/4] Simulating upgrade invocation on ${OLD_CONTRACT_ID} (--send=no) ..."
+    stellar contract invoke \
+      --id "${OLD_CONTRACT_ID}" \
+      --source "${TESTNET_SECRET_KEY}" \
+      --network "${NETWORK}" \
+      --send=no \
+      -- upgrade \
+      --new_wasm_hash "${WASM_HASH}" \
+      || echo "WARN: Upgrade simulation returned a non-zero exit — check output above."
+  else
+    echo "==> [3/4] OLD_CONTRACT_ID not set — skipping upgrade invocation simulation."
+  fi
+fi
+
+# ── Step 4: Verify storage version (read-only) ────────────────────────────────
+
+if [[ -n "${OLD_CONTRACT_ID:-}" ]]; then
+  echo "==> [4/4] Verifying old deployment storage-version gate (--send=no) ..."
+  echo "    Expecting: Error(Contract, #70) — UpgradeRequired"
+  stellar contract invoke \
+    --id "${OLD_CONTRACT_ID}" \
+    --source "${TESTNET_SECRET_KEY}" \
+    --network "${NETWORK}" \
+    --send=no \
+    -- get_admin 2>&1 \
+    | grep -q "UpgradeRequired\|#70" \
+    && echo "    OK: old deployment correctly locked." \
+    || echo "    WARN: old deployment did not return UpgradeRequired — verify manually."
+else
+  echo "==> [4/4] OLD_CONTRACT_ID not set — skipping version-lockout check."
+fi
+
+echo ""
+echo "==> Dry-run complete. No transactions were submitted."
+echo "    Review docs/upgrade-dry-run.md for the full deployment checklist."


### PR DESCRIPTION
#593 – Treasury pause gates collect_fee
- collect_fee already had the ContractPaused gate; added 4 targeted tests: collect_fee_paused_returns_contract_paused, collect_fee_paused_before_market_auth_check, collect_fee_paused_leaves_balances_unchanged, collect_fee_resumes_after_unpause.

#592 – resolve_market rejects expired oracle messages
- Add OracleMessageExpired = 24 to ContractError (oracle errors 20-29).
- Add expires_at: u64 parameter to resolve_market; 0 disables the check (backwards compatible). Non-zero values in the past return OracleMessageExpired before signature verification is attempted.
- Update all 11 existing test call sites with &0u64.
- Add 5 new tests covering: expired rejection, future acceptance, zero-disables-check, expiry-before-signature ordering, and no state mutation on rejection.

#591 – Position panel refreshes after successful withdraw
- WithdrawForm accepts optional onSuccess?: () => void prop.
- PositionPanel passes its refresh callback as onSuccess.
- After a successful withdrawal tx, onSuccess?.() triggers a position refetch without a full page reload.

#590 – Upgrade dry-run script documentation
- Add docs/upgrade-dry-run.md with 4-step dry-run procedure, contributor checklist, and links to the storage migration guide.
- Add scripts/upgrade-dry-run.sh: simulate-only wrapper (--send=no) safe for CI use; exits non-zero on any failed simulation step.
- Link the guide from README.md Documentation section.

chore: update .gitignore
- Add Rust coverage artifacts (*.profraw, *.profdata, lcov.info, tarpaulin).
- Add **/*.snap and **/__snapshots__/ for Soroban/Jest test snapshots.
- Add .env.local / .env.*.local local environment overrides.
Closes #593 
Closes #592 
Closes #591 
Closes #590 