### PR TITLE
fix(market): reject deposits at exactly end_time (>= instead of >)

### DIFF
--- a/contracts/market/src/deposit.rs
+++ b/contracts/market/src/deposit.rs
@@ -101,7 +101,15 @@ pub fn deposit_collateral(
         return Err(ContractError::MarketClosedToDeposits);
     }
 
-    if env.ledger().timestamp() > market.end_time {
+    // Reject deposits at or after end_time (Issue #549). A market expires the
+    // moment the ledger timestamp reaches end_time, so a deposit submitted in
+    // the same ledger second as expiry must be rejected (>= not just >).
+    //
+    // Using strict greater-than (>) would admit a deposit at exactly end_time,
+    // which is inside the expired window from the market's perspective — the
+    // same ledger second is simultaneously the last valid trading instant and
+    // the first expired one, so we treat it as expired and reject it.
+    if env.ledger().timestamp() >= market.end_time {
         return Err(ContractError::MarketExpired);
     }
 


### PR DESCRIPTION
## Summary

Closes #549

## Problem

The expiry guard in `deposit_collateral` used **strict greater-than** (`>`):

```rust
if env.ledger().timestamp() > market.end_time {
    return Err(ContractError::MarketExpired);
}
```

This admitted a deposit whose ledger timestamp equals `end_time` exactly. `end_time` is the market's expiry instant — a deposit that lands in the same ledger second is semantically a deposit into an **expired** market and must be rejected.

The Soroban ledger timestamp has second-level granularity. When `timestamp == end_time`, the market has simultaneously reached its expiry boundary. From the user's perspective and the market's rules, that boundary is exclusive — `end_time` marks the first instant at which the market is no longer active.

## Fix

Change the comparison to **greater-than-or-equal** (`>=`):

```rust
if env.ledger().timestamp() >= market.end_time {
    return Err(ContractError::MarketExpired);
}
```

## Boundary Behaviour

| Ledger timestamp | Before fix | After fix |
|---|---|---|
| `< end_time` | ✅ accepted | ✅ accepted |
| `== end_time` | ✅ accepted **(bug)** | ❌ `MarketExpired` **(fixed)** |
| `> end_time` | ❌ `MarketExpired` | ❌ `MarketExpired` |

## Files Changed

- `contracts/market/src/deposit.rs` — change `>` to `>=` in the expiry check, with explanatory comment

## Acceptance Criteria

- [x] **Expired market (timestamp > end_time)** rejects deposit with `MarketExpired` — unchanged
- [x] **Market at exactly end_time** rejects deposit with `MarketExpired` — fixed
- [x] **Active market (timestamp < end_time)** accepts deposit — unchanged
