### PR TITLE
Align resolve_market ABI, reject stale prices, wire Reflector adapter (#680-#683)

### DIFF
--- a/contracts/market/src/error.rs
+++ b/contracts/market/src/error.rs
@@ -121,6 +121,14 @@ pub enum ContractError {
     /// The requested threshold is invalid (e.g., higher than signer count or zero).
     InvalidThresholdQuorum = 25,
 
+    /// A Reflector/Pyth price observation is older than the adapter's
+    /// maximum allowed staleness window (#682).
+    ///
+    /// Both adapters read a timestamp/publish_time alongside the price but
+    /// previously never checked it — a disconnected or slow oracle feed
+    /// could otherwise resolve a market against an arbitrarily old price.
+    StalePrice = 26,
+
     // ========== Validation Errors (30-39) ==========
     /// Price is out of valid range (must be between 0 and 1).
     ///
@@ -365,6 +373,8 @@ mod tests {
             (ContractError::InvalidOutcome, 22),
             (ContractError::OraclePriceUnavailable, 23),
             (ContractError::OracleMessageExpired, 24),
+            (ContractError::InvalidThresholdQuorum, 25),
+            (ContractError::StalePrice, 26),
             (ContractError::InvalidPrice, 30),
             (ContractError::InvalidQuantity, 31),
             (ContractError::InvalidTimestamp, 32),

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -98,7 +98,8 @@ pub mod types;
 mod validation;
 
 use crate::error::ContractError;
-use crate::types::{AdapterType, Market, MarketStatus, Position};
+use crate::oracle_adapter::Asset;
+use crate::types::{AdapterType, Market, MarketAdapterConfig, MarketStatus, Position};
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String};
 use vatix_outcome_token_contract::{OutcomeTokenContractClient, types::TokenKind};
 use vatix_resolution_contract::types::CandidateStatus as ResolutionCandidateStatus;
@@ -734,6 +735,48 @@ impl MarketContract {
     /// Return whether the given oracle adapter type is currently enabled (#488).
     pub fn is_adapter_enabled(env: Env, adapter_type: AdapterType) -> bool {
         storage::is_adapter_enabled(&env, &adapter_type)
+    }
+
+    /// Set (or replace) the Reflector/Pyth adapter config for `market_id`
+    /// (#681) — the oracle contract address, asset, and price threshold
+    /// `oracle::verify_market_outcome` uses once the corresponding adapter
+    /// type is enabled via `set_adapter_enabled` (#680).
+    ///
+    /// Only the stored admin may call this.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotAdmin`] — `admin` is not the stored admin.
+    /// - [`ContractError::MarketNotFound`] — `market_id` does not exist.
+    pub fn set_market_adapter_config(
+        env: Env,
+        admin: Address,
+        market_id: u32,
+        oracle_contract: Address,
+        asset: Asset,
+        resolution_price: i128,
+    ) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env)?;
+        if admin != stored_admin {
+            return Err(ContractError::NotAdmin);
+        }
+        storage::get_market(&env, market_id)?.ok_or(ContractError::MarketNotFound)?;
+        storage::set_market_adapter_config(
+            &env,
+            market_id,
+            &MarketAdapterConfig {
+                oracle_contract,
+                asset,
+                resolution_price,
+            },
+        );
+        Ok(())
+    }
+
+    /// Return the stored Reflector/Pyth adapter config for `market_id`, if any (#681).
+    pub fn get_market_adapter_config(env: Env, market_id: u32) -> Option<MarketAdapterConfig> {
+        storage::get_market_adapter_config(&env, market_id)
     }
 
     /// Pause the contract for emergency maintenance.

--- a/contracts/market/src/oracle.rs
+++ b/contracts/market/src/oracle.rs
@@ -299,8 +299,12 @@ pub fn verify_market_outcome(
 ) -> Result<(), ContractError> {
     match adapter_type {
         AdapterType::Ed25519 => verify_oracle_signature(env, market_id, outcome, proof, &market.oracle_pubkey),
-        AdapterType::Reflector | AdapterType::Pyth => {
+        AdapterType::Reflector => verify_via_reflector(env, market_id, market, outcome, proof),
+        AdapterType::Pyth => {
             if crate::storage::is_adapter_enabled(env, &adapter_type) {
+                // Pyth needs a raw Wormhole VAA proof (`Bytes`), not the
+                // fixed 64-byte Ed25519 signature this entrypoint accepts —
+                // full wiring is a follow-up (#680 wires Reflector first).
                 Err(ContractError::UnauthorizedOracle)
             } else {
                 // Adapter disabled/unavailable — fall back to raw Ed25519 verification.
@@ -308,6 +312,35 @@ pub fn verify_market_outcome(
             }
         }
     }
+}
+
+/// Dispatch to the on-chain Reflector adapter when it is enabled and
+/// configured for `market_id`; otherwise fall back to Ed25519 (#680).
+///
+/// Requires a `MarketAdapterConfig` to have been set via
+/// `MarketContract::set_market_adapter_config` (#681, admin-only) — if the
+/// adapter is enabled but this market has no config, that is a
+/// misconfiguration and fails closed with `OraclePriceUnavailable` rather
+/// than silently falling back to Ed25519.
+fn verify_via_reflector(
+    env: &Env,
+    market_id: u32,
+    market: &Market,
+    outcome: bool,
+    proof: &BytesN<64>,
+) -> Result<(), ContractError> {
+    if !crate::storage::is_adapter_enabled(env, &AdapterType::Reflector) {
+        return verify_oracle_signature(env, market_id, outcome, proof, &market.oracle_pubkey);
+    }
+    let config = crate::storage::get_market_adapter_config(env, market_id)
+        .ok_or(ContractError::OraclePriceUnavailable)?;
+    use crate::oracle_adapter::OracleAdapter as _;
+    let adapter = crate::oracle_adapter::ReflectorAdapter {
+        contract_id: config.oracle_contract,
+        asset: config.asset,
+        resolution_price: config.resolution_price,
+    };
+    adapter.verify_outcome(env, market_id, outcome, &Bytes::new(env))
 }
 
 /// Verify that the market outcome is valid using V2 oracle signatures.
@@ -333,8 +366,35 @@ pub fn verify_market_outcome_v2(
             proof,
             &market.oracle_pubkey,
         ),
-        AdapterType::Reflector | AdapterType::Pyth => {
+        AdapterType::Reflector => {
             if crate::storage::is_adapter_enabled(env, &adapter_type) {
+                let config = crate::storage::get_market_adapter_config(env, market_id)
+                    .ok_or(ContractError::OraclePriceUnavailable)?;
+                use crate::oracle_adapter::OracleAdapter as _;
+                let adapter = crate::oracle_adapter::ReflectorAdapter {
+                    contract_id: config.oracle_contract,
+                    asset: config.asset,
+                    resolution_price: config.resolution_price,
+                };
+                adapter.verify_outcome(env, market_id, outcome, &Bytes::new(env))
+            } else {
+                // Adapter disabled/unavailable — fall back to raw Ed25519 V2 verification.
+                verify_oracle_signature_v2(
+                    env,
+                    passphrase_hash,
+                    market_id,
+                    outcome,
+                    valid_until,
+                    epoch,
+                    proof,
+                    &market.oracle_pubkey,
+                )
+            }
+        }
+        AdapterType::Pyth => {
+            if crate::storage::is_adapter_enabled(env, &adapter_type) {
+                // See `verify_market_outcome` — Pyth needs a raw VAA proof,
+                // not fitted by this V2 entrypoint's fixed signature param.
                 Err(ContractError::UnauthorizedOracle)
             } else {
                 // Adapter disabled/unavailable — fall back to raw Ed25519 V2 verification.

--- a/contracts/market/src/oracle_adapter.rs
+++ b/contracts/market/src/oracle_adapter.rs
@@ -17,6 +17,15 @@
 use crate::error::ContractError;
 use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env, IntoVal, Symbol, Val, Vec};
 
+/// Maximum age, in seconds, that a Reflector or Pyth price observation may
+/// have before it is rejected as stale (#682). Both adapters read a
+/// timestamp/publish_time alongside the price but previously never checked
+/// it, so a disconnected or slow-to-update oracle node could have a market
+/// resolve against an arbitrarily old price. One hour is a pragmatic default
+/// — generous enough for normal Reflector/Pyth update cadences, tight enough
+/// to block a stuck feed from silently resolving a market.
+pub const MAX_PRICE_AGE_SECONDS: u64 = 3_600;
+
 // ---------------------------------------------------------------------------
 // Asset type used by Reflector (#379)
 // ---------------------------------------------------------------------------
@@ -157,6 +166,14 @@ impl OracleAdapter for ReflectorAdapter {
 
         let data = price_data.ok_or(ContractError::OraclePriceUnavailable)?;
 
+        // Reject stale prices (#682): a price observation older than
+        // `MAX_PRICE_AGE_SECONDS` must not be used to resolve a market, even
+        // though Reflector returned `Some(..)` rather than `None`.
+        let now = env.ledger().timestamp();
+        if now.saturating_sub(data.timestamp) > MAX_PRICE_AGE_SECONDS {
+            return Err(ContractError::StalePrice);
+        }
+
         // YES when price >= threshold, NO otherwise.
         let resolved_yes = data.price >= self.resolution_price;
         if resolved_yes != outcome {
@@ -256,6 +273,13 @@ impl OracleAdapter for PythAdapter {
             &Symbol::new(env, "get_price"),
             price_args,
         );
+
+        // Reject stale prices (#682) — same staleness gate as Reflector,
+        // using Pyth's `publish_time` field.
+        let now = env.ledger().timestamp();
+        if now.saturating_sub(price_data.publish_time) > MAX_PRICE_AGE_SECONDS {
+            return Err(ContractError::StalePrice);
+        }
 
         let resolved_yes = price_data.price >= self.resolution_price;
         if resolved_yes != outcome {

--- a/contracts/market/src/storage.rs
+++ b/contracts/market/src/storage.rs
@@ -31,9 +31,13 @@ use soroban_sdk::{contracttype, Address, BytesN, Env, Vec};
 /// 5. Initialize: `stellar contract invoke ... -- initialize --admin <addr>`
 /// 6. Verify old deployment returns `UpgradeRequired` error
 ///
-/// ## Current version: 5
+/// ## Current version: 6
 ///
 /// ### Version history:
+/// - **v6:** Added per-market `MarketAdapterConfig` (Reflector/Pyth oracle
+///   contract, asset, resolution_price) so adapters can actually be
+///   configured per market (#681), and wired Reflector into
+///   `resolve_market`/`verify_signature` (#680).
 /// - **v5:** Added `EmergencyMode` storage for coordinated emergency mode (#662)
 /// - **v4:** Added per-adapter-type `AdapterEnabled` flag for the Reflector/Pyth
 ///   Ed25519 fallback path (#488)
@@ -42,7 +46,7 @@ use soroban_sdk::{contracttype, Address, BytesN, Env, Vec};
 /// - **v1:** Initial storage layout
 ///
 /// See `STORAGE_MIGRATION_GUIDE.md` and `MIGRATION.md` for detailed history.
-pub const STORAGE_VERSION: u32 = 5;
+pub const STORAGE_VERSION: u32 = 6;
 
 #[contracttype]
 pub enum StorageKey {
@@ -114,6 +118,9 @@ pub enum StorageKey {
     MarketThresholdSigners(u32),
     /// Per-market threshold quorum override (#665).
     MarketThresholdQuorum(u32),
+    /// Per-market Reflector/Pyth oracle adapter configuration (#681):
+    /// oracle contract address, asset, and resolution price threshold.
+    MarketAdapterConfig(u32),
 }
 
 pub fn get_pending_threshold_signers(env: &Env) -> Option<crate::types::PendingThresholdSignersChange> {
@@ -518,6 +525,34 @@ pub fn set_adapter_enabled(env: &Env, adapter_type: &crate::types::AdapterType, 
     env.storage()
         .persistent()
         .set(&StorageKey::AdapterEnabled(adapter_type.clone()), &enabled);
+}
+
+// --- Per-market Adapter Config (#681) ---
+
+/// Fetch the stored Reflector/Pyth adapter config for `market_id`, if any.
+///
+/// Returns `None` when the admin has not configured an adapter for this
+/// market yet — callers should fall back to Ed25519 verification rather than
+/// treating this as an error (see `oracle::verify_market_outcome`).
+pub fn get_market_adapter_config(
+    env: &Env,
+    market_id: u32,
+) -> Option<crate::types::MarketAdapterConfig> {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::MarketAdapterConfig(market_id))
+}
+
+/// Set (or replace) the Reflector/Pyth adapter config for `market_id`
+/// (admin-gated in `lib.rs`).
+pub fn set_market_adapter_config(
+    env: &Env,
+    market_id: u32,
+    config: &crate::types::MarketAdapterConfig,
+) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::MarketAdapterConfig(market_id), config);
 }
 
 // --- Deposit Reentrancy Lock (Issue #501) ---

--- a/contracts/market/src/types.rs
+++ b/contracts/market/src/types.rs
@@ -149,6 +149,31 @@ pub struct PendingAdapterTypeChange {
     pub effective_at: u64,
 }
 
+/// Per-market Reflector/Pyth oracle adapter configuration (#681).
+///
+/// `Market` carries an `adapter_type` but, before this, had nowhere to store
+/// the Reflector asset/contract or the price threshold a market resolves
+/// against — so an admin could mark a market `AdapterType::Reflector` but
+/// there was no way to actually configure it. Stored separately (keyed by
+/// `market_id`, see `StorageKey::MarketAdapterConfig` in `storage.rs`)
+/// rather than as inline `Market` fields so existing `Market` storage
+/// entries need no migration; a market with no entry here simply has no
+/// adapter config and `oracle::verify_market_outcome` falls back to Ed25519
+/// (see #680).
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct MarketAdapterConfig {
+    /// Address of the Reflector (or Pyth) oracle contract on the target
+    /// network.
+    pub oracle_contract: Address,
+    /// Reflector asset identifier queried via `lastprice`. Unused for Pyth.
+    pub asset: crate::oracle_adapter::Asset,
+    /// Price threshold, in the oracle's native fixed-point units (Reflector:
+    /// 7 decimals). The market resolves YES when the fetched price is
+    /// `>= resolution_price`.
+    pub resolution_price: i128,
+}
+
 /// A 32-byte change (like oracle pubkey) awaiting its timelock delay before it can take effect.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]

--- a/contracts/resolution/src/lib.rs
+++ b/contracts/resolution/src/lib.rs
@@ -549,11 +549,24 @@ impl ResolutionContract {
         // Cross-contract callback: resolve the market with the finalized outcome.
         // The Finalized status is already persisted above, so a second call to
         // finalize(candidate_id) will be rejected before reaching this point.
+        //
+        // Args must match `Market::resolve_market`'s real ABI (#683):
+        // (resolver: Address, market_id: String, outcome: bool, signature:
+        // BytesN<64>, expires_at: u64) — the old call used a mock ABI (bare
+        // u32 market_id, no resolver/expires_at) that silently mismatched
+        // the deployed market contract's actual entrypoint. `resolver` is
+        // this contract's own address (it self-authorizes as the direct
+        // invoker, matching how `arbitrate_uphold_proposer` settles
+        // disputes), and `expires_at` reuses the candidate's already-checked
+        // `signature_expiry` so `resolve_market`'s own expiry gate stays
+        // consistent with the check `finalize` already performed above.
         let args: Vec<Val> = soroban_sdk::vec![
             &env,
-            candidate.market_id.into_val(&env),
+            env.current_contract_address().into_val(&env),
+            market_id_to_string(&env, candidate.market_id).into_val(&env),
             candidate.outcome.into_val(&env),
             candidate.signature.clone().into_val(&env),
+            candidate.signature_expiry.into_val(&env),
         ];
         let _: () = env.invoke_contract(
             &config.market_contract,
@@ -682,11 +695,14 @@ impl ResolutionContract {
 
         events::emit_candidate_arbitrated(&env, candidate_id, candidate.market_id, candidate.outcome);
 
+        // Same ABI fix as `finalize` (#683) — see the comment there.
         let args: Vec<Val> = soroban_sdk::vec![
             &env,
-            candidate.market_id.into_val(&env),
+            env.current_contract_address().into_val(&env),
+            market_id_to_string(&env, candidate.market_id).into_val(&env),
             candidate.outcome.into_val(&env),
             candidate.signature.clone().into_val(&env),
+            candidate.signature_expiry.into_val(&env),
         ];
         let _: () = env.invoke_contract(
             &config.market_contract,
@@ -803,6 +819,32 @@ fn validate_uri(uri: &String) -> Result<(), ContractError> {
         return Err(ContractError::InvalidEvidenceUri);
     }
     Ok(())
+}
+
+/// Format `market_id` as its base-10 ASCII representation.
+///
+/// `Market::resolve_market` takes `market_id` as a `String` (parsed back to
+/// `u32` via `validation::parse_market_id`), while every other market
+/// entrypoint this contract calls (`verify_signature`,
+/// `get_collateral_token`, `get_market_status`) takes the raw `u32`. This
+/// bridges the two so `resolve_market`'s cross-contract call uses the real
+/// ABI instead of a bare `u32` (#683).
+fn market_id_to_string(env: &Env, market_id: u32) -> String {
+    let mut buf = [0u8; 10];
+    let mut n = market_id;
+    let mut i = buf.len();
+    if n == 0 {
+        i -= 1;
+        buf[i] = b'0';
+    } else {
+        while n > 0 {
+            i -= 1;
+            buf[i] = b'0' + (n % 10) as u8;
+            n /= 10;
+        }
+    }
+    let s = core::str::from_utf8(&buf[i..]).unwrap_or("0");
+    String::from_str(env, s)
 }
 
 /// Look up a market's collateral token via a cross-contract call to the


### PR DESCRIPTION
## Summary

- **#683** — `ResolutionContract::finalize` and `arbitrate_uphold_proposer` invoked `Market::resolve_market` with a mock ABI (bare `u32` market_id, no `resolver`/`expires_at`). Fixed both cross-contract calls to match the real ABI: `(resolver: Address, market_id: String, outcome: bool, signature: BytesN<64>, expires_at: u64)`. `resolver` is the resolution contract's own address (self-authorizing as the direct invoker); `expires_at` reuses the candidate's already-checked `signature_expiry`. Added a `market_id_to_string` helper since `resolve_market` takes the id as a decimal `String`.
- **#682** — `ReflectorAdapter`/`PythAdapter` read a price timestamp/`publish_time` but never checked it. Added a `MAX_PRICE_AGE_SECONDS` (1 hour) staleness gate and a new `ContractError::StalePrice` (26) returned when a fetched price is older than that window.
- **#681** — Added per-market `MarketAdapterConfig` (oracle contract address, Reflector `Asset`, `resolution_price`) stored separately from `Market` (no migration needed for existing markets), with admin-gated `set_market_adapter_config` / `get_market_adapter_config` entrypoints. Bumped `STORAGE_VERSION` to 6.
- **#680** — `oracle::verify_market_outcome` / `verify_market_outcome_v2` now dispatch to the on-chain `ReflectorAdapter` (built from the new per-market config) when the Reflector adapter is enabled via `set_adapter_enabled`, instead of always failing closed with `UnauthorizedOracle`. If enabled but unconfigured for a market, it fails closed with `OraclePriceUnavailable` rather than silently falling back.

## Notes / TODO

- Pyth wiring is intentionally left as a follow-up per #680's "Reflector first" framing — Pyth needs a raw Wormhole VAA `Bytes` proof rather than the fixed 64-byte Ed25519 signature these entrypoints accept, so it still fails closed with `UnauthorizedOracle` when enabled.
- `ResolutionContract::void_market` invokes a `void_market` entrypoint on the market contract that does not exist yet in `contracts/market/src/lib.rs`; this predates this PR and is out of scope for #683 (only `finalize`/`resolve_market` alignment was in scope).
- Per repo owner's request, this PR was implemented and pushed without running `cargo test`/`cargo build`/`soroban build` — please run CI/tests before merge.

Closes #683
Closes #682
Closes #681
Closes #680