### PR TITLE
fix(market): reject double initialize and harden init write ordering

### DIFF
--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -183,14 +183,39 @@ impl MarketContract {
         // 2. Require authorization from the admin
         admin.require_auth();
         
-        // 3. Check if already initialized
+        // 3. Check if already initialized.
+        //
+        // `has_admin` is the canonical "already initialized" sentinel — the
+        // same value that `require_initialized` checks — so this guard is
+        // consistent with every other function's initialization check.
+        // A second call to `initialize` after a successful first call always
+        // returns `AlreadyInitialized` (#42), leaving all storage unchanged.
         if storage::has_admin(&env) {
             return Err(ContractError::AlreadyInitialized);
         }
-        
-        // 4. Set admin and version
-        storage::set_admin(&env, &admin);
+
+        // 4. Write version BEFORE writing admin (Issue #548).
+        //
+        // If the transaction is interrupted between the two writes (e.g. an
+        // out-of-gas or host trap), the resulting partial state differs based
+        // on which write completed first:
+        //
+        //   Admin set, version NOT set (old ordering):
+        //     has_admin() == true  →  initialize() returns AlreadyInitialized
+        //     assert_version() returns UpgradeRequired
+        //     Result: contract is permanently bricked — initialization cannot
+        //     be retried, and no storage accessor can be called. The only
+        //     recovery is redeployment.
+        //
+        //   Version set, admin NOT set (new ordering):
+        //     has_admin() == false  →  initialize() can be retried
+        //     assert_version() returns Ok
+        //     All require_initialized guards reject callers in the gap.
+        //     Result: contract is in a recoverable, safe state.
+        //
+        // Writing version first eliminates the bricked state entirely.
         storage::set_version(&env);
+        storage::set_admin(&env, &admin);
         
         // 5. Emit initialization event
         events::emit_contract_initialized(&env, &admin);


### PR DESCRIPTION
## Summary

Closes #548

## Problem

The two storage writes in `initialize()` were ordered **admin-first, version-second**:

```rust
storage::set_admin(&env, &admin);
storage::set_version(&env);
```

If the transaction is interrupted between these two writes (e.g. an out-of-gas error or host trap), the resulting partial state is different depending on which write completed:

| Interrupted after | `has_admin()` | `assert_version()` | Effect |
|---|---|---|---|
| `set_admin` (old order) | `true` | `UpgradeRequired` | **Bricked**: `initialize()` returns `AlreadyInitialized` — cannot retry — yet all storage accessors return `UpgradeRequired`. No recovery path short of redeployment. |
| `set_version` (new order) | `false` | `Ok(())` | **Recoverable**: `initialize()` can be retried. All `require_initialized` guards still reject callers in the gap. |

Additionally, the existing `AlreadyInitialized` guard was correct but lacked documentation explaining why `has_admin()` is the canonical sentinel and why this ordering matters.

## Fix

**Swap the write order**: call `storage::set_version` **before** `storage::set_admin`.

The `AlreadyInitialized` guard is **unchanged** — `initialize()` still returns `ContractError::AlreadyInitialized` (#42) on any second call after a successful first call, with no storage modified.

```rust
// After fix — version written first
storage::set_version(&env);
storage::set_admin(&env, &admin);
```

## Why This Satisfies "Reject initialize twice"

The `has_admin()` check already correctly rejected second calls. This PR:
1. Documents the guard clearly.
2. Hardens the **write ordering** so interrupted initialization leaves the contract in a **retryable**, safe state rather than a permanently bricked one.

A complete second `initialize()` call on a successfully initialized contract still returns `AlreadyInitialized` with storage unchanged — this behavior is preserved.

## Files Changed

- `contracts/market/src/lib.rs` — reorder `set_version` before `set_admin` inside `initialize()`, with explanatory comments

## Acceptance Criteria

- [x] **Second `initialize` returns `ContractError::AlreadyInitialized`** — existing guard is unchanged, still fires on any second complete call
- [x] **Storage is unchanged after failed second init** — `AlreadyInitialized` is returned before any write occurs
- [x] **Partial-write recovery** — interrupted init (version written, admin not yet written) leaves contract in a retryable state, not a permanently bricked one
