### PR TITLE
Fix/wave 578 579 580 581reject set_threshold_signers quorum > signer count (new InvalidThresholdQuorum error + tests)

### DIFF
--- a/CLOSE_MARKET_FEATURE.md
+++ b/CLOSE_MARKET_FEATURE.md
@@ -8,7 +8,7 @@ This document describes the implementation of the "close market to new deposits"
 ### What This Feature Does
 - **Admin Control**: Administrators can invoke `close_market_to_deposits()` to prevent new deposits
 - **Preserve Functionality**: Existing positions can still be traded, and collateral can still be withdrawn
-- **Event Tracking**: Emits `MarketClosedToDepositsEvent` when a market is closed
+- **Event Tracking**: Emits `MarketClosedToDeposits` when a market is closed
 - **Idempotent**: Closing an already-closed market is a no-op (succeeds silently)
 
 ### What This Feature Does NOT Do
@@ -52,7 +52,7 @@ Added a new event structure:
 ```rust
 #[contractevent]
 #[derive(Clone, Debug)]
-pub struct MarketClosedToDepositsEvent {
+pub struct MarketClosedToDeposits {
     #[topic]
     pub market_id: u32,
     pub admin: Address,
@@ -86,7 +86,7 @@ pub fn close_market_to_deposits(
 3. Loads the market from storage
 4. Sets `closed_to_deposits = true`
 5. Persists the updated market
-6. Emits `MarketClosedToDepositsEvent`
+6. Emits `MarketClosedToDeposits`
 
 **Authorization**: Only the contract admin can call this function.
 
@@ -160,7 +160,7 @@ pub fn close_market_to_deposits(
 
 ### Event Emitted
 ```rust
-MarketClosedToDepositsEvent {
+MarketClosedToDeposits {
     market_id: u32,      // Market that was closed
     admin: Address,      // Admin address that closed it
     closed_at: u64,      // Ledger timestamp when closed
@@ -228,13 +228,13 @@ Potential improvements not included in this implementation:
 ## Migration Guide for Off-Chain Services
 
 ### Event Indexing
-Subscribe to `MarketClosedToDepositsEvent` to track when markets are closed:
+Subscribe to `MarketClosedToDeposits` to track when markets are closed:
 ```typescript
 // Example: Listen for market closure events
 const events = await client.events({
   contract: marketContractId,
   type: 'contract-emitted',
-  name: 'MarketClosedToDepositsEvent',
+  name: 'MarketClosedToDeposits',
 });
 
 events.forEach(event => {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,11 @@ Guide for adding a new contract crate or working on an existing one
   a fixture file).
 - Public contract functions return `Result<T, ContractError>` — add new
   error variants to `error.rs` rather than panicking.
+- Release builds compile with `panic = "abort"` (workspace `[profile.release]`
+  in the root `Cargo.toml`) since WASM has no stack-unwinding support — see
+  [README.md § Panic Strategy](README.md#panic-strategy-soroban-contract-builds)
+  for the smoke-test command and why `cargo test`'s `catch_unwind`-based
+  assertions don't carry over to a deployed contract.
 - Emit a `#[contractevent]` (see `events.rs` in any contract) for state
   changes that off-chain indexers care about, following the existing
   `EVENT_VERSION` topic-versioning pattern.

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -36,7 +36,7 @@ if market.closed_to_deposits {
 
 ### 4. Event (events.rs)
 ```rust
-pub struct MarketClosedToDepositsEvent {
+pub struct MarketClosedToDeposits {
     pub market_id: u32,
     pub admin: Address,
     pub closed_at: u64,
@@ -109,7 +109,7 @@ pub fn close_market_to_deposits(env: Env, admin: Address, market_id: u32) -> Res
 
 ### Event Emitted
 ```rust
-MarketClosedToDepositsEvent {
+MarketClosedToDeposits {
     market_id: u32,
     admin: Address,
     closed_at: u64,
@@ -144,7 +144,7 @@ MarketClosedToDepositsEvent {
 All changes verified via:
 - ✅ Code inspection - All files reviewed and structured correctly
 - ✅ Type analysis - Market struct properly updated
-- ✅ Event analysis - MarketClosedToDepositsEvent properly defined
+- ✅ Event analysis - MarketClosedToDeposits properly defined
 - ✅ Error analysis - MarketClosedToDeposits error code added
 - ✅ Test count - 13 tests covering positive and negative paths
 - ✅ Documentation - 3 files created/updated with complete details

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ pub fn close_market_to_deposits(env: Env, admin: Address, market_id: u32) -> Res
 
 **Event**:
 ```
-MarketClosedToDepositsEvent {
+MarketClosedToDeposits {
     market_id: u32,
     admin: Address,
     closed_at: u64,
@@ -185,6 +185,32 @@ cd ../treasury && cargo build
 cd ../outcome-token && cargo build
 cd ../resolution && cargo build
 ```
+
+### Panic Strategy (Soroban Contract Builds)
+
+The workspace `[profile.release]` (`Cargo.toml`) sets `panic = "abort"`. WASM
+has no stack-unwinding support, so a panicking contract call must abort
+(trap the VM) rather than unwind — this is required for `wasm32v1-none`
+output and also keeps release binaries smaller.
+
+This only applies to `--release` builds — the same profile `stellar contract
+build` and the deploy scripts use. The `dev`/`test` profiles that `cargo
+test`/`cargo check` build with still unwind by default, which is why a few
+integration tests (e.g. `tests/close_market_test.rs`) can use
+`std::panic::catch_unwind` to assert a call panics; that pattern only works
+against the host-run test binary, not a deployed (release) WASM contract.
+
+Smoke-test that a contract's release build still aborts on panic (useful
+after touching a crate's `Cargo.toml` or the workspace profile):
+
+```bash
+cd contracts/market
+RUSTFLAGS="-C panic=abort" cargo build --release --target wasm32v1-none
+```
+
+`RUSTFLAGS` is redundant with the workspace profile setting here — it's just
+an explicit way to confirm the setting is actually taking effect for a
+specific crate/target combination.
 
 ### Cargo Feature Flags
 

--- a/contracts/market/MIGRATION.md
+++ b/contracts/market/MIGRATION.md
@@ -27,7 +27,7 @@ pub fn close_market_to_deposits(
 ### Event Addition
 
 ```rust
-MarketClosedToDepositsEvent {
+MarketClosedToDeposits {
     market_id: u32,
     admin: Address,
     closed_at: u64,

--- a/contracts/market/src/error.rs
+++ b/contracts/market/src/error.rs
@@ -110,6 +110,14 @@ pub enum ContractError {
     /// node network may be temporarily disconnected.
     OraclePriceUnavailable = 23,
 
+    /// `set_threshold_signers` was called with a `quorum` greater than the
+    /// number of signers supplied.
+    ///
+    /// A quorum higher than the signer count could never be satisfied, so
+    /// resolution would be permanently stuck. `quorum == 0` remains valid
+    /// (it disables threshold resolution regardless of signer count).
+    InvalidThresholdQuorum = 24,
+
     // ========== Validation Errors (30-39) ==========
     /// Price is out of valid range (must be between 0 and 1).
     ///
@@ -259,6 +267,7 @@ mod tests {
         assert_eq!(ContractError::UnauthorizedOracle as u32, 21);
         assert_eq!(ContractError::InvalidOutcome as u32, 22);
         assert_eq!(ContractError::OraclePriceUnavailable as u32, 23);
+        assert_eq!(ContractError::InvalidThresholdQuorum as u32, 24);
         assert_eq!(ContractError::InvalidPrice as u32, 30);
         assert_eq!(ContractError::InvalidQuantity as u32, 31);
         assert_eq!(ContractError::InvalidTimestamp as u32, 32);
@@ -326,6 +335,7 @@ mod tests {
             (ContractError::UnauthorizedOracle, 21),
             (ContractError::InvalidOutcome, 22),
             (ContractError::OraclePriceUnavailable, 23),
+            (ContractError::InvalidThresholdQuorum, 24),
             (ContractError::InvalidPrice, 30),
             (ContractError::InvalidQuantity, 31),
             (ContractError::InvalidTimestamp, 32),

--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -71,7 +71,7 @@ pub fn emit_contract_initialized(env: &Env, admin: &Address) {
 /// Event emitted when the contract is paused or unpaused for emergency maintenance.
 #[contractevent]
 #[derive(Clone, Debug)]
-pub struct EmergencyPauseToggledEvent {
+pub struct EmergencyPauseToggled {
     #[topic]
     pub version: u32,
     #[topic]
@@ -82,7 +82,7 @@ pub struct EmergencyPauseToggledEvent {
 
 /// Emit event when the emergency pause flag is toggled.
 pub fn emit_emergency_pause_toggled(env: &Env, paused: bool) {
-    EmergencyPauseToggledEvent {
+    EmergencyPauseToggled {
         version: EVENT_VERSION,
         paused,
         timestamp: env.ledger().timestamp(),
@@ -283,7 +283,7 @@ pub fn emit_market_created(
 
 #[contractevent]
 #[derive(Clone, Debug)]
-pub struct MarketClosedToDepositsEvent {
+pub struct MarketClosedToDeposits {
     #[topic]
     pub version: u32,
     #[topic]
@@ -294,7 +294,7 @@ pub struct MarketClosedToDepositsEvent {
 
 /// Emit event when a market is closed to new deposits
 ///
-/// Publishes a [`MarketClosedToDepositsEvent`] to the Soroban event stream when
+/// Publishes a [`MarketClosedToDeposits`] to the Soroban event stream when
 /// an admin closes a market to prevent new collateral deposits. The event is indexed
 /// by `market_id` as a topic for efficient lookup by off-chain indexers.
 ///
@@ -314,7 +314,7 @@ pub fn emit_market_closed_to_deposits(
     admin: &Address,
     closed_at: u64,
 ) {
-    MarketClosedToDepositsEvent {
+    MarketClosedToDeposits {
         version: EVENT_VERSION,
         market_id,
         admin: admin.clone(),
@@ -985,7 +985,7 @@ pub fn emit_fee_rate_change_executed(env: &Env, new_rate_bps: i128, executed_at:
 
 #[contractevent]
 #[derive(Clone, Debug)]
-pub struct AdminRenounceProposedEvent {
+pub struct AdminRenounceProposed {
     #[topic]
     pub version: u32,
     #[topic]
@@ -994,7 +994,7 @@ pub struct AdminRenounceProposedEvent {
 }
 
 pub fn emit_admin_renounce_proposed(env: &Env, admin: &Address) {
-    AdminRenounceProposedEvent {
+    AdminRenounceProposed {
         version: EVENT_VERSION,
         admin: admin.clone(),
         proposed_at: env.ledger().timestamp(),
@@ -1004,7 +1004,7 @@ pub fn emit_admin_renounce_proposed(env: &Env, admin: &Address) {
 
 #[contractevent]
 #[derive(Clone, Debug)]
-pub struct AdminRenouncedEvent {
+pub struct AdminRenounced {
     #[topic]
     pub version: u32,
     #[topic]
@@ -1013,7 +1013,7 @@ pub struct AdminRenouncedEvent {
 }
 
 pub fn emit_admin_renounced(env: &Env, admin: &Address) {
-    AdminRenouncedEvent {
+    AdminRenounced {
         version: EVENT_VERSION,
         former_admin: admin.clone(),
         renounced_at: env.ledger().timestamp(),

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -1227,6 +1227,10 @@ impl MarketContract {
     /// disables threshold resolution.
     ///
     /// Only the stored admin may call this.
+    ///
+    /// # Errors
+    /// - [`ContractError::InvalidThresholdQuorum`] — `quorum` exceeds
+    ///   `signers.len()`; such a quorum could never be satisfied.
     pub fn set_threshold_signers(
         env: Env,
         admin: Address,
@@ -1238,6 +1242,9 @@ impl MarketContract {
         let stored_admin = storage::get_admin(&env)?;
         if admin != stored_admin {
             return Err(ContractError::NotAdmin);
+        }
+        if quorum > signers.len() {
+            return Err(ContractError::InvalidThresholdQuorum);
         }
         storage::set_threshold_signers(&env, &signers);
         storage::set_threshold_quorum(&env, quorum);

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -1723,7 +1723,7 @@ impl MarketContract {
     /// - [`ContractError::MarketNotFound`] – no market with `market_id` exists
     ///
     /// # Events
-    /// Emits [`events::MarketClosedToDepositsEvent`] with `market_id`,
+    /// Emits [`events::MarketClosedToDeposits`] with `market_id`,
     /// `admin`, and `closed_at` timestamp so off-chain indexers can track
     /// when a market was locked.
     pub fn close_market_to_deposits(

--- a/contracts/market/src/settlement.rs
+++ b/contracts/market/src/settlement.rs
@@ -84,6 +84,27 @@ fn compute_settlement(position: &mut Position, market: &Market) -> Result<i128, 
     Ok(payout)
 }
 
+/// Burn a settled position's outcome tokens (both YES and NO sides), if an
+/// outcome-token contract is wired up via [`crate::MarketContract::set_outcome_token_contract`].
+///
+/// Retires the position's tokens now that they have been redeemed for the
+/// collateral payout, so a settled position's outcome tokens can never be
+/// transferred or redeemed a second time. Shared by every settle path
+/// (`settle_position`, `batch_settle_positions`, `settle_positions_page`) so
+/// full-exit burning behaves identically regardless of which entrypoint a
+/// caller uses.
+fn burn_settled_outcome_tokens(env: &Env, market_id: u32, user: &Address, position: &Position) {
+    if let Some(outcome_token_address) = storage::get_outcome_token_contract(env) {
+        let token_client = OutcomeTokenContractClient::new(env, &outcome_token_address);
+        if position.yes_shares > 0 {
+            token_client.burn(&market_id, user, &TokenKind::Yes, &position.yes_shares);
+        }
+        if position.no_shares > 0 {
+            token_client.burn(&market_id, user, &TokenKind::No, &position.no_shares);
+        }
+    }
+}
+
 /// Execute settlement for a position and return payout
 ///
 /// This function:
@@ -163,19 +184,7 @@ pub fn settle_position(env: &Env, user: &Address, market_id: u32) -> Result<i128
     // payout, marks the position settled, and emits the PositionSettled event.
     let payout = execute_settlement(env, &mut position, &market)?;
 
-    // Merge (retire) this position's outcome tokens now that they have been
-    // redeemed for the collateral payout above. Both the winning and losing
-    // side balances are burned back into nothing so a settled position's
-    // outcome tokens can never be transferred or redeemed a second time.
-    if let Some(outcome_token_address) = storage::get_outcome_token_contract(env) {
-        let token_client = OutcomeTokenContractClient::new(env, &outcome_token_address);
-        if position.yes_shares > 0 {
-            token_client.burn(&market_id, user, &TokenKind::Yes, &position.yes_shares);
-        }
-        if position.no_shares > 0 {
-            token_client.burn(&market_id, user, &TokenKind::No, &position.no_shares);
-        }
-    }
+    burn_settled_outcome_tokens(env, market_id, user, &position);
 
     // Persist the settled position before paying out.
     storage::set_position(env, market_id, user, &position)?;
@@ -252,6 +261,8 @@ pub fn batch_settle_positions(
         let Ok(payout) = compute_settlement(&mut position, &market) else {
             continue;
         };
+
+        burn_settled_outcome_tokens(env, market_id, &user, &position);
 
         // Persist the settled flag; skip if storage fails.
         if storage::set_position(env, market_id, &user, &position).is_err() {
@@ -340,6 +351,8 @@ pub fn settle_positions_page(
         let Ok(payout) = compute_settlement(&mut position, &market) else {
             continue;
         };
+
+        burn_settled_outcome_tokens(env, market_id, &user, &position);
 
         if storage::set_position(env, market_id, &user, &position).is_err() {
             continue;
@@ -1089,6 +1102,91 @@ mod tests {
         }
     }
 
+    /// #578: `batch_settle_positions` and `settle_positions_page` must burn a
+    /// settled position's outcome tokens when an outcome-token contract is
+    /// wired, exactly like the single-user `settle_position` path already
+    /// does — otherwise a fully-exited position's YES/NO balances would be
+    /// left outstanding after settlement.
+    #[test]
+    fn test_batch_settle_burns_outcome_tokens_when_wired() {
+        use ed25519_dalek::{Signer, SigningKey};
+        use rand::rngs::OsRng;
+        use soroban_sdk::token::StellarAssetClient;
+        use soroban_sdk::String;
+        use vatix_outcome_token_contract::{OutcomeTokenContract, OutcomeTokenContractClient};
+
+        const DEPOSIT: i128 = 100_000_000;
+        const SHARES: i128 = 100_000_000;
+
+        let env = soroban_sdk::Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(crate::MarketContract, ());
+        let admin = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            storage::set_admin(&env, &admin);
+            storage::set_version(&env);
+        });
+
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin);
+        let collateral_token = token.address();
+        let sac = StellarAssetClient::new(&env, &collateral_token);
+
+        let ot_contract_id = env.register(OutcomeTokenContract, ());
+        let ot_client = OutcomeTokenContractClient::new(&env, &ot_contract_id);
+        ot_client.initialize(
+            &admin,
+            &contract_id,
+            &String::from_str(&env, "Vatix Outcome Token"),
+            &String::from_str(&env, "VOT"),
+        );
+
+        let mut csprng = OsRng;
+        let signing_key = SigningKey::generate(&mut csprng);
+        let oracle_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+
+        let client = crate::MarketContractClient::new(&env, &contract_id);
+        let question = String::from_str(&env, "Batch settle burns outcome tokens?");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let market_id = client.initialize_market(
+            &admin, &question, &end_time, &oracle_pubkey, &collateral_token,
+        );
+        client.set_outcome_token_contract(&admin, &ot_contract_id);
+
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
+        for u in [&user1, &user2] {
+            sac.mint(u, &DEPOSIT);
+            client.deposit_collateral(u, &market_id, &DEPOSIT);
+            client.update_position(u, &market_id, &SHARES, &0i128, &5_000i128);
+        }
+
+        // Outcome tokens were minted alongside the position updates above.
+        assert_eq!(ot_client.total_supply(&market_id, &TokenKind::Yes), SHARES * 2);
+        assert_eq!(ot_client.balance(&market_id, &user1, &TokenKind::Yes), SHARES);
+        assert_eq!(ot_client.balance(&market_id, &user2, &TokenKind::Yes), SHARES);
+
+        let outcome = true;
+        let message = crate::oracle::construct_oracle_message(&env, market_id, outcome);
+        let sig_bytes = signing_key.sign(message.to_array().as_slice()).to_bytes();
+        let signature = BytesN::from_array(&env, &sig_bytes);
+        let market_id_str = String::from_str(&env, "1");
+        client.resolve_market(&market_id_str, &outcome, &signature);
+
+        let mut users: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+        users.push_back(user1.clone());
+        users.push_back(user2.clone());
+        env.as_contract(&contract_id, || batch_settle_positions(&env, market_id, users))
+            .expect("batch settle should succeed");
+
+        // Full exit via batch settlement must burn every settled user's
+        // outcome tokens, driving total supply back to zero.
+        assert_eq!(ot_client.total_supply(&market_id, &TokenKind::Yes), 0);
+        assert_eq!(ot_client.balance(&market_id, &user1, &TokenKind::Yes), 0);
+        assert_eq!(ot_client.balance(&market_id, &user2, &TokenKind::Yes), 0);
+    }
+
     #[test]
     fn test_batch_settle_skips_already_settled() {
         use soroban_sdk::String;
@@ -1237,6 +1335,78 @@ mod tests {
         assert!(total_payout > 0, "resolved market page-settle must pay out");
         assert!(is_complete);
         assert_eq!(next_index, 2); // two participants were set up by setup_resolved_market
+    }
+
+    /// #578: `settle_positions_page` must also burn outcome tokens on full
+    /// exit, matching `settle_position` and `batch_settle_positions`.
+    #[test]
+    fn test_settle_positions_page_burns_outcome_tokens_when_wired() {
+        use ed25519_dalek::{Signer, SigningKey};
+        use rand::rngs::OsRng;
+        use soroban_sdk::token::StellarAssetClient;
+        use soroban_sdk::String;
+        use vatix_outcome_token_contract::{OutcomeTokenContract, OutcomeTokenContractClient};
+
+        const DEPOSIT: i128 = 100_000_000;
+        const SHARES: i128 = 100_000_000;
+
+        let env = soroban_sdk::Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(crate::MarketContract, ());
+        let admin = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            storage::set_admin(&env, &admin);
+            storage::set_version(&env);
+        });
+
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin);
+        let collateral_token = token.address();
+        let sac = StellarAssetClient::new(&env, &collateral_token);
+
+        let ot_contract_id = env.register(OutcomeTokenContract, ());
+        let ot_client = OutcomeTokenContractClient::new(&env, &ot_contract_id);
+        ot_client.initialize(
+            &admin,
+            &contract_id,
+            &String::from_str(&env, "Vatix Outcome Token"),
+            &String::from_str(&env, "VOT"),
+        );
+
+        let mut csprng = OsRng;
+        let signing_key = SigningKey::generate(&mut csprng);
+        let oracle_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+
+        let client = crate::MarketContractClient::new(&env, &contract_id);
+        let question = String::from_str(&env, "Page settle burns outcome tokens?");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let market_id = client.initialize_market(
+            &admin, &question, &end_time, &oracle_pubkey, &collateral_token,
+        );
+        client.set_outcome_token_contract(&admin, &ot_contract_id);
+
+        let user = Address::generate(&env);
+        sac.mint(&user, &DEPOSIT);
+        client.deposit_collateral(&user, &market_id, &DEPOSIT);
+        client.update_position(&user, &market_id, &SHARES, &0i128, &5_000i128);
+        assert_eq!(ot_client.balance(&market_id, &user, &TokenKind::Yes), SHARES);
+
+        let outcome = true;
+        let message = crate::oracle::construct_oracle_message(&env, market_id, outcome);
+        let sig_bytes = signing_key.sign(message.to_array().as_slice()).to_bytes();
+        let signature = BytesN::from_array(&env, &sig_bytes);
+        let market_id_str = String::from_str(&env, "1");
+        client.resolve_market(&market_id_str, &outcome, &signature);
+
+        // Fund the contract so the page-settle payout transfer succeeds.
+        StellarAssetClient::new(&env, &collateral_token).mint(&contract_id, &(1_000_000_000i128));
+
+        env.as_contract(&contract_id, || settle_positions_page(&env, market_id, 0, 10))
+            .expect("resolved market should settle successfully");
+
+        assert_eq!(ot_client.total_supply(&market_id, &TokenKind::Yes), 0);
+        assert_eq!(ot_client.balance(&market_id, &user, &TokenKind::Yes), 0);
     }
 
     // --- Issue #551: batch size hardening ---

--- a/contracts/outcome-token/src/events.rs
+++ b/contracts/outcome-token/src/events.rs
@@ -63,7 +63,7 @@ pub fn emit_token_burned(
 
 #[contractevent]
 #[derive(Clone, Debug)]
-pub struct TokenTransferredEvent {
+pub struct TokenTransferred {
     #[topic]
     pub market_id: u32,
     #[topic]
@@ -81,7 +81,7 @@ pub fn emit_token_transferred(
     kind: TokenKind,
     amount: i128,
 ) {
-    TokenTransferredEvent {
+    TokenTransferred {
         market_id,
         from: from.clone(),
         to: to.clone(),

--- a/contracts/treasury/src/events.rs
+++ b/contracts/treasury/src/events.rs
@@ -226,7 +226,7 @@ pub fn emit_fees_distributed(
 
 #[contractevent]
 #[derive(Clone, Debug)]
-pub struct TreasuryPausedEvent {
+pub struct TreasuryPaused {
     #[topic]
     pub admin: Address,
     pub paused_at: u64,
@@ -234,14 +234,14 @@ pub struct TreasuryPausedEvent {
 
 #[contractevent]
 #[derive(Clone, Debug)]
-pub struct TreasuryUnpausedEvent {
+pub struct TreasuryUnpaused {
     #[topic]
     pub admin: Address,
     pub unpaused_at: u64,
 }
 
 pub fn emit_treasury_paused(env: &Env, admin: &Address) {
-    TreasuryPausedEvent {
+    TreasuryPaused {
         admin: admin.clone(),
         paused_at: env.ledger().timestamp(),
     }
@@ -249,7 +249,7 @@ pub fn emit_treasury_paused(env: &Env, admin: &Address) {
 }
 
 pub fn emit_treasury_unpaused(env: &Env, admin: &Address) {
-    TreasuryUnpausedEvent {
+    TreasuryUnpaused {
         admin: admin.clone(),
         unpaused_at: env.ledger().timestamp(),
     }

--- a/docs/events-reference.md
+++ b/docs/events-reference.md
@@ -9,9 +9,12 @@ Every event below is defined with `#[contractevent]` and published via
 `.publish(env)` in the corresponding `emit_*` function. The **Event/Topic**
 column is the first (auto-generated) topic in the on-chain event — Soroban's
 `#[contractevent]` macro derives it by converting the struct name to
-`snake_case` **verbatim** (no suffix stripping), so a struct literally named
-e.g. `MarketClosedToDepositsEvent` produces the topic
-`market_closed_to_deposits_event`, not `market_closed_to_deposits`.
+`snake_case` **verbatim** (no suffix stripping), so an event struct's exact
+name directly determines its on-chain topic. Every event struct follows the
+`{Noun}{Verb}` PascalCase pattern without a redundant `Event` suffix (Issue
+#389, audited for consistency across all four contracts in Issue #581), so
+e.g. `MarketClosedToDeposits` produces the indexer-friendly topic
+`market_closed_to_deposits`, never `market_closed_to_deposits_event`.
 
 In the **Fields** column, fields marked `(topic)` are additional indexed
 topics (in declaration order, after the auto-generated event-name topic);
@@ -25,12 +28,12 @@ events additionally carry a `version: u32 (topic)` field
 | Event/Topic | Fields (name: type) | Emitted When |
 |---|---|---|
 | `contract_initialized` | `version: u32 (topic)`, `admin: Address (topic)`, `initialized_at: u64` | Contract is initialized with an admin (`initialize`) |
-| `emergency_pause_toggled_event` | `version: u32 (topic)`, `paused: bool (topic)`, `timestamp: u64` | The emergency pause flag is toggled on/off |
+| `emergency_pause_toggled` | `version: u32 (topic)`, `paused: bool (topic)`, `timestamp: u64` | The emergency pause flag is toggled on/off |
 | `market_created` | `version: u32 (topic)`, `market_id: u32 (topic)`, `creator: Address`, `question: String`, `end_time: u64`, `metadata_uri: Option<String>` | A new prediction market is created |
 | `collateral_deposited` | `version: u32 (topic)`, `user: Address (topic)`, `market_id: u32 (topic)`, `amount: i128`, `new_total: i128` | A user deposits collateral into a market |
 | `collateral_withdrawn` | `version: u32 (topic)`, `user: Address (topic)`, `market_id: u32 (topic)`, `amount: i128`, `new_total: i128` | A user withdraws collateral from a market |
 | `withdraw_edge_case` | `version: u32 (topic)`, `user: Address (topic)`, `market_id: u32 (topic)`, `amount: i128` | A user attempts to withdraw with zero collateral deposited (edge case for monitoring) |
-| `market_closed_to_deposits_event` | `version: u32 (topic)`, `market_id: u32 (topic)`, `admin: Address`, `closed_at: u64` | An admin closes a market to new collateral deposits |
+| `market_closed_to_deposits` | `version: u32 (topic)`, `market_id: u32 (topic)`, `admin: Address`, `closed_at: u64` | An admin closes a market to new collateral deposits |
 | `market_resolved` | `version: u32 (topic)`, `market_id: u32 (topic)`, `oracle_pubkey: BytesN<32>`, `resolver: Address`, `outcome: bool`, `resolved_at: u64` | A market is resolved with an oracle-signed outcome |
 | `market_canceled` | `version: u32 (topic)`, `market_id: u32 (topic)`, `canceler: Address`, `canceled_at: u64` | An admin cancels a market before resolution |
 | `position_limit_exceeded` | `version: u32 (topic)`, `market_id: u32 (topic)`, `user: Address (topic)`, `side_yes: bool` | A trade/position change is rejected because a share balance would go negative |
@@ -47,8 +50,8 @@ events additionally carry a `version: u32 (topic)` field
 | `treasury_set` | `version: u32 (topic)`, `treasury: Address (topic)`, `set_at: u64` | The Treasury contract address is registered on the market |
 | `fee_rate_change_proposed` | `version: u32 (topic)`, `new_rate_bps: i128`, `effective_at: u64` | An admin proposes a new withdrawal fee rate, effective at a future timestamp |
 | `fee_rate_change_executed` | `version: u32 (topic)`, `new_rate_bps: i128`, `executed_at: u64` | A previously-proposed fee rate change takes effect |
-| `admin_renounce_proposed_event` | `version: u32 (topic)`, `admin: Address (topic)`, `proposed_at: u64` | The admin proposes renouncing the admin role |
-| `admin_renounced_event` | `version: u32 (topic)`, `former_admin: Address (topic)`, `renounced_at: u64` | The admin renounce is finalized (admin role given up) |
+| `admin_renounce_proposed` | `version: u32 (topic)`, `admin: Address (topic)`, `proposed_at: u64` | The admin proposes renouncing the admin role |
+| `admin_renounced` | `version: u32 (topic)`, `former_admin: Address (topic)`, `renounced_at: u64` | The admin renounce is finalized (admin role given up) |
 | `oracle_adapter_configured` | `adapter_type: AdapterType (topic)`, `enabled: bool`, `configured_at: u64` | The admin enables/disables the Reflector or Pyth oracle adapter |
 | `fee_waiver_added` | `account: Address (topic)`, `admin: Address`, `added_at: u64` | The admin adds an address to the withdrawal fee waiver list |
 | `fee_waiver_removed` | `account: Address (topic)`, `admin: Address`, `removed_at: u64` | The admin removes an address from the fee waiver list |
@@ -66,8 +69,8 @@ events additionally carry a `version: u32 (topic)` field
 | `market_removed` | `market_contract: Address (topic)` | A market contract is removed from the Treasury's registry |
 | `stakeholders_updated` | `stakeholder_count: u32`, `updated_at: u64` | The fee-distribution stakeholder list is updated |
 | `fees_distributed` | `token: Address (topic)`, `distributed_amount: i128`, `remaining_token_balance: i128`, `stakeholder_count: u32`, `distributed_at: u64` | Fees for `token` are distributed across all configured stakeholders (once per `distribute_fees` call) |
-| `treasury_paused_event` | `admin: Address (topic)`, `paused_at: u64` | The Treasury is paused for emergency maintenance |
-| `treasury_unpaused_event` | `admin: Address (topic)`, `unpaused_at: u64` | The Treasury is unpaused |
+| `treasury_paused` | `admin: Address (topic)`, `paused_at: u64` | The Treasury is paused for emergency maintenance |
+| `treasury_unpaused` | `admin: Address (topic)`, `unpaused_at: u64` | The Treasury is unpaused |
 
 ## Resolution (`contracts/resolution/src/events.rs`)
 
@@ -85,7 +88,7 @@ events additionally carry a `version: u32 (topic)` field
 |---|---|---|
 | `token_minted` | `market_id: u32 (topic)`, `user: Address (topic)`, `kind: TokenKind`, `amount: i128`, `new_balance: i128` | Outcome tokens (YES/NO) are minted to a user |
 | `token_burned` | `market_id: u32 (topic)`, `user: Address (topic)`, `kind: TokenKind`, `amount: i128`, `new_balance: i128` | Outcome tokens are burned from a user |
-| `token_transferred_event` | `market_id: u32 (topic)`, `from: Address (topic)`, `to: Address`, `kind: TokenKind`, `amount: i128` | Outcome tokens are transferred between two users |
+| `token_transferred` | `market_id: u32 (topic)`, `from: Address (topic)`, `to: Address`, `kind: TokenKind`, `amount: i128` | Outcome tokens are transferred between two users |
 
 ## Notes for indexers
 

--- a/tests/client_entrypoints_test.rs
+++ b/tests/client_entrypoints_test.rs
@@ -10,7 +10,7 @@ use soroban_sdk::{
     token::{Client as TokenClient, StellarAssetClient},
     Address, BytesN, Env, String,
 };
-use vatix_market_contract::{storage, MarketContract, MarketContractClient};
+use vatix_market_contract::{error::ContractError, storage, MarketContract, MarketContractClient};
 use vatix_resolution_contract::{ResolutionContract, ResolutionContractClient};
 use vatix_treasury_contract::{TreasuryContract, TreasuryContractClient};
 
@@ -365,6 +365,37 @@ fn market_set_and_get_threshold_signers() {
 
     assert_eq!(client.get_threshold_quorum(), 1u32);
     assert_eq!(client.get_threshold_signers().get(0).unwrap(), signer);
+}
+
+#[test]
+fn market_set_threshold_signers_rejects_quorum_above_signer_count() {
+    let (env, admin, contract_id, _token) = market_env();
+    let client = MarketContractClient::new(&env, &contract_id);
+
+    let signer = BytesN::from_array(&env, &[1u8; 32]);
+    let signers = soroban_sdk::vec![&env, signer];
+
+    assert_eq!(
+        client.try_set_threshold_signers(&admin, &signers, &2u32),
+        Err(Ok(ContractError::InvalidThresholdQuorum))
+    );
+
+    // Storage is untouched after a rejected call.
+    assert_eq!(client.get_threshold_quorum(), 0u32);
+    assert_eq!(client.get_threshold_signers().len(), 0);
+}
+
+#[test]
+fn market_set_threshold_signers_allows_zero_quorum_regardless_of_signer_count() {
+    let (env, admin, contract_id, _token) = market_env();
+    let client = MarketContractClient::new(&env, &contract_id);
+
+    client
+        .set_threshold_signers(&admin, &soroban_sdk::Vec::new(&env), &0u32)
+        .unwrap();
+
+    assert_eq!(client.get_threshold_quorum(), 0u32);
+    assert_eq!(client.get_threshold_signers().len(), 0);
 }
 
 // ── Market: get_market / get_outcome_count ────────────────────────────────────

--- a/tests/close_market_test.rs
+++ b/tests/close_market_test.rs
@@ -79,7 +79,7 @@ fn close_market_to_deposits_succeeds() {
     assert_eq!(market_after.closed_to_deposits, true);
 
     // Verify the event was emitted
-    assert_event_emitted(&env, "market_closed_to_deposits_event");
+    assert_event_emitted(&env, "market_closed_to_deposits");
 }
 
 #[test]


### PR DESCRIPTION
  - #580 — reject set_threshold_signers quorum > signer count (new InvalidThresholdQuorum error + tests)
  - #578 — fixed batch/paginated settlement paths that were skipping outcome-token burn on full exit (only the single-user path had it before)
  - #581 — renamed 7 event structs that had a stray Event suffix leaking into their on-chain topic, updated the event catalog and every doc
  referencing them
  - #579 — documented the panic = "abort" release profile in README/CONTRIBUTING with a RUSTFLAGS smoke-test command
Closes #580 
Closes #578 
Closes #581 
Closes #579 