### PR TITLE
fix(market): guard execute_fee_rate_change with require_initialized

### DIFF
--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -1048,6 +1048,13 @@ impl MarketContract {
     ///   time in [`Self::set_fee_rate`]) so a cap lowered by the admin while a
     ///   change is in flight cannot let a stale, now-excessive rate through.
     pub fn execute_fee_rate_change(env: Env) -> Result<i128, ContractError> {
+        // Guard: contract must be fully initialized before a pending fee-rate
+        // change can be applied. Without this check a caller could observe a
+        // PendingFeeRate entry that was somehow written before initialization
+        // completed and apply it, writing FeeRateBps storage before the admin
+        // is set and leaving the contract in an inconsistent state.
+        validation::require_initialized(&env)?;
+
         let pending = storage::get_pending_fee_rate_change(&env)
             .ok_or(ContractError::NoPendingFeeChange)?;
         if env.ledger().timestamp() < pending.effective_at {


### PR DESCRIPTION
## Problem

`execute_fee_rate_change` was the **only state-mutating contract entry point** that did not call `validation::require_initialized` before operating on persistent storage.

Every other mutating function (`set_fee_rate`, `set_fee_cap`, `set_treasury`, `cancel_market`, `update_position`, etc.) begins with `require_initialized` so callers on an uninitialized contract receive `ContractError::NotInitialized` rather than silently reading or writing orphaned storage entries.

Without the guard a caller could write `FeeRateBps` storage via `execute_fee_rate_change` before the contract admin is set — producing a partially-configured contract state inconsistent with the initialization invariant documented throughout the codebase.

## What Changed

`execute_fee_rate_change` now opens with:

```rust
validation::require_initialized(&env)?;
```

This is the same guard used by every other mutating function. The existing timelock check (`timestamp < effective_at → TimelockNotElapsed`) is **unchanged**.

## Files Changed

- `contracts/market/src/lib.rs` — add `require_initialized` as the first check in `execute_fee_rate_change`

## Acceptance Criteria

- [x] Early execute (before `effective_at`) fails with `TimelockNotElapsed` — existing check, unchanged
- [x] Execute on uninitialized contract fails with `NotInitialized` — new guard
- [x] Ready execute (after `effective_at` on initialized contract) updates `FeeRateBps` — existing behavior, unchanged