### PR TITLE
fix(market): guard execute_fee_rate_change with require_initialized

### DIFF
--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -1048,6 +1048,14 @@ impl MarketContract {
     ///   time in [`Self::set_fee_rate`]) so a cap lowered by the admin while a
     ///   change is in flight cannot let a stale, now-excessive rate through.
     pub fn execute_fee_rate_change(env: Env) -> Result<i128, ContractError> {
+        // Guard: contract must be fully initialized before a pending fee-rate
+        // change can be applied (Issue #547). Without this check a caller could
+        // invoke execute_fee_rate_change on a contract where the admin has not
+        // yet been set, writing FeeRateBps storage before initialization is
+        // complete and leaving the contract in an inconsistent state.
+        // This is the same guard used by every other state-mutating entry point.
+        validation::require_initialized(&env)?;
+
         let pending = storage::get_pending_fee_rate_change(&env)
             .ok_or(ContractError::NoPendingFeeChange)?;
         if env.ledger().timestamp() < pending.effective_at {


### PR DESCRIPTION
## Summary

Closes #547

## Problem

`execute_fee_rate_change` was the **only state-mutating entry point** that did not call `validation::require_initialized` before touching persistent storage.

Every other mutating function — `set_fee_rate`, `set_fee_cap`, `set_treasury`, `cancel_market`, `update_position`, `pause`, `unpause`, etc. — opens with `require_initialized` so callers on an uninitialized contract receive `ContractError::NotInitialized` rather than silently reading or writing orphaned storage entries.

Without the guard:
- A caller could invoke `execute_fee_rate_change` on a contract where `initialize` has not yet been called.
- If a `PendingFeeRate` entry somehow existed (e.g. written by a prior partial-init or storage migration), the function would write `FeeRateBps` before the admin is set — producing a contract state that is partially configured and inconsistent with the initialization invariant documented throughout the codebase.

## Fix

Add `validation::require_initialized(&env)?;` as the first statement in `execute_fee_rate_change`, identical to every other mutating function.

The **existing timelock check** (`timestamp < effective_at → TimelockNotElapsed`) is **unchanged** — it still correctly rejects attempts to execute a pending fee-rate change before the 48-hour delay has elapsed.

## Execution timeline after this fix

| Contract state | `execute_fee_rate_change` result |
|---|---|
| Not initialized | `NotInitialized` (new guard) |
| Initialized, no pending change | `NoPendingFeeChange` (unchanged) |
| Initialized, pending change, before `effective_at` | `TimelockNotElapsed` (unchanged) |
| Initialized, pending change, after `effective_at`, rate > cap | `FeeCapExceeded` (unchanged) |
| Initialized, pending change, after `effective_at`, rate ≤ cap | Applies change, returns new rate (unchanged) |

## Files Changed

- `contracts/market/src/lib.rs` — add `require_initialized` as the first check in `execute_fee_rate_change`

## Acceptance Criteria

- [x] **Early execute fails** — calling before `effective_at` returns `TimelockNotElapsed` (existing check, unchanged)
- [x] **Execute on uninitialized contract fails** — new `require_initialized` guard returns `NotInitialized`
- [x] **Ready execute updates `FeeRateBps`** — after timelock elapses on initialized contract, fee rate is applied (existing behaviour, unchanged)
