### PR TITLE
fix(market): enforce exclusive threshold resolution mode

### DIFF
--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -1575,6 +1575,9 @@ impl MarketContract {
     /// - [`ContractError::MarketAlreadyResolved`] — already resolved.
     /// - [`ContractError::UnauthorizedOracle`] — no signers/quorum configured.
     /// - [`ContractError::InvalidSignature`] — fewer than quorum valid sigs.
+    /// If a resolution contract is registered, this returns
+    /// [`ContractError::ResolutionNotFinalized`]. Challenge-based and
+    /// threshold-based resolution are intentionally mutually exclusive.
     pub fn resolve_market_threshold(
         env: Env,
         resolver: Address,
@@ -1590,6 +1593,14 @@ impl MarketContract {
         if market.status == MarketStatus::Resolved {
             return Err(ContractError::MarketAlreadyResolved);
         }
+
+        // Threshold resolution and challenge-window resolution are explicit,
+        // mutually exclusive modes. Once a resolution contract is registered,
+        // every resolution must pass through its propose/challenge/finalize
+        // lifecycle and the single-signature callback guarded by
+        // `require_resolution_finalized`. Allowing this entry point as well
+        // would let a quorum bypass an open or challenged candidate.
+        require_threshold_resolution_mode(&env)?;
 
         let signers = storage::get_threshold_signers(&env);
         let quorum = storage::get_threshold_quorum(&env);
@@ -2222,6 +2233,20 @@ fn require_resolution_finalized(
         || candidate.outcome != outcome
         || &candidate.signature != signature
     {
+        return Err(ContractError::ResolutionNotFinalized);
+    }
+    Ok(())
+}
+
+/// Enforce mutually exclusive market-resolution modes.
+///
+/// Threshold resolution is available only when no challenge-based resolution
+/// contract is registered. Once an admin registers one, its
+/// propose/challenge/finalize lifecycle becomes the sole resolution path; the
+/// threshold entry point fails closed regardless of whether the current
+/// candidate is proposed, challenged, or ready to finalize.
+fn require_threshold_resolution_mode(env: &Env) -> Result<(), ContractError> {
+    if storage::get_resolution_contract(env).is_some() {
         return Err(ContractError::ResolutionNotFinalized);
     }
     Ok(())

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -1689,6 +1689,82 @@ mod test {
     }
 
     #[test]
+    fn test_threshold_resolution_is_disabled_when_resolution_contract_is_registered() {
+        use crate::error::ContractError;
+
+        let (env, admin, client, contract_id) = create_test_contract();
+        let resolver = Address::generate(&env);
+        let question = String::from_str(&env, "Will the challenge window be bypassed?");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let market_id = client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &BytesN::from_array(&env, &[1u8; 32]),
+            &Address::generate(&env),
+            &None,
+        );
+
+        let (signer, signature) = generate_test_keypair_and_sign(&env, market_id, true);
+        let signers = soroban_sdk::vec![&env, signer];
+        client.set_threshold_signers(&admin, &signers, &1u32);
+        let signatures = soroban_sdk::vec![&env, signature];
+
+        // Registering the challenge-based resolution contract selects that
+        // mode exclusively. The gate is intentionally independent of the
+        // candidate's current status, so proposed and challenged candidates
+        // cannot be bypassed through a valid threshold quorum.
+        client.set_resolution_contract(&admin, &Address::generate(&env));
+
+        assert_eq!(
+            client.try_resolve_market_threshold(&resolver, &market_id, &true, &signatures),
+            Err(Ok(ContractError::ResolutionNotFinalized))
+        );
+
+        let market = get_market_from_storage(&env, &contract_id, market_id);
+        assert_eq!(market.status, MarketStatus::Active);
+        assert_eq!(market.result, None);
+        assert_eq!(market.resolver, None);
+    }
+
+    #[test]
+    fn test_threshold_resolution_without_resolution_contract_succeeds_once() {
+        use crate::error::ContractError;
+
+        let (env, admin, client, contract_id) = create_test_contract();
+        let resolver = Address::generate(&env);
+        let question = String::from_str(&env, "Will threshold mode settle exactly once?");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let market_id = client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &BytesN::from_array(&env, &[1u8; 32]),
+            &Address::generate(&env),
+            &None,
+        );
+
+        let (signer, signature) = generate_test_keypair_and_sign(&env, market_id, true);
+        let signers = soroban_sdk::vec![&env, signer];
+        client.set_threshold_signers(&admin, &signers, &1u32);
+        let signatures = soroban_sdk::vec![&env, signature];
+
+        assert_eq!(
+            client.try_resolve_market_threshold(&resolver, &market_id, &true, &signatures),
+            Ok(Ok(()))
+        );
+        assert_eq!(
+            client.try_resolve_market_threshold(&resolver, &market_id, &true, &signatures),
+            Err(Ok(ContractError::MarketAlreadyResolved))
+        );
+
+        let market = get_market_from_storage(&env, &contract_id, market_id);
+        assert_eq!(market.status, MarketStatus::Resolved);
+        assert_eq!(market.result, Some(true));
+        assert_eq!(market.resolver, Some(resolver));
+    }
+
+    #[test]
     fn test_first_nominee_cannot_accept_after_overwrite() {
         let (env, admin, client, _contract_id) = create_test_contract();
         let first_nominee = Address::generate(&env);

--- a/docs/cross-contract-call-graph.md
+++ b/docs/cross-contract-call-graph.md
@@ -165,6 +165,15 @@ reconcile_position_tokens(admin, market_id, user)     [admin-gated]
 
 ---
 
+Registering a resolution contract selects this challenge-based lifecycle as the
+market's exclusive resolution mode. While the registration is present,
+`Market::resolve_market_threshold` fails closed with
+`ResolutionNotFinalized`; a threshold quorum therefore cannot bypass an open or
+challenged candidate. Threshold resolution remains available only when no
+resolution contract is registered. After `finalize` resolves the market through
+the guarded single-signature callback, any later resolution attempt fails with
+`MarketAlreadyResolved`.
+
 ## Authorization Summary
 
 | Call | Who authorizes |
@@ -175,6 +184,7 @@ reconcile_position_tokens(admin, market_id, user)     [admin-gated]
 | `Market::resolve_market` (via Resolution) | Resolution contract address as `resolver` |
 | `Market::reconcile_position_tokens` | Market contract's stored admin |
 | `Market::get_position_token_parity` | No auth (public read) |
+| `Market::resolve_market_threshold` | Caller authorizes as `resolver`; disabled while a Resolution contract is registered |
 
 ---
 


### PR DESCRIPTION
Closes #656

## What changed

- Fail closed in `resolve_market_threshold` whenever a challenge-based Resolution contract is registered.
- Make threshold resolution and challenge-window resolution explicit, mutually exclusive modes.
- Add regressions proving that a registered Resolution contract blocks an otherwise-valid threshold quorum without mutating market state, while threshold-only mode still resolves exactly once.
- Document the invariant and authorization behavior in the cross-contract call graph.

## Why

The single-signature path already requires a finalized Resolution candidate, but the threshold path could skip that lifecycle. A valid quorum could therefore bypass an open or challenged candidate and resolve the market early.

## Validation

- `git diff --check origin/dev...HEAD` — passes.
- Focused test command: `cargo test -p vatix-market-contract threshold_resolution --lib`.
- Library check: `cargo check -p vatix-market-contract --lib`.

The two Cargo commands are currently blocked by pre-existing `dev` failures that reproduce unchanged in a clean worktree at `origin/dev` (`388624e`):

- `soroban-env-host` testutils fails to compile because its `ChaCha20Rng` does not satisfy the `ed25519-dalek` 3.0 `CryptoRng` bound.
- `vatix-resolution-contract` fails before the market crate with existing missing storage variants/helpers and a `#[contractevent]` macro panic.

No dependency or unrelated baseline changes are included in this focused PR.
