### PR TITLE
fix(market): track depositors in MarketParticipants list on deposit

### DIFF
--- a/contracts/market/src/deposit.rs
+++ b/contracts/market/src/deposit.rs
@@ -147,6 +147,13 @@ pub fn deposit_collateral(
     // Persist updated position
     storage::set_position(&env, market_id, &user, &position)?;
 
+    // Track first-time participants so the market can later be settled
+    // page-by-page via `settle_positions_page` (Issue #495) without
+    // requiring an off-chain index of every depositor. Idempotent — safe
+    // to call on every deposit; the helper only appends when the address
+    // is not already present.
+    storage::add_market_participant(&env, market_id, &user);
+
     // Record deposit timestamp for cooldown enforcement on withdrawals (issue #413).
     storage::set_last_deposit_time(&env, market_id, &user, env.ledger().timestamp());
 


### PR DESCRIPTION
## Problem

`deposit_collateral` never called `add_market_participant`, so users who deposited collateral but never executed a trade were **absent from the `MarketParticipants(market_id)` list**. This breaks:

- `settle_positions_page`: the paginated partial-settlement path enumerates participants from this list — a depositor-only user would never be settled.
- Off-chain tooling (indexers, admin scripts) that relies on the list to enumerate all market participants.

## Root Cause

`add_market_participant` was introduced in #495 and wired into the **trade path** (`update_position`), but was never added to the **deposit path** (`deposit_collateral`).

## Fix

Call `storage::add_market_participant(&env, market_id, &user)` immediately after `set_position` in `deposit_collateral`.

The helper is **idempotent**: it performs a linear search before appending, so repeated deposits by the same user produce no duplicate entries. The uniqueness invariant is upheld by the existing implementation.

## Files Changed

- `contracts/market/src/deposit.rs` — call `add_market_participant` after persisting position

## Acceptance Criteria

- [x] Participants list stays unique — `add_market_participant` is idempotent
- [x] Depositor-only users included in partial settlement path