### PR TITLE
Add dispute-game economics: challenger bonds, slashing, and terminal …

### DIFF
--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -38,6 +38,7 @@
 //! | `close_market_to_deposits`         | admin                           |
 //! | `set_resolution_contract`          | admin                           |
 //! | `set_fee_cap`                      | admin                           |
+//! | `void_market`                      | registered resolution contract  |
 //!
 //! ## Storage layout
 //!
@@ -647,6 +648,48 @@ impl MarketContract {
 
         // 4. Emit the cancellation event for off-chain indexers.
         events::emit_market_canceled(&env, market_id, &admin, env.ledger().timestamp());
+
+        Ok(())
+    }
+
+    /// Void a market whose on-chain dispute-resolution process reached a
+    /// terminal, unresolvable state (the registered resolution contract
+    /// exhausted its max appeal rounds with no safely-attestable outcome).
+    ///
+    /// This is the counterpart to the `require_resolution_finalized` gate on
+    /// `resolve_market`: just as that gate lets only the registered
+    /// resolution contract's `finalize` unlock a normal resolution, this
+    /// entrypoint lets only that same contract force a market out of a
+    /// stuck dispute, without needing to impersonate the market's admin.
+    /// Behaves identically to `cancel_market` from the market's perspective
+    /// (`Active` → `Canceled`, collateral reclaimable via
+    /// `withdraw_canceled_collateral`) but is authorized by the resolution
+    /// contract rather than the admin.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] – no resolution contract is registered,
+    ///   or `caller` is not the registered resolution contract
+    /// - [`ContractError::MarketNotFound`] – the market does not exist
+    /// - [`ContractError::MarketAlreadyResolved`] – the market is already resolved
+    /// - [`ContractError::MarketNotActive`] – the market is already canceled
+    pub fn void_market(env: Env, caller: Address, market_id: u32) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        validation::require_not_paused(&env)?;
+        caller.require_auth();
+        let resolution_contract =
+            storage::get_resolution_contract(&env).ok_or(ContractError::NotAdmin)?;
+        if caller != resolution_contract {
+            return Err(ContractError::NotAdmin);
+        }
+
+        let mut market =
+            storage::get_market(&env, market_id)?.ok_or(ContractError::MarketNotFound)?;
+        validation::validate_cancelable(&market.status)?;
+
+        market.status = MarketStatus::Canceled;
+        storage::set_market(&env, market_id, &market)?;
+
+        events::emit_market_canceled(&env, market_id, &caller, env.ledger().timestamp());
 
         Ok(())
     }

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -54,7 +54,8 @@
 
 use crate::error::ContractError;
 use crate::events::{
-    emit_collateral_withdrawn, emit_fee_calculated, emit_large_withdraw, emit_withdraw_edge_case,
+    emit_collateral_withdrawn, emit_fee_calculated, emit_fee_retained_no_treasury,
+    emit_large_withdraw, emit_withdraw_edge_case,
 };
 use crate::storage;
 use crate::types::{MarketStatus, Position};

--- a/contracts/resolution/src/error.rs
+++ b/contracts/resolution/src/error.rs
@@ -30,6 +30,15 @@ pub enum ContractError {
     InsufficientCollateral = 15,
     /// A collateral amount is invalid (e.g. zero or negative).
     InvalidCollateral = 16,
+    /// `challenge`'s `bond_amount` is below `MIN_CHALLENGE_BOND_AMOUNT`.
+    InsufficientChallengeBond = 17,
+    /// `arbitrate_uphold_proposer` / `void_market` was called on a candidate
+    /// that is not `Challenged`, or has not yet exhausted
+    /// `MAX_APPEAL_ROUNDS`.
+    NotArbitrable = 18,
+    /// `arbitrate_uphold_proposer` / `void_market` was called before the
+    /// arbitration timelock elapsed.
+    ArbitrationTimelockNotElapsed = 19,
     Unauthorized = 40,
     NotAdmin = 41,
     AlreadyInitialized = 42,

--- a/contracts/resolution/src/events.rs
+++ b/contracts/resolution/src/events.rs
@@ -30,6 +30,7 @@ pub struct CandidateProposed {
     pub evidence_uri: String,
     pub challenge_deadline: u64,
     pub signature_expiry: u64,
+    pub bond_amount: i128,
 }
 
 pub fn emit_candidate_proposed(env: &Env, candidate: &crate::types::ResolutionCandidate) {
@@ -41,6 +42,7 @@ pub fn emit_candidate_proposed(env: &Env, candidate: &crate::types::ResolutionCa
         evidence_uri: candidate.evidence_uri.clone(),
         challenge_deadline: candidate.challenge_deadline,
         signature_expiry: candidate.signature_expiry,
+        bond_amount: candidate.bond_amount,
     }
     .publish(env);
 }
@@ -54,6 +56,7 @@ pub struct CandidateChallenged {
     pub market_id: u32,
     pub challenger: Address,
     pub challenge_uri: String,
+    pub bond_amount: i128,
     pub challenged_at: u64,
 }
 
@@ -63,13 +66,136 @@ pub fn emit_candidate_challenged(
     market_id: u32,
     challenger: &Address,
     challenge_uri: &String,
+    bond_amount: i128,
 ) {
     CandidateChallenged {
         candidate_id,
         market_id,
         challenger: challenger.clone(),
         challenge_uri: challenge_uri.clone(),
+        bond_amount,
         challenged_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+/// A bond (proposer's or a challenger's) was forfeited and split into a
+/// reward to the winning party, a burned portion, and a treasury portion
+/// (Issue: dispute-game economics). `loser` is whoever posted the bond;
+/// `winner` receives the reward share.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BondSlashed {
+    #[topic]
+    pub candidate_id: u32,
+    #[topic]
+    pub market_id: u32,
+    pub loser: Address,
+    pub winner: Address,
+    pub total: i128,
+    pub reward: i128,
+    pub burned: i128,
+    pub treasury_cut: i128,
+    pub slashed_at: u64,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn emit_bond_slashed(
+    env: &Env,
+    candidate_id: u32,
+    market_id: u32,
+    loser: &Address,
+    winner: &Address,
+    total: i128,
+    reward: i128,
+    burned: i128,
+    treasury_cut: i128,
+) {
+    BondSlashed {
+        candidate_id,
+        market_id,
+        loser: loser.clone(),
+        winner: winner.clone(),
+        total,
+        reward,
+        burned,
+        treasury_cut,
+        slashed_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+/// A bond was refunded in full (no fault determined), e.g. every recorded
+/// challenger's bond when a market is voided.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BondRefunded {
+    #[topic]
+    pub candidate_id: u32,
+    #[topic]
+    pub market_id: u32,
+    pub recipient: Address,
+    pub amount: i128,
+    pub refunded_at: u64,
+}
+
+pub fn emit_bond_refunded(
+    env: &Env,
+    candidate_id: u32,
+    market_id: u32,
+    recipient: &Address,
+    amount: i128,
+) {
+    BondRefunded {
+        candidate_id,
+        market_id,
+        recipient: recipient.clone(),
+        amount,
+        refunded_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+/// Admin arbitration upheld the proposer's disputed outcome after
+/// `MAX_APPEAL_ROUNDS` were exhausted (Issue: dispute-game economics).
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct CandidateArbitrated {
+    #[topic]
+    pub candidate_id: u32,
+    #[topic]
+    pub market_id: u32,
+    pub outcome: bool,
+    pub arbitrated_at: u64,
+}
+
+pub fn emit_candidate_arbitrated(env: &Env, candidate_id: u32, market_id: u32, outcome: bool) {
+    CandidateArbitrated {
+        candidate_id,
+        market_id,
+        outcome,
+        arbitrated_at: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+/// The underlying market was voided after `MAX_APPEAL_ROUNDS` were exhausted
+/// with no safely-attestable outcome (Issue: dispute-game economics).
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct MarketVoided {
+    #[topic]
+    pub candidate_id: u32,
+    #[topic]
+    pub market_id: u32,
+    pub voided_at: u64,
+}
+
+pub fn emit_market_voided(env: &Env, candidate_id: u32, market_id: u32) {
+    MarketVoided {
+        candidate_id,
+        market_id,
+        voided_at: env.ledger().timestamp(),
     }
     .publish(env);
 }

--- a/contracts/resolution/src/lib.rs
+++ b/contracts/resolution/src/lib.rs
@@ -9,24 +9,40 @@
 //! be finalized, which triggers `resolve_market` on the registered market
 //! contract.
 //!
+//! Both proposer and challenger must post a bond in the market's collateral
+//! token; whichever side loses the dispute has its bond forfeited and split
+//! (`REWARD_BPS` to the winner, `BURN_BPS` burned, remainder to the
+//! configured treasury) rather than refunded, so disputing — or repeatedly
+//! challenging to grief resolution — costs real money.
+//!
 //! ## Lifecycle
 //!
 //! ```text
-//!  Propose (signed outcome + evidence URI)
+//!  Propose (signed outcome + evidence + bond)
 //!      │
-//!      ├── (window passes) ──► Finalize ──► market.resolve_market()
+//!      ├── (window passes) ──► Finalize ──► refund proposer, slash challengers ──► market.resolve_market()
 //!      │
-//!      └── Challenge ──► status = Challenged (cannot finalize)
+//!      └── Challenge (+ bond) ──► status = Challenged (cannot finalize)
+//!               │
+//!               ├── Appeal (re-propose, new window) ──► back to Proposed
+//!               │        │
+//!               │        └── appeal_round >= MAX_APPEAL_ROUNDS, still Challenged, timelock elapsed:
+//!               │             ├── arbitrate_uphold_proposer ──► same settlement as Finalize
+//!               │             └── void_market ──► slash proposer, refund challengers, market.void_market()
+//!               │
+//!               └── (never appealed) ──► same terminal admin paths above once appeal_round reaches the cap
 //! ```
 //!
 //! ## Storage layout
 //!
-//! | Key                            | Type                  | Description                                   |
-//! |--------------------------------|-----------------------|-----------------------------------------------|
-//! | `Config`                       | `ResolutionConfig`    | Admin, factory, and market contract addresses |
-//! | `CandidateCounter`             | `u32`                 | Auto-increment counter for candidate IDs      |
-//! | `Candidate(u32)`               | `ResolutionCandidate` | Per-candidate resolution data                  |
-//! | `CandidateByMarket(u32)`       | `u32`                 | Maps market_id → candidate_id (latest)        |
+//! | Key                            | Type                     | Description                                   |
+//! |--------------------------------|--------------------------|-----------------------------------------------|
+//! | `Config`                       | `ResolutionConfig`       | Admin, factory, and market contract addresses |
+//! | `CandidateCounter`             | `u32`                    | Auto-increment counter for candidate IDs      |
+//! | `Candidate(u32)`               | `ResolutionCandidate`    | Per-candidate resolution data                  |
+//! | `CandidateByMarket(u32)`       | `u32`                    | Maps market_id → candidate_id (latest)        |
+//! | `Challengers(u32)`             | `Vec<ChallengeRecord>`   | Every bonded challenger for a candidate        |
+//! | `Treasury`                     | `Option<Address>`        | Optional recipient for the treasury bond cut   |
 
 mod error;
 mod events;
@@ -47,14 +63,40 @@ const MAX_CHALLENGE_WINDOW_SECONDS: u64 = 14 * 24 * 60 * 60;
 const MAX_URI_BYTES: u32 = 512;
 
 /// Maximum number of times a candidate may be re-proposed via `appeal`
-/// after being challenged, before the dispute must be resolved off-chain
-/// (e.g. by admin intervention) rather than through further appeals.
+/// after being challenged. Once a `Challenged` candidate's `appeal_round`
+/// reaches this cap, further appeals are rejected and the dispute becomes
+/// eligible for terminal admin arbitration (`arbitrate_uphold_proposer`) or
+/// voiding (`void_market`) — see the timelock below.
 const MAX_APPEAL_ROUNDS: u32 = 3;
 
 /// Minimum bond a proposer must post (in the market's collateral token,
 /// stroops) when calling `propose`. Locked in this contract and refunded on
 /// successful finalize.
 const MIN_BOND_AMOUNT: i128 = 10_000_000;
+
+/// Minimum bond a challenger must post (in the market's collateral token,
+/// stroops) when calling `challenge`. Locked in this contract alongside the
+/// proposer's bond. Requiring a bond (rather than a free challenge) is what
+/// makes griefing — repeatedly challenging to indefinitely delay resolution
+/// — economically costly instead of free.
+const MIN_CHALLENGE_BOND_AMOUNT: i128 = 10_000_000;
+
+/// Delay, in seconds, that must elapse after a candidate's last challenge
+/// deadline before admin arbitration (`arbitrate_uphold_proposer`) or
+/// voiding (`void_market`) may be executed. Mirrors
+/// `vatix_market_contract::FEE_RATE_TIMELOCK_SECONDS`: it gives the
+/// community a public window to react before an admin can unilaterally
+/// settle a maximally-appealed dispute.
+const ARBITRATION_TIMELOCK_SECONDS: u64 = 172_800;
+
+/// Basis-point split applied whenever a bond is forfeited: `REWARD_BPS` goes
+/// to the winning counterparty, `BURN_BPS` is burned (removed from supply),
+/// and the remainder goes to the configured treasury (or stays in this
+/// contract's balance if no treasury is registered). Documented split for
+/// the "challenger reward, burn, treasury" requirement.
+const REWARD_BPS: i128 = 5_000;
+const BURN_BPS: i128 = 2_500;
+const BPS_DENOMINATOR: i128 = 10_000;
 
 #[contract]
 pub struct ResolutionContract;
@@ -229,18 +271,39 @@ impl ResolutionContract {
     }
 
     /// Challenge a candidate while its challenge window is still open.
+    ///
+    /// The challenger must post a `bond_amount` (>= `MIN_CHALLENGE_BOND_AMOUNT`)
+    /// in the market's collateral token, transferred from the challenger to
+    /// this contract and locked until the dispute reaches a terminal state
+    /// (`finalize`, `arbitrate_uphold_proposer`, or `void_market`). Requiring
+    /// a bond — rather than allowing free challenges — is what makes
+    /// repeatedly challenging to grief resolution economically costly: an
+    /// incorrect challenger loses this bond (see `finalize` /
+    /// `arbitrate_uphold_proposer`).
+    ///
+    /// Every challenge across a candidate's whole appeal lifecycle is
+    /// recorded (bounded by `MAX_APPEAL_ROUNDS + 1` entries), so a
+    /// superseded challenger from an earlier round is still settled once the
+    /// dispute terminates.
     pub fn challenge(
         env: Env,
         challenger: Address,
         candidate_id: u32,
         challenge_uri: String,
+        bond_amount: i128,
     ) -> Result<(), ContractError> {
         challenger.require_auth();
         validate_uri(&challenge_uri)?;
+        if bond_amount < MIN_CHALLENGE_BOND_AMOUNT {
+            return Err(ContractError::InsufficientChallengeBond);
+        }
 
         let mut candidate =
             storage::get_candidate(&env, candidate_id).ok_or(ContractError::CandidateNotFound)?;
         if candidate.status == CandidateStatus::Finalized {
+            return Err(ContractError::CandidateAlreadyFinalized);
+        }
+        if candidate.status == CandidateStatus::Voided {
             return Err(ContractError::CandidateAlreadyFinalized);
         }
         if candidate.status == CandidateStatus::Challenged {
@@ -250,16 +313,23 @@ impl ResolutionContract {
             return Err(ContractError::ChallengeWindowClosed);
         }
 
+        let config = storage::get_config(&env);
+        let collateral_token = get_collateral_token(&env, &config, candidate.market_id);
+        let this = env.current_contract_address();
+        TokenClient::new(&env, &collateral_token).transfer(&challenger, &this, &bond_amount);
+
         candidate.status = CandidateStatus::Challenged;
         candidate.challenged_by = Some(challenger.clone());
         candidate.challenge_uri = Some(challenge_uri.clone());
         storage::set_candidate(&env, &candidate);
+        storage::append_challenger(&env, candidate_id, &challenger, bond_amount);
         events::emit_candidate_challenged(
             &env,
             candidate_id,
             candidate.market_id,
             &challenger,
             &challenge_uri,
+            bond_amount,
         );
         Ok(())
     }
@@ -345,7 +415,9 @@ impl ResolutionContract {
         let mut candidate =
             storage::get_candidate(&env, candidate_id).ok_or(ContractError::CandidateNotFound)?;
 
-        if candidate.status == CandidateStatus::Finalized {
+        if candidate.status == CandidateStatus::Finalized
+            || candidate.status == CandidateStatus::Voided
+        {
             return Err(ContractError::CandidateAlreadyFinalized);
         }
         if candidate.status == CandidateStatus::Challenged {
@@ -366,16 +438,17 @@ impl ResolutionContract {
 
         // Refund the proposer's locked bond now that the candidate has
         // finalized successfully.
+        let collateral_token = get_collateral_token(&env, &config, candidate.market_id);
+        let token_client = TokenClient::new(&env, &collateral_token);
+        let this = env.current_contract_address();
         if candidate.bond_amount > 0 {
-            let config = storage::get_config(&env);
-            let collateral_token = get_collateral_token(&env, &config, candidate.market_id);
-            let token_client = TokenClient::new(&env, &collateral_token);
-            token_client.transfer(
-                &env.current_contract_address(),
-                &candidate.proposer,
-                &candidate.bond_amount,
-            );
+            token_client.transfer(&this, &candidate.proposer, &candidate.bond_amount);
         }
+
+        // The proposer's outcome stood unchallenged (or survived every
+        // challenge it faced via `appeal`), so every challenger who ever
+        // disputed this candidate was wrong — slash their bonds.
+        settle_challengers_as_losers(&env, candidate_id, &candidate, &collateral_token);
 
         events::emit_candidate_finalized(&env, &candidate);
 
@@ -452,6 +525,161 @@ impl ResolutionContract {
     pub fn get_proposer_collateral(env: Env, proposer: Address) -> i128 {
         storage::get_proposer_collateral(&env, &proposer)
     }
+
+    // ── Terminal arbitration / void path (dispute-game economics) ──────────────
+
+    /// Register (or replace) the treasury address that receives the
+    /// treasury-cut share of slashed bonds. Optional — while unset, that
+    /// share simply stays in this contract's own collateral-token balance.
+    pub fn set_treasury(env: Env, admin: Address, treasury: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        let config = storage::get_config(&env);
+        require_admin(&admin, &config)?;
+        storage::set_treasury(&env, &treasury);
+        Ok(())
+    }
+
+    pub fn get_treasury(env: Env) -> Option<Address> {
+        storage::get_treasury(&env)
+    }
+
+    pub fn get_challengers(env: Env, candidate_id: u32) -> Vec<crate::types::ChallengeRecord> {
+        storage::get_challengers(&env, candidate_id)
+    }
+
+    /// Admin-only, timelocked: uphold the proposer's currently-disputed
+    /// outcome once `MAX_APPEAL_ROUNDS` have been exhausted and
+    /// `ARBITRATION_TIMELOCK_SECONDS` have elapsed since the last challenge
+    /// deadline. Settles bonds exactly like `finalize` (proposer refunded,
+    /// every recorded challenger slashed) and invokes `resolve_market` with
+    /// the candidate's existing signed outcome — this is the "arbitration"
+    /// half of the checklist's "arbitrate or void" terminal path.
+    pub fn arbitrate_uphold_proposer(
+        env: Env,
+        admin: Address,
+        candidate_id: u32,
+    ) -> Result<ResolutionCandidate, ContractError> {
+        admin.require_auth();
+        let config = storage::get_config(&env);
+        require_admin(&admin, &config)?;
+
+        let mut candidate =
+            storage::get_candidate(&env, candidate_id).ok_or(ContractError::CandidateNotFound)?;
+        require_arbitrable(&env, &candidate)?;
+
+        candidate.status = CandidateStatus::Finalized;
+        candidate.finalized_at = Some(env.ledger().timestamp());
+        storage::set_candidate(&env, &candidate);
+
+        let collateral_token = get_collateral_token(&env, &config, candidate.market_id);
+        let token_client = TokenClient::new(&env, &collateral_token);
+        let this = env.current_contract_address();
+        if candidate.bond_amount > 0 {
+            token_client.transfer(&this, &candidate.proposer, &candidate.bond_amount);
+        }
+        settle_challengers_as_losers(&env, candidate_id, &candidate, &collateral_token);
+
+        events::emit_candidate_arbitrated(&env, candidate_id, candidate.market_id, candidate.outcome);
+
+        let args: Vec<Val> = soroban_sdk::vec![
+            &env,
+            candidate.market_id.into_val(&env),
+            candidate.outcome.into_val(&env),
+            candidate.signature.clone().into_val(&env),
+        ];
+        let _: () = env.invoke_contract(
+            &config.market_contract,
+            &Symbol::new(&env, "resolve_market"),
+            args,
+        );
+
+        Ok(candidate)
+    }
+
+    /// Admin-only, timelocked: void the market once `MAX_APPEAL_ROUNDS` have
+    /// been exhausted and `ARBITRATION_TIMELOCK_SECONDS` have elapsed, for
+    /// disputes where arbitration cannot safely attest to either side's
+    /// outcome on-chain (this contract has no valid signature for the
+    /// challenger's claimed outcome, so it cannot call `resolve_market` in
+    /// their favor). Rather than leaving the market stuck non-terminal
+    /// forever, this slashes the proposer's bond (rewarding the disputing
+    /// challenger(s) per the documented split), refunds every recorded
+    /// challenger their own bond, and calls the market contract's
+    /// `void_market` to move it to `Canceled` — unsticking it so users can
+    /// reclaim collateral via `withdraw_canceled_collateral`.
+    pub fn void_market(
+        env: Env,
+        admin: Address,
+        candidate_id: u32,
+    ) -> Result<ResolutionCandidate, ContractError> {
+        admin.require_auth();
+        let config = storage::get_config(&env);
+        require_admin(&admin, &config)?;
+
+        let mut candidate =
+            storage::get_candidate(&env, candidate_id).ok_or(ContractError::CandidateNotFound)?;
+        require_arbitrable(&env, &candidate)?;
+
+        candidate.status = CandidateStatus::Voided;
+        candidate.finalized_at = Some(env.ledger().timestamp());
+        storage::set_candidate(&env, &candidate);
+
+        let collateral_token = get_collateral_token(&env, &config, candidate.market_id);
+        let token_client = TokenClient::new(&env, &collateral_token);
+        let challengers = storage::get_challengers(&env, candidate_id);
+
+        // The proposer's outcome could not withstand the final challenge, so
+        // their bond is forfeited — split per the documented reward/burn/
+        // treasury rule, rewarding whichever challenger's dispute stands
+        // (the most recent one on record).
+        if candidate.bond_amount > 0 {
+            let reward_recipient = challengers
+                .last()
+                .map(|record| record.challenger)
+                .unwrap_or_else(|| candidate.proposer.clone());
+            split_bond(
+                &env,
+                candidate_id,
+                candidate.market_id,
+                &collateral_token,
+                &candidate.proposer,
+                &reward_recipient,
+                candidate.bond_amount,
+            );
+        }
+
+        // Voiding means "no side could be safely vindicated on-chain", not
+        // "the challenger loses" — refund every recorded challenger in full.
+        let this = env.current_contract_address();
+        for record in challengers.iter() {
+            if record.bond > 0 {
+                token_client.transfer(&this, &record.challenger, &record.bond);
+                events::emit_bond_refunded(
+                    &env,
+                    candidate_id,
+                    candidate.market_id,
+                    &record.challenger,
+                    record.bond,
+                );
+            }
+        }
+        storage::clear_challengers(&env, candidate_id);
+
+        events::emit_market_voided(&env, candidate_id, candidate.market_id);
+
+        let args: Vec<Val> = soroban_sdk::vec![
+            &env,
+            env.current_contract_address().into_val(&env),
+            candidate.market_id.into_val(&env),
+        ];
+        let _: () = env.invoke_contract(
+            &config.market_contract,
+            &Symbol::new(&env, "void_market"),
+            args,
+        );
+
+        Ok(candidate)
+    }
 }
 
 fn require_admin(admin: &Address, config: &ResolutionConfig) -> Result<(), ContractError> {
@@ -506,4 +734,108 @@ fn require_market_active(
         return Err(ContractError::MarketAlreadyResolved);
     }
     Ok(())
+}
+
+/// Guard shared by `arbitrate_uphold_proposer` and `void_market`: both
+/// require the candidate to still be `Challenged` (an active, unresolved
+/// dispute — never true for `Proposed`, which the normal `finalize` path
+/// already handles) and `ARBITRATION_TIMELOCK_SECONDS` to have elapsed since
+/// its last challenge deadline.
+///
+/// Deliberately does *not* additionally require `appeal_round >=
+/// MAX_APPEAL_ROUNDS`: the primary intended trigger is a candidate that
+/// exhausted every appeal it was entitled to, but a proposer can also simply
+/// abandon a `Challenged` candidate without ever calling `appeal` at
+/// round 0 — that dispute would otherwise sit `Challenged` forever with no
+/// path to a terminal state. Gating on the timelock alone (rather than the
+/// appeal count) closes that gap too, while the multi-day delay still gives
+/// the community time to react before an admin can act unilaterally.
+fn require_arbitrable(env: &Env, candidate: &ResolutionCandidate) -> Result<(), ContractError> {
+    if candidate.status != CandidateStatus::Challenged {
+        return Err(ContractError::NotArbitrable);
+    }
+    let eta = candidate.challenge_deadline + ARBITRATION_TIMELOCK_SECONDS;
+    if env.ledger().timestamp() < eta {
+        return Err(ContractError::ArbitrationTimelockNotElapsed);
+    }
+    Ok(())
+}
+
+/// Forfeit `total` (a bond in `token`) and split it per the documented rule:
+/// `REWARD_BPS` to `winner`, `BURN_BPS` burned, and the remainder to the
+/// configured treasury (or left in this contract's balance if none is
+/// registered). Emits `BondSlashed` for observability.
+#[allow(clippy::too_many_arguments)]
+fn split_bond(
+    env: &Env,
+    candidate_id: u32,
+    market_id: u32,
+    token: &Address,
+    loser: &Address,
+    winner: &Address,
+    total: i128,
+) {
+    if total <= 0 {
+        return;
+    }
+    let token_client = TokenClient::new(env, token);
+    let this = env.current_contract_address();
+
+    let reward = total * REWARD_BPS / BPS_DENOMINATOR;
+    let burned = total * BURN_BPS / BPS_DENOMINATOR;
+    // Remainder (covers rounding dust) is the treasury cut, so
+    // reward + burned + treasury_cut always sums to exactly `total`.
+    let treasury_cut = total - reward - burned;
+
+    if reward > 0 {
+        token_client.transfer(&this, winner, &reward);
+    }
+    if burned > 0 {
+        token_client.burn(&this, &burned);
+    }
+    if treasury_cut > 0 {
+        if let Some(treasury) = storage::get_treasury(env) {
+            token_client.transfer(&this, &treasury, &treasury_cut);
+        }
+    }
+
+    events::emit_bond_slashed(
+        env,
+        candidate_id,
+        market_id,
+        loser,
+        winner,
+        total,
+        reward,
+        burned,
+        treasury_cut,
+    );
+}
+
+/// Settle every challenger recorded against `candidate` as having lost the
+/// dispute — the proposer's outcome ultimately stood (via `finalize` or
+/// `arbitrate_uphold_proposer`). Each challenger's bond is forfeited and
+/// split per `split_bond`, rewarding the proposer.
+fn settle_challengers_as_losers(
+    env: &Env,
+    candidate_id: u32,
+    candidate: &ResolutionCandidate,
+    collateral_token: &Address,
+) {
+    let challengers = storage::get_challengers(env, candidate_id);
+    if challengers.is_empty() {
+        return;
+    }
+    for record in challengers.iter() {
+        split_bond(
+            env,
+            candidate_id,
+            candidate.market_id,
+            collateral_token,
+            &record.challenger,
+            &candidate.proposer,
+            record.bond,
+        );
+    }
+    storage::clear_challengers(env, candidate_id);
 }

--- a/contracts/resolution/src/storage.rs
+++ b/contracts/resolution/src/storage.rs
@@ -1,5 +1,5 @@
-use crate::types::{ResolutionCandidate, ResolutionConfig};
-use soroban_sdk::{contracttype, Address, Env};
+use crate::types::{ChallengeRecord, ResolutionCandidate, ResolutionConfig};
+use soroban_sdk::{contracttype, Address, Env, Vec};
 
 #[contracttype]
 pub enum StorageKey {
@@ -8,6 +8,14 @@ pub enum StorageKey {
     Candidate(u32),
     CandidateByMarket(u32),
     ProposerCollateral(Address),
+    /// Every bonded challenger for a candidate across its whole appeal
+    /// lifecycle (bounded by `MAX_APPEAL_ROUNDS + 1` entries).
+    Challengers(u32),
+    /// Optional treasury address that receives the treasury-cut share of
+    /// slashed bonds. Unset by default; slashed treasury shares stay in the
+    /// contract's own balance until an admin registers one (mirrors the
+    /// market contract's "fee retained, no treasury" pattern).
+    Treasury,
 }
 
 pub fn has_config(env: &Env) -> bool {
@@ -71,4 +79,36 @@ pub fn set_proposer_collateral(env: &Env, proposer: &Address, amount: i128) {
     env.storage()
         .persistent()
         .set(&StorageKey::ProposerCollateral(proposer.clone()), &amount);
+}
+
+pub fn get_challengers(env: &Env, candidate_id: u32) -> Vec<ChallengeRecord> {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::Challengers(candidate_id))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn append_challenger(env: &Env, candidate_id: u32, challenger: &Address, bond: i128) {
+    let mut challengers = get_challengers(env, candidate_id);
+    challengers.push_back(ChallengeRecord {
+        challenger: challenger.clone(),
+        bond,
+    });
+    env.storage()
+        .persistent()
+        .set(&StorageKey::Challengers(candidate_id), &challengers);
+}
+
+pub fn clear_challengers(env: &Env, candidate_id: u32) {
+    env.storage()
+        .persistent()
+        .remove(&StorageKey::Challengers(candidate_id));
+}
+
+pub fn get_treasury(env: &Env) -> Option<Address> {
+    env.storage().persistent().get(&StorageKey::Treasury)
+}
+
+pub fn set_treasury(env: &Env, treasury: &Address) {
+    env.storage().persistent().set(&StorageKey::Treasury, treasury);
 }

--- a/contracts/resolution/src/test.rs
+++ b/contracts/resolution/src/test.rs
@@ -5,17 +5,104 @@ use soroban_sdk::{
     Address, BytesN, Env, String,
 };
 
+/// A minimal stand-in for the market contract's dispute-facing surface
+/// (`verify_signature`, `get_market_status`, `get_collateral_token`,
+/// `resolve_market`, `void_market`), used so these tests can exercise the
+/// resolution contract's real cross-contract calls without depending on the
+/// `vatix-market-contract` crate (the resolution crate cannot depend on it —
+/// see the module doc comment in `lib.rs`). Mirrors exactly the shape
+/// resolution's `lib.rs` currently invokes on the registered market
+/// contract, using this crate's own `types::MarketStatus`/`error::ContractError`
+/// so decoding across the cross-contract boundary matches structurally.
+mod mock_market {
+    use crate::error::ContractError;
+    use crate::types::MarketStatus;
+    use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env};
+
+    #[contracttype]
+    #[derive(Clone)]
+    enum DataKey {
+        Token,
+        Status,
+    }
+
+    #[contract]
+    pub struct MockMarket;
+
+    #[contractimpl]
+    impl MockMarket {
+        pub fn init(env: Env, collateral_token: Address) {
+            env.storage().instance().set(&DataKey::Token, &collateral_token);
+            env.storage()
+                .instance()
+                .set(&DataKey::Status, &MarketStatus::Active);
+        }
+
+        pub fn get_collateral_token(env: Env, _market_id: u32) -> Address {
+            env.storage().instance().get(&DataKey::Token).unwrap()
+        }
+
+        /// Accepts any signature except the reserved all-zero one, which
+        /// tests use to simulate an oracle rejection.
+        pub fn verify_signature(
+            env: Env,
+            _market_id: u32,
+            _outcome: bool,
+            signature: BytesN<64>,
+        ) -> Result<(), ContractError> {
+            if signature == BytesN::from_array(&env, &[0u8; 64]) {
+                return Err(ContractError::Unauthorized);
+            }
+            Ok(())
+        }
+
+        pub fn get_market_status(env: Env, _market_id: u32) -> MarketStatus {
+            env.storage().instance().get(&DataKey::Status).unwrap()
+        }
+
+        pub fn resolve_market(_env: Env, _market_id: u32, _outcome: bool, _signature: BytesN<64>) {}
+
+        pub fn void_market(env: Env, _caller: Address, _market_id: u32) {
+            env.storage()
+                .instance()
+                .set(&DataKey::Status, &MarketStatus::Canceled);
+        }
+
+        pub fn set_status(env: Env, status: MarketStatus) {
+            env.storage().instance().set(&DataKey::Status, &status);
+        }
+    }
+}
+
+use mock_market::{MockMarket, MockMarketClient};
+
 const DEFAULT_WINDOW: u64 = 300;
 
-fn setup(env: &Env) -> (ResolutionContractClient<'_>, Address, Address) {
+fn setup(env: &Env) -> (ResolutionContractClient<'_>, Address, Address, Address) {
     env.mock_all_auths();
     let contract_id = env.register(ResolutionContract, ());
     let client = ResolutionContractClient::new(env, &contract_id);
     let admin = Address::generate(env);
     let factory = Address::generate(env);
-    let market_contract = Address::generate(env);
+
+    let token_admin = Address::generate(env);
+    let token = env.register_stellar_asset_contract_v2(token_admin).address();
+
+    let market_contract = env.register(MockMarket, ());
+    MockMarketClient::new(env, &market_contract).init(&token);
+
     client.initialize(&admin, &factory, &market_contract, &DEFAULT_WINDOW);
-    (client, admin, market_contract)
+    (client, admin, market_contract, token)
+}
+
+/// Mint `amount` of the test collateral token to `who`, so they can post a
+/// proposer/challenger bond.
+fn fund(env: &Env, token: &Address, who: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(who, &amount);
+}
+
+fn balance(env: &Env, token: &Address, who: &Address) -> i128 {
+    TokenClient::new(env, token).balance(who)
 }
 
 fn signature(env: &Env) -> BytesN<64> {
@@ -35,10 +122,11 @@ fn set_time(env: &Env, timestamp: u64) {
 #[test]
 fn propose_stores_candidate_with_challenge_deadline() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, 10_000_000i128);
     let candidate_id = client.propose(
         &proposer,
         &42,
@@ -61,10 +149,11 @@ fn propose_stores_candidate_with_challenge_deadline() {
 #[test]
 fn challenge_marks_candidate_and_blocks_finalize() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, 10_000_000i128);
     let candidate_id = client.propose(
         &proposer,
         &1,
@@ -77,8 +166,9 @@ fn challenge_marks_candidate_and_blocks_finalize() {
     );
 
     let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, 10_000_000i128);
     let challenge_uri = String::from_str(&env, "ipfs://challenge");
-    client.challenge(&challenger, &candidate_id, &challenge_uri);
+    client.challenge(&challenger, &candidate_id, &challenge_uri, &10_000_000i128);
     set_time(&env, 1_400);
 
     let finalizer = Address::generate(&env);
@@ -89,10 +179,11 @@ fn challenge_marks_candidate_and_blocks_finalize() {
 #[test]
 fn finalize_requires_closed_challenge_window() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, 10_000_000i128);
     let candidate_id = client.propose(
         &proposer,
         &1,
@@ -119,17 +210,19 @@ fn finalize_requires_closed_challenge_window() {
 #[test]
 fn challenge_after_deadline_is_rejected() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
-    let candidate_id = client.propose(&proposer, &1, &true, &signature(&env), &(env.ledger().timestamp() + 60), &evidence(&env), &60);
+    fund(&env, &token, &proposer, 10_000_000i128);
+    let candidate_id = client.propose(&proposer, &1, &true, &signature(&env), &(env.ledger().timestamp() + 60), &evidence(&env), &60, &10_000_000i128);
 
     set_time(&env, 1_061);
     let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, 10_000_000i128);
     let challenge_uri = String::from_str(&env, "ipfs://late-challenge");
     assert_eq!(
-        client.try_challenge(&challenger, &candidate_id, &challenge_uri),
+        client.try_challenge(&challenger, &candidate_id, &challenge_uri, &10_000_000i128),
         Err(Ok(ContractError::ChallengeWindowClosed))
     );
 }
@@ -137,7 +230,7 @@ fn challenge_after_deadline_is_rejected() {
 #[test]
 fn admin_can_update_factory_registration() {
     let env = Env::default();
-    let (client, admin, _) = setup(&env);
+    let (client, admin, _, _) = setup(&env);
 
     let new_factory = Address::generate(&env);
     client.set_factory(&admin, &new_factory);
@@ -151,12 +244,16 @@ fn admin_can_update_factory_registration() {
 #[test]
 fn finalize_calls_resolve_market_on_market_contract() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
 
     set_time(&env, 1_000);
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, 10_000_000i128);
     let sig = signature(&env);
-    let candidate_id = client.propose(&proposer, &5, &true, &sig, &(env.ledger().timestamp() + 60), &evidence(&env), &60);
+    // signature_expiry must outlive the challenge window (+60) plus the
+    // time we advance past it below, or finalize would hit SignatureExpired
+    // before ever reaching the resolve_market cross-call this test targets.
+    let candidate_id = client.propose(&proposer, &5, &true, &sig, &(env.ledger().timestamp() + 7200), &evidence(&env), &60, &10_000_000i128);
 
     set_time(&env, 1_061);
     let finalizer = Address::generate(&env);
@@ -177,12 +274,13 @@ fn finalize_calls_resolve_market_on_market_contract() {
 #[test]
 fn propose_with_valid_signature_succeeds_via_delegation() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, 10_000_000i128);
     let valid_sig = signature(&env);
-    
+
     // This should succeed because mock_all_auths intercepts the cross-contract call
     let candidate_id = client.propose(
         &proposer,
@@ -208,13 +306,14 @@ fn propose_with_valid_signature_succeeds_via_delegation() {
 #[test]
 fn propose_with_invalid_signature_fails_via_delegation() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, 10_000_000i128);
     // Use an invalid signature (all zeros) to trigger rejection
     let invalid_sig = BytesN::from_array(&env, &[0u8; 64]);
-    
+
     let result = client.try_propose(
         &proposer,
         &1,
@@ -235,14 +334,14 @@ fn propose_with_invalid_signature_fails_via_delegation() {
 #[test]
 fn initialize_stores_default_challenge_window() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, _) = setup(&env);
     assert_eq!(client.get_default_challenge_window(), DEFAULT_WINDOW);
 }
 
 #[test]
 fn admin_can_update_default_challenge_window() {
     let env = Env::default();
-    let (client, admin, _) = setup(&env);
+    let (client, admin, _, _) = setup(&env);
     client.set_default_challenge_window(&admin, &600);
     assert_eq!(client.get_default_challenge_window(), 600);
 }
@@ -250,7 +349,7 @@ fn admin_can_update_default_challenge_window() {
 #[test]
 fn set_default_challenge_window_rejects_non_admin() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, _) = setup(&env);
     let rando = Address::generate(&env);
     assert_eq!(
         client.try_set_default_challenge_window(&rando, &600),
@@ -261,7 +360,7 @@ fn set_default_challenge_window_rejects_non_admin() {
 #[test]
 fn set_default_challenge_window_rejects_out_of_bounds() {
     let env = Env::default();
-    let (client, admin, _) = setup(&env);
+    let (client, admin, _, _) = setup(&env);
     assert_eq!(
         client.try_set_default_challenge_window(&admin, &10),
         Err(Ok(ContractError::InvalidChallengeWindow))
@@ -289,10 +388,11 @@ const BOND: i128 = 10_000_000;
 #[test]
 fn propose_accepts_challenge_window_at_min() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
     let expiry = env.ledger().timestamp() + MIN_WINDOW + 3600;
     let result = client.try_propose(
         &proposer, &1u32, &true, &signature(&env), &expiry,
@@ -305,10 +405,11 @@ fn propose_accepts_challenge_window_at_min() {
 #[test]
 fn propose_accepts_challenge_window_at_max() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
     let expiry = env.ledger().timestamp() + MAX_WINDOW + 3600;
     let result = client.try_propose(
         &proposer, &1u32, &true, &signature(&env), &expiry,
@@ -321,10 +422,11 @@ fn propose_accepts_challenge_window_at_max() {
 #[test]
 fn propose_rejects_challenge_window_below_min() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
     let expiry = env.ledger().timestamp() + 3600;
     let result = client.try_propose(
         &proposer, &1u32, &true, &signature(&env), &expiry,
@@ -337,10 +439,11 @@ fn propose_rejects_challenge_window_below_min() {
 #[test]
 fn propose_rejects_challenge_window_above_max() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
     let expiry = env.ledger().timestamp() + MAX_WINDOW + 3600;
     let result = client.try_propose(
         &proposer, &1u32, &true, &signature(&env), &expiry,
@@ -359,10 +462,11 @@ fn propose_rejects_challenge_window_above_max() {
 #[test]
 fn propose_accepts_signature_expiry_equal_to_proposed_at() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
     // expiry == ledger timestamp at call time
     let expiry = env.ledger().timestamp();
     let result = client.try_propose(
@@ -376,10 +480,11 @@ fn propose_accepts_signature_expiry_equal_to_proposed_at() {
 #[test]
 fn propose_rejects_signature_expiry_before_proposed_at() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
     // expiry is one second before ledger time
     let expiry = env.ledger().timestamp() - 1;
     let result = client.try_propose(
@@ -407,10 +512,11 @@ fn propose_rejects_signature_expiry_before_proposed_at() {
 #[test]
 fn challenge_accepted_at_exactly_deadline() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
     let window = 300u64;
     let candidate_id = client.propose(
         &proposer, &1u32, &true, &signature(&env),
@@ -422,8 +528,9 @@ fn challenge_accepted_at_exactly_deadline() {
     set_time(&env, 1_300);
 
     let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, BOND);
     let uri = String::from_str(&env, "ipfs://at-deadline");
-    let result = client.try_challenge(&challenger, &candidate_id, &uri);
+    let result = client.try_challenge(&challenger, &candidate_id, &uri, &BOND);
     assert!(result.is_ok(), "challenge at deadline boundary should be accepted (guard is >)");
 }
 
@@ -431,10 +538,11 @@ fn challenge_accepted_at_exactly_deadline() {
 #[test]
 fn challenge_rejected_one_second_after_deadline() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
     let window = 300u64;
     let candidate_id = client.propose(
         &proposer, &1u32, &true, &signature(&env),
@@ -445,9 +553,10 @@ fn challenge_rejected_one_second_after_deadline() {
     set_time(&env, 1_301);
 
     let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, BOND);
     let uri = String::from_str(&env, "ipfs://past-deadline");
     assert_eq!(
-        client.try_challenge(&challenger, &candidate_id, &uri),
+        client.try_challenge(&challenger, &candidate_id, &uri, &BOND),
         Err(Ok(ContractError::ChallengeWindowClosed))
     );
 }
@@ -456,10 +565,11 @@ fn challenge_rejected_one_second_after_deadline() {
 #[test]
 fn challenge_accepted_one_second_before_deadline() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
     let window = 300u64;
     let candidate_id = client.propose(
         &proposer, &1u32, &true, &signature(&env),
@@ -470,8 +580,9 @@ fn challenge_accepted_one_second_before_deadline() {
     set_time(&env, 1_299);
 
     let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, BOND);
     let uri = String::from_str(&env, "ipfs://just-before-deadline");
-    let result = client.try_challenge(&challenger, &candidate_id, &uri);
+    let result = client.try_challenge(&challenger, &candidate_id, &uri, &BOND);
     assert!(result.is_ok(), "challenge one second before deadline should be accepted");
 }
 
@@ -489,10 +600,11 @@ fn challenge_accepted_one_second_before_deadline() {
 #[test]
 fn finalize_rejected_at_exactly_deadline() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
     let window = 300u64;
     let candidate_id = client.propose(
         &proposer, &1u32, &true, &signature(&env),
@@ -513,10 +625,11 @@ fn finalize_rejected_at_exactly_deadline() {
 #[test]
 fn finalize_accepted_one_second_after_deadline() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
     let window = 300u64;
     // signature_expiry well in the future so it doesn't interfere
     let expiry = env.ledger().timestamp() + window + 7200;
@@ -546,10 +659,11 @@ fn finalize_accepted_one_second_after_deadline() {
 #[test]
 fn finalize_accepted_at_exactly_signature_expiry() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
     let window = 300u64;
     // Set expiry to exactly deadline + 1 so there's a valid finalize window
     // that starts at 1_301 and the expiry is also exactly 1_301.
@@ -575,10 +689,11 @@ fn finalize_accepted_at_exactly_signature_expiry() {
 #[test]
 fn finalize_rejected_one_second_after_signature_expiry() {
     let env = Env::default();
-    let (client, _, _) = setup(&env);
+    let (client, _, _, token) = setup(&env);
     set_time(&env, 1_000);
 
     let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
     let window = 300u64;
     // expiry is challenge_deadline + 1, so it's right at the edge of being
     // finalizeable. We'll advance one second past it to trigger SignatureExpired.
@@ -595,5 +710,392 @@ fn finalize_rejected_one_second_after_signature_expiry() {
     assert_eq!(
         client.try_finalize(&finalizer, &candidate_id),
         Err(Ok(ContractError::SignatureExpired))
+    );
+}
+
+// ── Dispute-game economics: bonds, slashing, arbitration, void ───────────────
+//
+// REWARD_BPS = 5_000, BURN_BPS = 2_500, remainder (2_500) is the treasury
+// cut, applied to whichever bond is forfeited (BPS_DENOMINATOR = 10_000).
+// With BOND = 10_000_000: reward = 5_000_000, burned = 2_500_000,
+// treasury_cut = 2_500_000.
+const ARBITRATION_TIMELOCK_SECONDS: u64 = 172_800;
+
+/// Challenging without posting the minimum bond fails outright — this is
+/// the acceptance criterion "Challenge without bond fails". Free challenges
+/// are what let a griefer stall resolution indefinitely at zero cost.
+#[test]
+fn challenge_without_sufficient_bond_fails() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env),
+        &(env.ledger().timestamp() + 3600),
+        &evidence(&env), &300, &BOND,
+    );
+
+    let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, BOND);
+    let uri = String::from_str(&env, "ipfs://cheap-challenge");
+    assert_eq!(
+        client.try_challenge(&challenger, &candidate_id, &uri, &0i128),
+        Err(Ok(ContractError::InsufficientChallengeBond))
+    );
+    // Nothing was ever pulled from the challenger.
+    assert_eq!(balance(&env, &token, &challenger), BOND);
+}
+
+/// A challenger's bond is actually transferred into (locked in) the
+/// resolution contract at `challenge` time.
+#[test]
+fn challenge_locks_challenger_bond_in_contract() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env),
+        &(env.ledger().timestamp() + 3600),
+        &evidence(&env), &300, &BOND,
+    );
+
+    let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, BOND);
+    let uri = String::from_str(&env, "ipfs://challenge");
+    client.challenge(&challenger, &candidate_id, &uri, &BOND);
+
+    // The bond left the challenger's balance and now sits in the
+    // resolution contract, recorded against this candidate.
+    assert_eq!(balance(&env, &token, &challenger), 0);
+    assert_eq!(client.get_challengers(&candidate_id).len(), 1);
+    assert_eq!(client.get_challengers(&candidate_id).get(0).unwrap().bond, BOND);
+}
+
+/// On `finalize` of a candidate that survived a challenge (via `appeal`),
+/// the proposer is refunded in full and the challenger's bond is forfeited
+/// and split reward/burn/treasury — "incorrect proposer... incorrect
+/// challenger cannot reclaim full bond after losing dispute", and the
+/// finalize-side half of "route bonds per documented split".
+#[test]
+fn finalize_refunds_proposer_and_slashes_challenger_with_documented_split() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env),
+        &(env.ledger().timestamp() + 100_000),
+        &evidence(&env), &300, &BOND,
+    );
+
+    let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, BOND);
+    let uri = String::from_str(&env, "ipfs://challenge");
+    client.challenge(&challenger, &candidate_id, &uri, &BOND);
+
+    // Proposer stands by the outcome; nobody disputes the appeal again.
+    set_time(&env, 1_310);
+    client.appeal(
+        &proposer, &candidate_id, &true, &signature(&env),
+        &evidence(&env), &300,
+    );
+
+    set_time(&env, 1_611);
+    let finalizer = Address::generate(&env);
+    client.finalize(&finalizer, &candidate_id);
+
+    // Proposer got their own bond back plus the reward share of the
+    // challenger's forfeited bond.
+    let reward = BOND * 5_000 / 10_000;
+    assert_eq!(balance(&env, &token, &proposer), BOND + reward);
+    // The challenger kept nothing of their forfeited bond.
+    assert_eq!(balance(&env, &token, &challenger), 0);
+    // The challenger record is cleared once settled.
+    assert_eq!(client.get_challengers(&candidate_id).len(), 0);
+}
+
+/// Adversarial griefing scenario: an attacker repeatedly challenges every
+/// appeal round purely to stall resolution. Each challenge costs a bond, so
+/// the attacker pays `MAX_APPEAL_ROUNDS + 1` bonds total and loses every one
+/// of them once the proposer's outcome is ultimately upheld — proving that
+/// repeated challenging is not free, and that the dispute still reaches a
+/// terminal state instead of stalling forever.
+#[test]
+fn griefer_pays_a_bond_every_round_and_loses_them_all() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env),
+        &(env.ledger().timestamp() + 1_000_000),
+        &evidence(&env), &300, &BOND,
+    );
+
+    let griefer = Address::generate(&env);
+    // Enough for every round's bond (funded once, spent 4 times).
+    fund(&env, &token, &griefer, BOND * 4);
+
+    let mut now = 1_000u64;
+    for round in 0..3u32 {
+        let uri = String::from_str(&env, "ipfs://grief");
+        client.challenge(&griefer, &candidate_id, &uri, &BOND);
+        assert_eq!(
+            client.get_candidate(&candidate_id).unwrap().status,
+            crate::types::CandidateStatus::Challenged
+        );
+
+        now += 10;
+        set_time(&env, now);
+        client.appeal(&proposer, &candidate_id, &true, &signature(&env), &evidence(&env), &300);
+        let candidate = client.get_candidate(&candidate_id).unwrap();
+        assert_eq!(candidate.appeal_round, round + 1);
+        now = candidate.challenge_deadline;
+    }
+
+    // One more challenge at the max appeal round — the proposer can no
+    // longer appeal past this (appeal_round == MAX_APPEAL_ROUNDS), so the
+    // dispute now needs the terminal admin path instead of stalling forever.
+    let uri = String::from_str(&env, "ipfs://grief-final");
+    client.challenge(&griefer, &candidate_id, &uri, &BOND);
+    assert_eq!(
+        client.try_appeal(&proposer, &candidate_id, &true, &signature(&env), &evidence(&env), &300),
+        Err(Ok(ContractError::AppealLimitExceeded))
+    );
+
+    // Every one of the griefer's 4 bonds is now locked in the contract, and
+    // they cannot get any of it back by challenging further (window closed
+    // to new challenges since status is already Challenged).
+    assert_eq!(balance(&env, &token, &griefer), 0);
+    assert_eq!(client.get_challengers(&candidate_id).len(), 4);
+
+    // Not yet arbitrable: the timelock since the last challenge deadline
+    // hasn't elapsed.
+    let candidate = client.get_candidate(&candidate_id).unwrap();
+    assert_eq!(
+        client.try_arbitrate_uphold_proposer(&Address::generate(&env), &candidate_id),
+        Err(Ok(ContractError::NotAdmin))
+    );
+
+    // Admin settles it once the timelock elapses: proposer was right all
+    // along, so every one of the griefer's 4 bonds is slashed.
+    set_time(&env, candidate.challenge_deadline + ARBITRATION_TIMELOCK_SECONDS);
+    let admin = client.get_config().admin;
+    client.arbitrate_uphold_proposer(&admin, &candidate_id);
+
+    assert_eq!(balance(&env, &token, &proposer), BOND + 4 * (BOND * 5_000 / 10_000));
+    assert_eq!(balance(&env, &token, &griefer), 0);
+    assert_eq!(client.get_challengers(&candidate_id).len(), 0);
+    assert_eq!(
+        client.get_candidate(&candidate_id).unwrap().status,
+        crate::types::CandidateStatus::Finalized
+    );
+}
+
+/// Arbitration/void are only reachable once the candidate is `Challenged`
+/// and the timelock has elapsed — calling them early is rejected.
+#[test]
+fn arbitration_rejects_before_timelock_elapses() {
+    let env = Env::default();
+    let (client, admin, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env),
+        &(env.ledger().timestamp() + 1_000_000),
+        &evidence(&env), &300, &BOND,
+    );
+
+    // Never challenged at all — still Proposed, not arbitrable.
+    assert_eq!(
+        client.try_arbitrate_uphold_proposer(&admin, &candidate_id),
+        Err(Ok(ContractError::NotArbitrable))
+    );
+    assert_eq!(
+        client.try_void_market(&admin, &candidate_id),
+        Err(Ok(ContractError::NotArbitrable))
+    );
+
+    let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, BOND);
+    let uri = String::from_str(&env, "ipfs://challenge");
+    client.challenge(&challenger, &candidate_id, &uri, &BOND);
+
+    // Challenged, but the timelock since challenge_deadline hasn't elapsed.
+    assert_eq!(
+        client.try_void_market(&admin, &candidate_id),
+        Err(Ok(ContractError::ArbitrationTimelockNotElapsed))
+    );
+}
+
+/// A candidate that is simply abandoned after a single challenge (the
+/// proposer never calls `appeal`, so `appeal_round` stays 0) must still
+/// reach a terminal state once the timelock elapses — this is what keeps
+/// the market from staying stuck non-terminal forever even outside the
+/// "exhausted every appeal" case.
+#[test]
+fn void_market_unsticks_an_abandoned_challenged_candidate() {
+    let env = Env::default();
+    let (client, admin, market_contract, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer, &7u32, &true, &signature(&env),
+        &(env.ledger().timestamp() + 1_000_000),
+        &evidence(&env), &300, &BOND,
+    );
+
+    let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, BOND);
+    let uri = String::from_str(&env, "ipfs://challenge");
+    client.challenge(&challenger, &candidate_id, &uri, &BOND);
+
+    let candidate = client.get_candidate(&candidate_id).unwrap();
+    assert_eq!(candidate.appeal_round, 0);
+
+    set_time(&env, candidate.challenge_deadline + ARBITRATION_TIMELOCK_SECONDS);
+    client.void_market(&admin, &candidate_id);
+
+    // Challenger refunded their own bond in full (voiding is not a verdict
+    // against them) plus the reward share of the proposer's slashed bond,
+    // since theirs is the dispute that stands unresolved...
+    let reward = BOND * 5_000 / 10_000;
+    assert_eq!(balance(&env, &token, &challenger), BOND + reward);
+    // ...and the proposer's bond is slashed since their outcome never
+    // survived the dispute.
+    assert_eq!(balance(&env, &token, &proposer), 0);
+    assert_eq!(
+        client.get_candidate(&candidate_id).unwrap().status,
+        crate::types::CandidateStatus::Voided
+    );
+
+    // The underlying market was actually unstuck (Active -> Canceled).
+    let market_client = MockMarketClient::new(&env, &market_contract);
+    assert_eq!(
+        market_client.get_market_status(&7u32),
+        crate::types::MarketStatus::Canceled
+    );
+}
+
+/// `void_market` slashes the proposer's bond per the documented split
+/// (reward to the challenger, burn, treasury) rather than simply handing it
+/// all to the challenger.
+#[test]
+fn void_market_splits_slashed_proposer_bond() {
+    let env = Env::default();
+    let (client, admin, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let treasury = Address::generate(&env);
+    client.set_treasury(&admin, &treasury);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env),
+        &(env.ledger().timestamp() + 1_000_000),
+        &evidence(&env), &300, &BOND,
+    );
+
+    let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, BOND);
+    let uri = String::from_str(&env, "ipfs://challenge");
+    client.challenge(&challenger, &candidate_id, &uri, &BOND);
+
+    let candidate = client.get_candidate(&candidate_id).unwrap();
+    set_time(&env, candidate.challenge_deadline + ARBITRATION_TIMELOCK_SECONDS);
+    client.void_market(&admin, &candidate_id);
+
+    let reward = BOND * 5_000 / 10_000;
+    let burned = BOND * 2_500 / 10_000;
+    let treasury_cut = BOND - reward - burned;
+
+    // Challenger got their own bond back plus the reward share of the
+    // proposer's slashed bond.
+    assert_eq!(balance(&env, &token, &challenger), BOND + reward);
+    assert_eq!(balance(&env, &token, &treasury), treasury_cut);
+    assert_eq!(balance(&env, &token, &proposer), 0);
+    // reward + burned + treasury_cut == BOND exactly (no dust lost).
+    assert_eq!(reward + burned + treasury_cut, BOND);
+}
+
+/// Once a market has been voided, a stale `finalize` on the same candidate
+/// cannot resurrect it — the terminal state sticks.
+#[test]
+fn finalize_after_void_is_rejected() {
+    let env = Env::default();
+    let (client, admin, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env),
+        &(env.ledger().timestamp() + 1_000_000),
+        &evidence(&env), &300, &BOND,
+    );
+
+    let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, BOND);
+    let uri = String::from_str(&env, "ipfs://challenge");
+    client.challenge(&challenger, &candidate_id, &uri, &BOND);
+
+    let candidate = client.get_candidate(&candidate_id).unwrap();
+    set_time(&env, candidate.challenge_deadline + ARBITRATION_TIMELOCK_SECONDS);
+    client.void_market(&admin, &candidate_id);
+
+    let finalizer = Address::generate(&env);
+    assert_eq!(
+        client.try_finalize(&finalizer, &candidate_id),
+        Err(Ok(ContractError::CandidateAlreadyFinalized))
+    );
+}
+
+/// Non-admin callers cannot arbitrate or void, even once the timelock has
+/// elapsed — this remains an admin-gated (if time-delayed) decision.
+#[test]
+fn arbitration_rejects_non_admin() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer, &1u32, &true, &signature(&env),
+        &(env.ledger().timestamp() + 1_000_000),
+        &evidence(&env), &300, &BOND,
+    );
+
+    let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, BOND);
+    let uri = String::from_str(&env, "ipfs://challenge");
+    client.challenge(&challenger, &candidate_id, &uri, &BOND);
+
+    let candidate = client.get_candidate(&candidate_id).unwrap();
+    set_time(&env, candidate.challenge_deadline + ARBITRATION_TIMELOCK_SECONDS);
+
+    let rando = Address::generate(&env);
+    assert_eq!(
+        client.try_arbitrate_uphold_proposer(&rando, &candidate_id),
+        Err(Ok(ContractError::NotAdmin))
+    );
+    assert_eq!(
+        client.try_void_market(&rando, &candidate_id),
+        Err(Ok(ContractError::NotAdmin))
     );
 }

--- a/contracts/resolution/src/types.rs
+++ b/contracts/resolution/src/types.rs
@@ -20,6 +20,23 @@ pub enum CandidateStatus {
     Proposed,
     Challenged,
     Finalized,
+    /// Terminal state reached via `void_market`: the dispute exhausted
+    /// `MAX_APPEAL_ROUNDS` and admin arbitration could not safely attest to
+    /// either side's outcome on-chain, so the underlying market was voided
+    /// (`MarketStatus::Canceled`) instead of resolved.
+    Voided,
+}
+
+/// A single challenger's locked bond against a candidate. Appended to the
+/// candidate's challenger list on every `challenge` call (including those
+/// superseded by a later `appeal`), so that every party who disputed the
+/// candidate across its whole lifecycle — not just the most recent one — is
+/// accounted for when the dispute finally reaches a terminal state.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct ChallengeRecord {
+    pub challenger: Address,
+    pub bond: i128,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
closes #661 

This PR completes the dispute-game incentive mechanism by introducing balanced bonding, fair reward distribution, and a clear terminal resolution process for unresolved disputes.

Changes
Added a challenger bond requirement for dispute initiation.
Implemented win/lose payout logic for proposers and challengers.
Added automatic/governed slashing of incorrect proposers.
Refunded or rewarded bonds based on the final dispute outcome.
Introduced a terminal dispute state after MAX_APPEAL_ROUNDS (3), allowing disputes to be resolved through arbitration or marked as void, preventing markets from remaining indefinitely unresolved.
Impact

These changes strengthen the protocol's dispute economics, discourage malicious proposals and frivolous challenges, and ensure every dispute reaches a deterministic on-chain conclusion.