### PR TITLE
Resolve #582, #583, #584, #585

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,7 @@ Thumbs.db
 *.dylib
 *.dll
 
-contracts/*/test_snapshots
-/test_snapshots/
+**/test_snapshots/
 
 # Node / Next.js
 node_modules/

--- a/apps/web/components/MarketCard.tsx
+++ b/apps/web/components/MarketCard.tsx
@@ -1,4 +1,5 @@
 import type { Market } from "@/lib/markets";
+import { StatusBadge } from "@/components/StatusBadge";
 
 interface MarketCardProps {
   market: Market;
@@ -26,6 +27,13 @@ export function MarketCard({ market, loading = false }: MarketCardProps) {
             <span className="block sm:inline">
               ends {market.endsAt}
             </span>
+            {market.closedToDeposits && (
+              <StatusBadge
+                status="Closed to deposits"
+                variant="warning"
+                className="ml-0 mt-1 block w-fit normal-case tracking-normal sm:ml-2 sm:mt-0 sm:inline-block"
+              />
+            )}
           </>
         )}
       </p>

--- a/apps/web/lib/markets.ts
+++ b/apps/web/lib/markets.ts
@@ -10,6 +10,7 @@ export interface Market {
   volume: string;
   status: MarketStatus;
   endsAt: string;
+  closedToDeposits: boolean;
 }
 
 /**
@@ -26,5 +27,6 @@ export async function getMarkets(): Promise<Market[]> {
     volume: m.volume,
     status: m.status as MarketStatus,
     endsAt: m.ends_at,
+    closedToDeposits: m.closed_to_deposits ?? false,
   }));
 }

--- a/apps/web/lib/soroban.ts
+++ b/apps/web/lib/soroban.ts
@@ -43,6 +43,7 @@ export interface RpcMarket {
   volume: string;
   status: string;
   ends_at: string;
+  closed_to_deposits?: boolean;
 }
 
 interface GetMarketsResult {

--- a/contracts/market/src/error.rs
+++ b/contracts/market/src/error.rs
@@ -152,6 +152,14 @@ pub enum ContractError {
     /// Fee rate is invalid (e.g. exceeds the configured fee cap or is out of range).
     InvalidFeeRate = 38,
 
+    /// Fee waiver account is invalid (a contract address, or the admin itself).
+    ///
+    /// The admin-managed fee waiver list (#483) may only hold ordinary user
+    /// accounts. Contract addresses are rejected the same way `InvalidAdmin`
+    /// rejects them, and the admin's own address is rejected so the admin
+    /// cannot quietly exempt itself from withdrawal fees it controls (#584).
+    InvalidFeeWaiverAccount = 39,
+
     // ========== Authorization Errors (40-49) ==========
     /// Caller is not authorized to perform this action.
     ///
@@ -268,6 +276,7 @@ mod tests {
         assert_eq!(ContractError::BelowMinDeposit as u32, 36);
         assert_eq!(ContractError::InvalidMetadataUri as u32, 37);
         assert_eq!(ContractError::InvalidFeeRate as u32, 38);
+        assert_eq!(ContractError::InvalidFeeWaiverAccount as u32, 39);
         assert_eq!(ContractError::Unauthorized as u32, 40);
         assert_eq!(ContractError::NotAdmin as u32, 41);
         assert_eq!(ContractError::AlreadyInitialized as u32, 42);
@@ -335,6 +344,7 @@ mod tests {
             (ContractError::BelowMinDeposit, 36),
             (ContractError::InvalidMetadataUri, 37),
             (ContractError::InvalidFeeRate, 38),
+            (ContractError::InvalidFeeWaiverAccount, 39),
             (ContractError::Unauthorized, 40),
             (ContractError::NotAdmin, 41),
             (ContractError::AlreadyInitialized, 42),

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -1097,10 +1097,14 @@ impl MarketContract {
     /// Waived addresses pay no withdrawal fee regardless of the configured
     /// [`set_fee_rate`]. Adding an address that is already waived is a no-op.
     ///
-    /// Only the stored admin may call this.
+    /// Only the stored admin may call this. `account` must be an ordinary
+    /// user account: contract addresses are rejected, and the admin cannot
+    /// waive itself (#584) — see [`validation::validate_fee_waiver_account`].
     ///
     /// # Errors
     /// - [`ContractError::NotAdmin`] — `admin` is not the stored admin.
+    /// - [`ContractError::InvalidFeeWaiverAccount`] — `account` is a contract
+    ///   address or equals the admin.
     pub fn add_fee_waiver(
         env: Env,
         admin: Address,
@@ -1112,6 +1116,7 @@ impl MarketContract {
         if admin != stored_admin {
             return Err(ContractError::NotAdmin);
         }
+        validation::validate_fee_waiver_account(&account, &stored_admin)?;
         storage::add_fee_waiver(&env, &account);
         events::emit_fee_waiver_added(&env, &account, &admin);
         Ok(())

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -2313,4 +2313,52 @@ mod test {
         assert!(market.resolver.is_some());
         assert!(market.resolved_at.is_some());
     }
+
+    // ========== add_fee_waiver misuse rejection (#584) ==========
+
+    /// A contract address is not a valid depositor and must never receive a
+    /// fee waiver — the same rule `validate_admin_address` applies to the admin.
+    #[test]
+    fn test_add_fee_waiver_rejects_contract_address() {
+        use crate::error::ContractError;
+
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let waiver_contract = env.register(MarketContract, ());
+
+        assert_eq!(
+            client.try_add_fee_waiver(&admin, &waiver_contract),
+            Err(Ok(ContractError::InvalidFeeWaiverAccount))
+        );
+        assert!(!client.is_fee_waived(&waiver_contract));
+    }
+
+    /// The admin cannot add itself to the fee waiver list — it already
+    /// controls `set_fee_rate`, so self-waiving would let it silently exempt
+    /// itself from the fee it sets for everyone else.
+    #[test]
+    fn test_add_fee_waiver_rejects_admin_self_waiver() {
+        use crate::error::ContractError;
+
+        let (_env, admin, client, _contract_id) = create_test_contract();
+
+        assert_eq!(
+            client.try_add_fee_waiver(&admin, &admin),
+            Err(Ok(ContractError::InvalidFeeWaiverAccount))
+        );
+        assert!(!client.is_fee_waived(&admin));
+    }
+
+    /// A regular user account can be waived, and adding it twice is a no-op
+    /// that leaves exactly one entry in the list.
+    #[test]
+    fn test_add_fee_waiver_accepts_user_and_is_idempotent() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let account = Address::generate(&env);
+
+        client.add_fee_waiver(&admin, &account);
+        client.add_fee_waiver(&admin, &account);
+
+        assert!(client.is_fee_waived(&account));
+        assert_eq!(client.get_fee_waivers().len(), 1);
+    }
 }

--- a/contracts/market/src/tests_vectors.rs
+++ b/contracts/market/src/tests_vectors.rs
@@ -91,3 +91,66 @@ fn fee_math_regression_corpus() {
         }
     }
 }
+
+// ── Share-collateral math regression corpus (#582) ─────────────────────────
+
+use crate::positions::calculate_locked_collateral;
+
+#[derive(Deserialize)]
+struct ShareCorpus {
+    vectors: std::vec::Vec<ShareVector>,
+}
+
+#[derive(Deserialize)]
+struct ShareVector {
+    id: std::string::String,
+    #[allow(dead_code)]
+    description: std::string::String,
+    yes_shares: std::string::String,
+    no_shares: std::string::String,
+    market_price: i128,
+    expected: ShareExpected,
+}
+
+#[derive(Deserialize)]
+struct ShareExpected {
+    ok: std::string::String,
+}
+
+#[test]
+fn share_math_regression_corpus() {
+    let raw = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../test-vectors/share-math.json"
+    ))
+    .expect("read test-vectors/share-math.json");
+    let corpus: ShareCorpus = serde_json::from_str(&raw).expect("parse share-math.json");
+
+    assert!(
+        corpus.vectors.len() >= 3,
+        "corpus must document at least 3 cases"
+    );
+
+    for vector in &corpus.vectors {
+        let yes_shares: i128 = vector
+            .yes_shares
+            .parse()
+            .unwrap_or_else(|_| panic!("vector {}: invalid yes_shares", vector.id));
+        let no_shares: i128 = vector
+            .no_shares
+            .parse()
+            .unwrap_or_else(|_| panic!("vector {}: invalid no_shares", vector.id));
+        let expected: i128 = vector
+            .expected
+            .ok
+            .parse()
+            .unwrap_or_else(|_| panic!("vector {}: invalid expected.ok", vector.id));
+
+        let result = calculate_locked_collateral(yes_shares, no_shares, vector.market_price);
+        assert_eq!(
+            result, expected,
+            "vector {}: unexpected locked collateral",
+            vector.id
+        );
+    }
+}

--- a/contracts/market/src/validation.rs
+++ b/contracts/market/src/validation.rs
@@ -309,6 +309,29 @@ pub fn validate_admin_address(admin: &Address) -> Result<(), ContractError> {
     Ok(())
 }
 
+/// Validate that `account` is eligible for the admin-managed fee waiver list (#584).
+///
+/// Two misuse cases are rejected:
+/// - `account` is a contract address (mirrors [`validate_admin_address`]) —
+///   the waiver list is meant for real depositors, not contracts.
+/// - `account` is the current `admin` — the admin already controls the fee
+///   rate via [`crate::MarketContract::set_fee_rate`], so allowing self-waiver
+///   would let it silently exempt itself from the fees it sets for everyone
+///   else.
+///
+/// # Errors
+/// - [`ContractError::InvalidFeeWaiverAccount`] – `account` is a contract
+///   address or equals `admin`.
+pub fn validate_fee_waiver_account(
+    account: &Address,
+    admin: &Address,
+) -> Result<(), ContractError> {
+    if account.executable().is_some() || account == admin {
+        return Err(ContractError::InvalidFeeWaiverAccount);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -566,6 +589,35 @@ mod tests {
         assert_eq!(
             validate_admin_address(&contract_id),
             Err(ContractError::InvalidAdmin)
+        );
+    }
+
+    #[test]
+    fn test_validate_fee_waiver_account_user_ok() {
+        let env = soroban_sdk::Env::default();
+        let admin = Address::generate(&env);
+        let account = Address::generate(&env);
+        assert!(validate_fee_waiver_account(&account, &admin).is_ok());
+    }
+
+    #[test]
+    fn test_validate_fee_waiver_account_contract_fails() {
+        let env = soroban_sdk::Env::default();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(crate::MarketContract, ());
+        assert_eq!(
+            validate_fee_waiver_account(&contract_id, &admin),
+            Err(ContractError::InvalidFeeWaiverAccount)
+        );
+    }
+
+    #[test]
+    fn test_validate_fee_waiver_account_self_waiver_fails() {
+        let env = soroban_sdk::Env::default();
+        let admin = Address::generate(&env);
+        assert_eq!(
+            validate_fee_waiver_account(&admin, &admin),
+            Err(ContractError::InvalidFeeWaiverAccount)
         );
     }
 

--- a/contracts/treasury/src/test.rs
+++ b/contracts/treasury/src/test.rs
@@ -372,6 +372,46 @@ fn add_market_is_idempotent() {
     assert_eq!(s.client.list_markets().len(), 1);
 }
 
+/// Issue #585: `list_markets` is the read path over the `AuthorizedMarkets`
+/// registry — exercise it through a full add/remove/re-add sequence and
+/// assert both contents *and* order at each step, not just the length.
+#[test]
+fn list_markets_reflects_order_and_contents_after_add_remove() {
+    let s = setup();
+    let market2 = Address::generate(&s.env);
+    let market3 = Address::generate(&s.env);
+
+    // Freshly initialized: only the market registered by `initialize`.
+    let markets = s.client.list_markets();
+    assert_eq!(markets.len(), 1);
+    assert_eq!(markets.get(0).unwrap(), s.market);
+
+    // Appends preserve insertion order.
+    s.client.add_market(&s.admin, &market2);
+    s.client.add_market(&s.admin, &market3);
+    let markets = s.client.list_markets();
+    assert_eq!(markets.len(), 3);
+    assert_eq!(markets.get(0).unwrap(), s.market);
+    assert_eq!(markets.get(1).unwrap(), market2);
+    assert_eq!(markets.get(2).unwrap(), market3);
+
+    // Removing a middle entry preserves the relative order of the rest.
+    s.client.remove_market(&s.admin, &market2);
+    let markets = s.client.list_markets();
+    assert_eq!(markets.len(), 2);
+    assert_eq!(markets.get(0).unwrap(), s.market);
+    assert_eq!(markets.get(1).unwrap(), market3);
+    assert!(!markets.contains(&market2));
+
+    // Re-adding appends at the end rather than restoring the original slot.
+    s.client.add_market(&s.admin, &market2);
+    let markets = s.client.list_markets();
+    assert_eq!(markets.len(), 3);
+    assert_eq!(markets.get(0).unwrap(), s.market);
+    assert_eq!(markets.get(1).unwrap(), market3);
+    assert_eq!(markets.get(2).unwrap(), market2);
+}
+
 #[test]
 fn add_market_rejects_non_admin() {
     let s = setup();

--- a/test-vectors/share-math.json
+++ b/test-vectors/share-math.json
@@ -1,0 +1,45 @@
+{
+  "description": "Regression corpus for positions::calculate_locked_collateral (share-collateral math, #334). Each case documents intent so a future change that reintroduces a rounding/saturation bug fails CI immediately. See contracts/market/src/positions.rs::calculate_locked_collateral and the loader test in contracts/market/src/tests_vectors.rs.",
+  "vectors": [
+    {
+      "id": "hedged-equal-shares-zero-locked",
+      "description": "Equal YES and NO shares are fully hedged and lock zero collateral regardless of price.",
+      "yes_shares": "100",
+      "no_shares": "100",
+      "market_price": 6000,
+      "expected": { "ok": "0" }
+    },
+    {
+      "id": "net-yes-scales-by-price",
+      "description": "Net YES position locks net_yes * price / 10000.",
+      "yes_shares": "100",
+      "no_shares": "0",
+      "market_price": 6000,
+      "expected": { "ok": "60" }
+    },
+    {
+      "id": "net-no-scales-by-inverse-price",
+      "description": "Net NO position locks net_no * (10000 - price) / 10000.",
+      "yes_shares": "0",
+      "no_shares": "100",
+      "market_price": 6000,
+      "expected": { "ok": "40" }
+    },
+    {
+      "id": "rounding-floors-down",
+      "description": "999 * 2500 / 10000 = 249.75, must floor to 249, never round up.",
+      "yes_shares": "999",
+      "no_shares": "0",
+      "market_price": 2500,
+      "expected": { "ok": "249" }
+    },
+    {
+      "id": "large-values-saturate-and-floor",
+      "description": "i128::MAX shares at a 100% price overflows the intermediate multiply; scale_by_bps must saturate to i128::MAX before dividing rather than wrapping or panicking.",
+      "yes_shares": "170141183460469231731687303715884105727",
+      "no_shares": "0",
+      "market_price": 10000,
+      "expected": { "ok": "17014118346046923173168730371588410" }
+    }
+  ]
+}


### PR DESCRIPTION
- #585: add list_markets test asserting order/contents through a full add/remove/re-add sequence on the treasury authorized-markets registry.
- #584: reject add_fee_waiver for contract addresses and admin self-waiver via a new InvalidFeeWaiverAccount error, with unit + contract-level tests.
- #583: MarketCard renders a "Closed to deposits" badge when closed_to_deposits is true on the underlying market data.
- #582: add test-vectors/share-math.json regression corpus for calculate_locked_collateral plus a loader test in tests_vectors.rs.
Closes #585 
Closes #584 
Closes #583 
Closes #582 