### PR TITLE
fix(market): track depositors in MarketParticipants list on first deposit

### DIFF
--- a/contracts/market/src/deposit.rs
+++ b/contracts/market/src/deposit.rs
@@ -147,6 +147,16 @@ pub fn deposit_collateral(
     // Persist updated position
     storage::set_position(&env, market_id, &user, &position)?;
 
+    // Track first-time depositors in the MarketParticipants list (Issue #546 / #495).
+    //
+    // `add_market_participant` is idempotent — it performs a linear search
+    // before appending, so repeated deposits by the same user produce no
+    // duplicate entries. Calling it here (in addition to the call in
+    // `update_position`) ensures that users who deposit collateral but never
+    // execute a trade are still present in the list and will be reached by
+    // the paginated `settle_positions_page` settlement path.
+    storage::add_market_participant(&env, market_id, &user);
+
     // Record deposit timestamp for cooldown enforcement on withdrawals (issue #413).
     storage::set_last_deposit_time(&env, market_id, &user, env.ledger().timestamp());
 


### PR DESCRIPTION
## Summary

Closes #546

## Problem

`deposit_collateral` never called `storage::add_market_participant`, so users who deposited collateral but never executed a trade were **absent from the `MarketParticipants(market_id)` list**.

This broke two distinct code paths:

1. **Paginated settlement (`settle_positions_page`)** — the partial-settlement path enumerates participants exclusively from this list. A depositor-only user (collateral deposited, zero trades) would never appear in the list and therefore could never be settled, permanently locking their collateral in the contract.

2. **Off-chain tooling** — indexers and admin scripts that call `get_market_participant_count` / `get_market_participants` to enumerate all participants in a market would return an incomplete set, leading to silent under-reporting.

## Root Cause

`add_market_participant` was introduced to track on-chain membership (Issue #495) and wired into the **trade path** (`update_position` in `lib.rs`), but was never added to the **deposit path** (`deposit_collateral` in `deposit.rs`).

## Fix

Call `storage::add_market_participant(&env, market_id, &user)` immediately after `set_position` in `deposit_collateral`.

The helper is **idempotent**: it performs a linear scan before appending, so:
- A user who deposits multiple times is recorded exactly once.
- A user who later executes a trade (triggering the existing call in `update_position`) is still recorded exactly once — no duplicates.

The uniqueness invariant documented in `storage.rs` is fully preserved.

## Files Changed

- `contracts/market/src/deposit.rs` — call `add_market_participant` after persisting position

## Acceptance Criteria

- [x] **Participants list stays unique** — `add_market_participant` is idempotent; duplicate deposits do not produce duplicate entries
- [x] **Depositor-only users included in partial settlement path** — `settle_positions_page` will now reach users who only deposited collateral without trading
