### PR TITLE
fix(market): write StorageVersion before Admin in initialize

### DIFF
--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -183,14 +183,34 @@ impl MarketContract {
         // 2. Require authorization from the admin
         admin.require_auth();
         
-        // 3. Check if already initialized
+        // 3. Guard against double-initialization using the stored admin as the
+        //    canonical "already initialized" sentinel. This is the same value
+        //    that require_initialized checks, so the rejection is consistent
+        //    with every other function's initialization guard.
         if storage::has_admin(&env) {
             return Err(ContractError::AlreadyInitialized);
         }
         
-        // 4. Set admin and version
-        storage::set_admin(&env, &admin);
+        // 4. Write version BEFORE writing admin.
+        //
+        //    If the transaction is interrupted between the two writes (e.g. due
+        //    to an out-of-gas or host error), we want the contract to be left
+        //    in the least-dangerous incomplete state:
+        //
+        //    - Version set, admin NOT set: has_admin() == false, so a retry of
+        //      initialize() will succeed and complete the setup. The contract
+        //      is effectively unowned and all require_initialized guards still
+        //      fail, so no state-mutating function can be called.
+        //
+        //    - Admin set, version NOT set: has_admin() == true, so a retry of
+        //      initialize() returns AlreadyInitialized — the contract is
+        //      permanently locked out of initialization while storage accessors
+        //      that call assert_version() return UpgradeRequired. The contract
+        //      is bricked with no recovery path short of redeployment.
+        //
+        //    Writing version first avoids the bricked state entirely.
         storage::set_version(&env);
+        storage::set_admin(&env, &admin);
         
         // 5. Emit initialization event
         events::emit_contract_initialized(&env, &admin);


### PR DESCRIPTION
## Problem

The two storage writes in `initialize()` were ordered **admin-first, version-second**. If the transaction is interrupted between those two writes (out-of-gas or host error), the resulting partial state is different depending on which write completed:

| Interrupted after | `has_admin()` | `assert_version()` | Result |
|---|---|---|---|
| `set_admin` (old ordering) | `true` | `UpgradeRequired` | **Bricked**: `initialize()` returns `AlreadyInitialized`, but all storage accessors return `UpgradeRequired`. No recovery path short of redeployment. |
| `set_version` (new ordering) | `false` | `Ok(())` | **Recoverable**: `initialize()` can be retried. All `require_initialized` guards still reject callers, so nothing can be called in the gap. |

## Fix

Swap the write order: call `storage::set_version` **before** `storage::set_admin`.

The `AlreadyInitialized` guard (`has_admin()` check) is **unchanged** — it still correctly rejects any second complete call to `initialize()` after a successful first run.

## Why This Satisfies "Reject initialize twice"

The existing `has_admin()` guard already returns `ContractError::AlreadyInitialized` on a second call. This PR does not change that logic — it hardens the **write ordering** so that the guard's sentinel value (`Admin`) is only written once all preceding state is durable. A second `initialize()` call on a successfully initialized contract still returns `AlreadyInitialized` (#42).

## Files Changed

- `contracts/market/src/lib.rs` — reorder `set_version` before `set_admin` inside `initialize()`

## Acceptance Criteria

- [x] Second `initialize` returns `ContractError::AlreadyInitialized` — existing guard, unchanged
- [x] Partial-write recovery: interrupted init leaves contract in a retryable state, not a bricked one