### PR TITLE
  fix(market): add void_market entrypoint + settlement parity hardening 

### DIFF
--- a/AUTH_TABLE.md
+++ b/AUTH_TABLE.md
@@ -27,6 +27,7 @@ Every row below follows the same two-step pattern unless noted otherwise:
 | `initialize_market`             | ✅ | ✅ | |
 | `cancel_market`                 | ✅ | ✅ | |
 | `reopen_market`                 | ✅ | ✅ | Only sanctioned `Canceled` → `Active` path. |
+| `void_market`                    | ✅ (`caller`) | n/a — cross-contract equality check | Issue #708. Callable **only** by the registered resolution contract (`storage::get_resolution_contract`); every other caller — admin included — gets `Unauthorized`, and an unset resolution contract fails closed with `Unauthorized`. Forces `Active` → `Canceled` for the resolution `void_market` dispute outcome; `Resolved`/`Canceled` markets are rejected. |
 | `close_market_to_deposits`      | ✅ | ✅ | Idempotent; always emits an event, even when already closed. |
 | `set_oracle_v1_disabled`        | ✅ | ✅ | Legacy Ed25519-v1 kill switch (#657). |
 | `set_adapter_enabled`           | ✅ | ✅ | Enables/disables the Reflector/Pyth adapter; fails closed to direct Ed25519 verification while disabled — never a silent fallback while an adapter is *enabled but unavailable*. |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,6 +2014,7 @@ dependencies = [
 name = "vatix-resolution-contract"
 version = "0.0.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -2021,6 +2022,7 @@ dependencies = [
 name = "vatix-treasury-contract"
 version = "0.0.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 

--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -16,6 +16,7 @@
 //! | `WithdrawEdgeCase`       | `withdraw_edge_case`                |
 //! | `MarketResolved`         | `market_resolved`                   |
 //! | `MarketCanceled`         | `market_canceled`                   |
+//! | `MarketVoided`           | `market_voided`                     |
 //! | `PositionSettled`        | `position_settled`                  |
 //! | `PositionUpdated`        | `position_updated`                  |
 //! | `PositionLimitExceeded`  | `position_limit_exceeded`           |
@@ -462,6 +463,45 @@ pub fn emit_market_canceled(env: &Env, market_id: u32, canceler: &Address, cance
         market_id,
         canceler: canceler.clone(),
         canceled_at,
+    }
+    .publish(env);
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct MarketVoided {
+    #[topic]
+    pub version: u32,
+    #[topic]
+    pub market_id: u32,
+    /// The registered resolution contract address that voided the market.
+    pub voided_by: Address,
+    pub voided_at: u64,
+}
+
+/// Emit a `MarketVoided` event.
+///
+/// Published when the registered resolution contract voids a market via
+/// [`crate::MarketContract::void_market`] (Issue #708) — the dispute path
+/// where neither side could be safely vindicated on-chain, so the market is
+/// force-transitioned to [`crate::types::MarketStatus::Canceled`] and users
+/// reclaim collateral through `withdraw_canceled_collateral`.
+///
+/// Distinct from [`MarketCanceled`] (admin-initiated `cancel_market`) so
+/// indexers can tell a governance cancellation apart from a resolution-driven
+/// void, even though both land the market in the same `Canceled` state.
+///
+/// # Arguments
+/// * `env` - Contract environment
+/// * `market_id` - Unique identifier of the voided market
+/// * `voided_by` - The registered resolution contract address
+/// * `voided_at` - Unix timestamp (ledger time) when the void occurred
+pub fn emit_market_voided(env: &Env, market_id: u32, voided_by: &Address, voided_at: u64) {
+    MarketVoided {
+        version: EVENT_VERSION,
+        market_id,
+        voided_by: voided_by.clone(),
+        voided_at,
     }
     .publish(env);
 }
@@ -1532,6 +1572,47 @@ mod tests {
             .into_val(&env);
         assert_eq!(canceler_val, canceler);
         assert_eq!(canceled_at_val, canceled_at);
+    }
+
+    #[test]
+    fn test_emit_market_voided() {
+        let env = Env::default();
+        let contract_id = env.register(MarketContract, ());
+
+        let market_id = 7u32;
+        let voided_by = Address::generate(&env);
+        let voided_at = 1_700_000_000u64;
+
+        env.as_contract(&contract_id, || {
+            emit_market_voided(&env, market_id, &voided_by, voided_at);
+        });
+
+        let events = env.events().all();
+        assert_eq!(events.len(), 1);
+
+        let event = events.first().unwrap();
+        let topics = &event.1;
+
+        let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+        assert_eq!(topic0, Symbol::new(&env, "market_voided"));
+
+        let topic1: u32 = topics.get(1).unwrap().into_val(&env);
+        assert_eq!(topic1, EVENT_VERSION);
+
+        let topic2: u32 = topics.get(2).unwrap().into_val(&env);
+        assert_eq!(topic2, market_id);
+
+        let data: Map<Symbol, Val> = event.2.try_into_val(&env).unwrap();
+        let voided_by_val: Address = data
+            .get(Symbol::new(&env, "voided_by"))
+            .unwrap()
+            .into_val(&env);
+        let voided_at_val: u64 = data
+            .get(Symbol::new(&env, "voided_at"))
+            .unwrap()
+            .into_val(&env);
+        assert_eq!(voided_by_val, voided_by);
+        assert_eq!(voided_at_val, voided_at);
     }
 
     #[test]

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -1008,6 +1008,75 @@ impl MarketContract {
         Ok(())
     }
 
+    /// Void a market at the direction of the registered resolution contract
+    /// (Issue #708).
+    ///
+    /// This is the market-side half of the resolution contract's `void_market`
+    /// arbitration outcome: when a dispute cannot be safely vindicated
+    /// on-chain for either side, the resolution contract slashes/refunds the
+    /// posted bonds and then calls this to force the market to
+    /// [`MarketStatus::Canceled`], unsticking it so users can reclaim their
+    /// collateral via [`Self::withdraw_canceled_collateral`].
+    ///
+    /// # Authorization
+    /// Callable **only** by the address registered as the resolution contract
+    /// (see [`Self::propose_resolution_contract`] /
+    /// [`Self::execute_resolution_contract`]). Every other caller — the admin
+    /// included — is rejected with [`ContractError::Unauthorized`], and the
+    /// call also fails closed with [`ContractError::Unauthorized`] when no
+    /// resolution contract is registered at all, so a wrong or malicious
+    /// caller can never void a live market.
+    ///
+    /// # Arguments
+    /// * `env` - Contract environment
+    /// * `caller` - Must be the registered resolution contract (authorizes the call)
+    /// * `market_id` - Identifier of the market to void
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] – the contract is not initialized
+    /// - [`ContractError::Unauthorized`] – `caller` is not the registered
+    ///   resolution contract, or none is registered
+    /// - [`ContractError::MarketNotFound`] – the market does not exist
+    /// - [`ContractError::MarketAlreadyResolved`] – the market already has a
+    ///   final outcome and cannot be voided
+    /// - [`ContractError::MarketNotActive`] – the market is already canceled
+    ///
+    /// # Events
+    /// Emits [`events::MarketVoided`] with `market_id`, `voided_by`, and
+    /// `voided_at` on success.
+    pub fn void_market(env: Env, caller: Address, market_id: u32) -> Result<(), ContractError> {
+        validation::require_initialized(&env)?;
+        // Intentionally NOT gated by `require_not_paused`: voiding is the
+        // sanctioned unstick path for a market frozen mid-dispute, and the
+        // only possible caller is the resolution contract itself.
+        caller.require_auth();
+
+        // Fail closed: an unset resolution contract means nobody is authorized
+        // to void — never fall back to admin or open access.
+        let resolution_contract =
+            storage::get_resolution_contract(&env).ok_or(ContractError::Unauthorized)?;
+        if caller != resolution_contract {
+            return Err(ContractError::Unauthorized);
+        }
+
+        // Checks: load the market and enforce the void policy (Active only).
+        let mut market =
+            storage::get_market(&env, market_id)?.ok_or(ContractError::MarketNotFound)?;
+        match market.status {
+            MarketStatus::Resolved => return Err(ContractError::MarketAlreadyResolved),
+            MarketStatus::Canceled => return Err(ContractError::MarketNotActive),
+            MarketStatus::Active => {}
+        }
+
+        // Effects: transition to Canceled and persist before emitting.
+        market.status = MarketStatus::Canceled;
+        storage::set_market(&env, market_id, &market)?;
+
+        events::emit_market_voided(&env, market_id, &caller, env.ledger().timestamp());
+
+        Ok(())
+    }
+
     /// Reclaim deposited collateral from a canceled market.
     ///
     /// When a market is canceled before resolution there is no winning outcome,

--- a/contracts/market/src/reconciliation.rs
+++ b/contracts/market/src/reconciliation.rs
@@ -58,6 +58,16 @@ fn load_token_balances(env: &Env, market_id: u32, user: &Address) -> Option<(i12
 /// When no outcome-token contract is registered there is no second ledger to
 /// diverge from, so parity is vacuously satisfied (token balances mirror
 /// shares 1:1).
+///
+/// A **settled** position is likewise reported as matched regardless of the
+/// raw balances (Issue #708 / #578 parity): every settle path
+/// (`settle_position`, `batch_settle_positions`, `settle_positions_page`)
+/// burns the position's outcome tokens back to zero on full exit while the
+/// `Position` row is deliberately retained as a historical record — its
+/// `yes_shares` / `no_shares` are *not* zeroed. Without this carve-out every
+/// settled position would report `is_matched: false` forever, and
+/// [`reconcile_position_tokens`] would "repair" it by **re-minting the
+/// tokens that settlement just burned**.
 pub fn get_position_token_parity(
     env: &Env,
     market_id: u32,
@@ -69,13 +79,16 @@ pub fn get_position_token_parity(
     let (yes_token_balance, no_token_balance) = load_token_balances(env, market_id, user)
         .unwrap_or((position.yes_shares, position.no_shares));
 
+    let is_matched = position.is_settled
+        || (yes_token_balance == position.yes_shares
+            && no_token_balance == position.no_shares);
+
     Ok(PositionTokenParity {
         yes_shares: position.yes_shares,
         no_shares: position.no_shares,
         yes_token_balance,
         no_token_balance,
-        is_matched: yes_token_balance == position.yes_shares
-            && no_token_balance == position.no_shares,
+        is_matched,
     })
 }
 
@@ -181,6 +194,58 @@ mod tests {
         assert!(parity.is_matched);
         assert_eq!(parity.yes_shares, 0);
         assert_eq!(parity.no_shares, 0);
+    }
+
+    /// Issue #708 / #578 parity: once a position is settled, every settle path
+    /// burns its outcome tokens back to zero while the `Position` row is kept
+    /// as a historical record (shares not zeroed). The parity view must report
+    /// such a position as matched — otherwise `reconcile_position_tokens`
+    /// would re-mint the tokens settlement just burned.
+    #[test]
+    fn test_settled_position_reports_matched_even_though_tokens_burned() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let market_contract_id = env.register(MarketContract, ());
+        let admin = <Address as TestAddress>::generate(&env);
+        let user = <Address as TestAddress>::generate(&env);
+        let market_id = 1u32;
+
+        let outcome_token_id = env.register(OutcomeTokenContract, ());
+        OutcomeTokenContractClient::new(&env, &outcome_token_id).initialize(
+            &admin,
+            &market_contract_id,
+            &String::from_str(&env, "Vatix Outcome Token"),
+            &String::from_str(&env, "VOT"),
+        );
+
+        let parity = env.as_contract(&market_contract_id, || {
+            storage::set_version(&env);
+            storage::set_outcome_token_contract(&env, &outcome_token_id);
+
+            // A fully-exited, settled position: 100 YES shares on record, but
+            // the outcome-token balance is 0 (burned on settlement).
+            let mut position = Position::new_empty(market_id, user.clone());
+            position.yes_shares = 100 * STROOPS_PER_USDC;
+            position.is_settled = true;
+            storage::set_position(&env, market_id, &user, &position).unwrap();
+
+            get_position_token_parity(&env, market_id, &user).unwrap()
+        });
+
+        assert!(
+            parity.is_matched,
+            "a settled position must report matched despite burned tokens"
+        );
+        assert_eq!(parity.yes_shares, 100 * STROOPS_PER_USDC);
+        assert_eq!(parity.yes_token_balance, 0);
+
+        // And the admin repair path is a no-op (does not re-mint).
+        let repaired = env.as_contract(&market_contract_id, || {
+            reconcile_position_tokens(&env, &admin, market_id, &user).unwrap()
+        });
+        assert!(repaired.is_matched);
+        assert_eq!(repaired.yes_token_balance, 0);
     }
 
     /// Full setup: a Market contract wired to a real OutcomeToken contract, one

--- a/contracts/market/src/settlement.rs
+++ b/contracts/market/src/settlement.rs
@@ -1505,4 +1505,44 @@ mod tests {
         // No positions exist for any ghost address — payout is 0, not an error.
         assert_eq!(result, Ok(0));
     }
+
+    /// Issue #706: the gas-griefing cap is exactly 100. Pinned as an explicit
+    /// value so a change to the constant is a deliberate, reviewed edit (the
+    /// AUTH_TABLE / griefing analysis references this number).
+    #[test]
+    fn test_max_batch_settle_size_constant_is_100() {
+        assert_eq!(crate::MAX_BATCH_SETTLE_SIZE, 100);
+    }
+
+    /// Issue #706: the empty-batch and oversize-batch guards fire before the
+    /// market is even loaded, so they reject regardless of market state — i.e.
+    /// a griefing caller cannot burn gas iterating an unbounded (or spoofed
+    /// empty) list. Complements the resolved-market coverage above by pinning
+    /// the guard ordering: `BatchTooLarge` wins over `MarketNotFound`.
+    #[test]
+    fn test_batch_settle_size_guards_precede_market_load() {
+        use crate::MarketContract;
+        let env = soroban_sdk::Env::default();
+        let contract_id = env.register(MarketContract, ());
+        env.as_contract(&contract_id, || {
+            storage::set_version(&env);
+        });
+
+        // Empty list → BatchTooLarge, even though market 12345 does not exist.
+        let empty: Vec<Address> = Vec::new(&env);
+        assert_eq!(
+            env.as_contract(&contract_id, || batch_settle_positions(&env, 12345, empty)),
+            Err(ContractError::BatchTooLarge),
+        );
+
+        // 101 entries → BatchTooLarge, again before any market lookup.
+        let mut oversized: Vec<Address> = Vec::new(&env);
+        for _ in 0..=crate::MAX_BATCH_SETTLE_SIZE {
+            oversized.push_back(Address::generate(&env));
+        }
+        assert_eq!(
+            env.as_contract(&contract_id, || batch_settle_positions(&env, 12345, oversized)),
+            Err(ContractError::BatchTooLarge),
+        );
+    }
 }

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -2817,6 +2817,136 @@ mod test {
         assert_eq!(client.get_resolution_contract(), Some(resolution_contract));
     }
 
+    // ========== Issue #708: void_market caller authorization ==========
+    //
+    // `void_market` is the market-side half of the resolution contract's
+    // `void_market` arbitration outcome. It must be callable ONLY by the
+    // registered resolution contract — a wrong caller (including the admin)
+    // must never be able to void a live market, and an unset resolution
+    // contract must fail closed.
+
+    /// Register `resolution` as the market's resolution contract by writing
+    /// storage directly (there is no instant public setter — the production
+    /// path is the `propose_resolution_contract` / `execute_resolution_contract`
+    /// timelock pair).
+    fn wire_resolution_contract(env: &Env, contract_id: &Address, resolution: &Address) {
+        env.as_contract(contract_id, || {
+            storage::set_resolution_contract(env, resolution);
+        });
+    }
+
+    fn new_active_market(env: &Env, client: &MarketContractClient<'_>, admin: &Address) -> u32 {
+        client.initialize_market(
+            admin,
+            &String::from_str(env, "Void me?"),
+            &(env.ledger().timestamp() + 86_400),
+            &BytesN::from_array(env, &[3u8; 32]),
+            &Address::generate(env),
+            &None,
+        )
+    }
+
+    #[test]
+    fn test_void_market_by_registered_resolution_contract_cancels() {
+        let (env, admin, client, contract_id) = create_test_contract();
+        let resolution = Address::generate(&env);
+        wire_resolution_contract(&env, &contract_id, &resolution);
+
+        let market_id = new_active_market(&env, &client, &admin);
+
+        let events_before = env.events().all().len();
+        client.void_market(&resolution, &market_id);
+
+        assert_eq!(client.get_market(&market_id).status, MarketStatus::Canceled);
+        // The authoritative status-transition emits at least one event
+        // (`MarketVoided`); the exact topic/payload is asserted in
+        // `events::tests::test_emit_market_voided`.
+        assert!(env.events().all().len() > events_before);
+    }
+
+    #[test]
+    fn test_void_market_rejects_non_resolution_caller() {
+        let (env, admin, client, contract_id) = create_test_contract();
+        let resolution = Address::generate(&env);
+        wire_resolution_contract(&env, &contract_id, &resolution);
+
+        let market_id = new_active_market(&env, &client, &admin);
+
+        let stranger = Address::generate(&env);
+        let result = client.try_void_market(&stranger, &market_id);
+        assert_eq!(result, Err(Ok(crate::error::ContractError::Unauthorized)));
+        assert_eq!(client.get_market(&market_id).status, MarketStatus::Active);
+    }
+
+    #[test]
+    fn test_void_market_rejects_admin_caller() {
+        let (env, admin, client, contract_id) = create_test_contract();
+        let resolution = Address::generate(&env);
+        wire_resolution_contract(&env, &contract_id, &resolution);
+
+        let market_id = new_active_market(&env, &client, &admin);
+
+        // Even the admin cannot void a market — only the resolution contract.
+        let result = client.try_void_market(&admin, &market_id);
+        assert_eq!(result, Err(Ok(crate::error::ContractError::Unauthorized)));
+        assert_eq!(client.get_market(&market_id).status, MarketStatus::Active);
+    }
+
+    #[test]
+    fn test_void_market_fails_closed_when_no_resolution_contract_registered() {
+        let (env, admin, client, _contract_id) = create_test_contract();
+        let market_id = new_active_market(&env, &client, &admin);
+
+        let anyone = Address::generate(&env);
+        let result = client.try_void_market(&anyone, &market_id);
+        assert_eq!(result, Err(Ok(crate::error::ContractError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_void_market_rejects_already_resolved_market() {
+        let (env, admin, client, contract_id) = create_test_contract();
+        let resolution = Address::generate(&env);
+        wire_resolution_contract(&env, &contract_id, &resolution);
+
+        let market_id = new_active_market(&env, &client, &admin);
+        env.as_contract(&contract_id, || {
+            let mut m = storage::get_market(&env, market_id).unwrap().unwrap();
+            m.status = MarketStatus::Resolved;
+            m.result = Some(true);
+            storage::set_market(&env, market_id, &m).unwrap();
+        });
+
+        let result = client.try_void_market(&resolution, &market_id);
+        assert_eq!(
+            result,
+            Err(Ok(crate::error::ContractError::MarketAlreadyResolved))
+        );
+    }
+
+    #[test]
+    fn test_void_market_rejects_already_canceled_market() {
+        let (env, admin, client, contract_id) = create_test_contract();
+        let resolution = Address::generate(&env);
+        wire_resolution_contract(&env, &contract_id, &resolution);
+
+        let market_id = new_active_market(&env, &client, &admin);
+        client.void_market(&resolution, &market_id);
+
+        // A second void is rejected — no silent double-transition.
+        let result = client.try_void_market(&resolution, &market_id);
+        assert_eq!(result, Err(Ok(crate::error::ContractError::MarketNotActive)));
+    }
+
+    #[test]
+    fn test_void_market_rejects_unknown_market() {
+        let (env, _admin, client, contract_id) = create_test_contract();
+        let resolution = Address::generate(&env);
+        wire_resolution_contract(&env, &contract_id, &resolution);
+
+        let result = client.try_void_market(&resolution, &999u32);
+        assert_eq!(result, Err(Ok(crate::error::ContractError::MarketNotFound)));
+    }
+
     // ========== Fee cap hardening: set-time and execute-time enforcement ==========
 
     #[test]

--- a/docs/events-reference.md
+++ b/docs/events-reference.md
@@ -36,6 +36,7 @@ events additionally carry a `version: u32 (topic)` field
 | `market_closed_to_deposits` | `version: u32 (topic)`, `market_id: u32 (topic)`, `admin: Address`, `closed_at: u64` | An admin closes a market to new collateral deposits |
 | `market_resolved` | `version: u32 (topic)`, `market_id: u32 (topic)`, `oracle_pubkey: BytesN<32>`, `resolver: Address`, `outcome: bool`, `resolved_at: u64` | A market is resolved with an oracle-signed outcome |
 | `market_canceled` | `version: u32 (topic)`, `market_id: u32 (topic)`, `canceler: Address`, `canceled_at: u64` | An admin cancels a market before resolution |
+| `market_voided` | `version: u32 (topic)`, `market_id: u32 (topic)`, `voided_by: Address`, `voided_at: u64` | The registered resolution contract voids a market via `void_market` (Issue #708) — dispute outcome where neither side could be vindicated on-chain; `voided_by` is the resolution contract address. Distinct from `market_canceled` (admin `cancel_market`) though both land in `Canceled`. |
 | `position_limit_exceeded` | `version: u32 (topic)`, `market_id: u32 (topic)`, `user: Address (topic)`, `side_yes: bool` | A trade/position change is rejected because a share balance would go negative |
 | `position_updated` | `version: u32 (topic)`, `market_id: u32 (topic)`, `user: Address (topic)`, `yes_shares: i128`, `no_shares: i128`, `locked_collateral: i128` | A user's position (share balances / locked collateral) changes |
 | `trade_executed` | `version: u32 (topic)`, `market_id: u32 (topic)`, `user: Address (topic)`, `quantity: i128`, `price_bps: i128`, `side_yes: bool`, `executed_at: u64` | A user executes a trade (buy or sell of YES/NO shares) |
@@ -84,6 +85,7 @@ events additionally carry a `version: u32 (topic)` field
 | `candidate_finalized` | `candidate_id: u32 (topic)`, `market_id: u32 (topic)`, `outcome: bool`, `finalized_at: u64` | A candidate is finalized after its challenge window closes (`finalize`) — invokes `resolve_market` or `resolve_market_v2` on the market contract depending on how the candidate was proposed (#701) |
 | `candidate_appealed` | `candidate_id: u32 (topic)`, `market_id: u32 (topic)`, `outcome: bool`, `proposer: Address`, `appeal_round: u32`, `evidence_uri: String`, `challenge_deadline: u64`, `appealed_at: u64` | A challenged candidate is re-proposed/appealed for another round. V1-only (`appeal` rejects a V2-proposed candidate, #701) |
 | `emergency_mode_changed` | `new_mode: EmergencyMode (topic)`, `admin: Address`, `changed_at: u64` | Admin changes the mirrored emergency mode (`set_emergency_mode`), coordinated with the Market and Treasury contracts (#662, wired up for resolution by #701) |
+| `market_voided` | `candidate_id: u32 (topic)`, `market_id: u32 (topic)`, `voided_at: u64` | Resolution `void_market` runs: the proposer's bond is split/slashed, challengers are refunded, and the market contract's `void_market` is invoked to move the market to `Canceled` (Issue #708). The market contract emits its own `market_voided` for the status transition. |
 
 ## Outcome Token (`contracts/outcome-token/src/events.rs`)
 

--- a/docs/reentrancy-cei-audit.md
+++ b/docs/reentrancy-cei-audit.md
@@ -15,6 +15,7 @@
 | **Market** | `withdraw_unused_collateral` | External fee transfer & `collect_fee` call occurred **before** `storage::set_position`. | High | **Fixed** |
 | **Market** | `settle_position` | Outcome token `burn()` external call occurred **before** `storage::set_position`. | Medium | **Fixed** |
 | **Market** | `deposit_collateral` | External collateral `transfer()` occurred **before** `storage::set_position` / `add_market_participant` / `set_last_deposit_time`. | Medium | **Fixed** |
+| **Market** | `void_market` (Issue #708) | No external calls: the caller-identity check reads `storage::get_resolution_contract`, the status flips to `Canceled` via `storage::set_market`, then `emit_market_voided` publishes. No token transfer or cross-contract invoke on this path. | — | No violation (CEI-ordered: check → effect → event) |
 | **Treasury** | `withdraw_fees` | External `transfer()` occurred **before** `storage::set_token_balance` / `set_total_collected`. | High | **Fixed** |
 | **Treasury** | `distribute_fees` | Per-stakeholder external `transfer()` calls occurred **inside** the accumulation loop, **before** `storage::set_token_balance` was updated with the reduced balance. | High | **Fixed** |
 | **Treasury** | `collect_fee` | No external token call — the caller (a market contract) moves funds separately; `collect_fee` only records the accounting entry. | — | No violation (informational) |

--- a/scripts/upgrade/UPGRADE_PLAYBOOK.md
+++ b/scripts/upgrade/UPGRADE_PLAYBOOK.md
@@ -75,6 +75,17 @@ address) is exactly the "partial upgrade bricks finalize" failure mode this
 playbook exists to catch. Always re-wire both sides of a relationship in the
 same maintenance window.
 
+**`Market::void_market` (Issue #708).** The resolution contract's
+`void_market` dispute path invokes `MarketContract::void_market(caller,
+market_id)` as its final step. That market entrypoint authorizes the call by
+requiring `caller == storage::get_resolution_contract(env)` and **fails
+closed with `Unauthorized`** when no resolution contract is registered or the
+caller is anyone else (the admin included). So the Market↔Resolution wiring
+in step 5 must be complete before a `void_market` can succeed, and after any
+Resolution redeployment `Market::set_resolution_contract` must be pointed at
+the new address in the same window — otherwise a stuck disputed market cannot
+be voided.
+
 ## WASM hash pinning
 
 [`scripts/verify-wasm-hash.sh`](../verify-wasm-hash.sh) computes the


### PR DESCRIPTION


## Summary

Addresses the four Soroban audit/mainnet-readiness issues #704, #706, #707, #708.
On investigation, **#704, #706 and the token-burn half of #707 were already
implemented** on `dev` — this PR verifies them with pinned regression tests and
fixes the two remaining real gaps:

1. closes #708** — the market contract had **no `void_market` entrypoint at all**.
   The resolution contract's `void_market` invokes `MarketContract::void_market`
   via `invoke_contract`, so the dispute-void path would trap. Added the
   entrypoint with fail-closed caller authorization.
2. closes #707** — settled positions permanently reported a Position/OutcomeToken
   parity mismatch (tokens burned to 0 on settlement, shares retained as
   history), so `reconcile_position_tokens` would **re-mint the tokens that
   settlement just burned**. Fixed the parity view to treat settled positions
   as matched.

## Changes

closes  #708 — `MarketContract::void_market` (new entrypoint)

`void_market(caller: Address, market_id: u32) -> Result<(), ContractError>`

- Callable **only** by the address in `storage::get_resolution_contract`.
  Every other caller — the admin included — is rejected with `Unauthorized`,
  and an **unset** resolution contract also fails closed with `Unauthorized`
  (no fallback to admin or open access).
- `Active → Canceled` only. `Resolved` → `MarketAlreadyResolved`,
  already-`Canceled` → `MarketNotActive`, missing → `MarketNotFound`.
- CEI-ordered: caller check → `storage::set_market` → event. No token transfer
  or cross-contract call on this path.
- Not gated by `require_not_paused` / emergency mode: voiding is the sanctioned
  unstick path for a market frozen mid-dispute, and the only possible caller is
  the resolution contract itself (documented inline).
- New `MarketVoided` event (`market_voided` topic), kept distinct from
  `MarketCanceled` (admin `cancel_market`) so indexers can tell a
  resolution-driven void from a governance cancellation, even though both land
  in `Canceled`.
closes  #707 — settlement parity in `reconciliation.rs`

`get_position_token_parity` now reports `is_matched: true` for any
`position.is_settled` position regardless of raw balances. Every settle path
(`settle_position`, `batch_settle_positions`, `settle_positions_page`) burns
outcome tokens to zero on full exit while retaining the `Position` row as a
historical record. Without this carve-out every settled position reported
`is_matched: false` forever and `reconcile_position_tokens` would repair it by
re-minting the burned tokens.

closes #706 — regression tests only

Guards (`empty → BatchTooLarge`, `> MAX_BATCH_SETTLE_SIZE → BatchTooLarge`) were
already in place. Added:
- `test_max_batch_settle_size_constant_is_100` — pins the cap value that the
  griefing analysis / AUTH_TABLE reference.
- `test_batch_settle_size_guards_precede_market_load` — pins that the size
  guards fire before the market is loaded (`BatchTooLarge` wins over
  `MarketNotFound`).

closes  #704 — no code change

`execute_fee_rate_change` already re-reads the fee cap at execute time
(`contracts/market/src/lib.rs`), covered by
`test_execute_fee_rate_change_rejects_when_cap_lowered_after_proposal` and
`_accepts_at_cap`. AUTH_TABLE already documents it. Listed here for traceability.

## Tests added

| File | Tests |
|---|---|
| `contracts/market/src/test.rs` | `test_void_market_by_registered_resolution_contract_cancels`, `test_void_market_rejects_non_resolution_caller`, `test_void_market_rejects_admin_caller`, `test_void_market_fails_closed_when_no_resolution_contract_registered`, `test_void_market_rejects_already_resolved_market`, `test_void_market_rejects_already_canceled_market`, `test_void_market_rejects_unknown_market` |
| `contracts/market/src/events.rs` | `test_emit_market_voided` (topic/payload snapshot) |
| `contracts/market/src/reconciliation.rs` | `test_settled_position_reports_matched_even_though_tokens_burned` |
| `contracts/market/src/settlement.rs` | `test_max_batch_settle_size_constant_is_100`, `test_batch_settle_size_guards_precede_market_load` |

## Docs updated

- `AUTH_TABLE.md` — Market contract `void_market` row (cross-contract equality check, fail-closed).
- `docs/events-reference.md` — `market_voided` for both the market contract (status transition) and the resolution contract (bond settlement + invoke).
- `docs/reentrancy-cei-audit.md` — `Market::void_market` row: no external calls, CEI-ordered.
- `scripts/upgrade/UPGRADE_PLAYBOOK.md` — `void_market` depends on the Market↔Resolution wiring; re-point `set_resolution_contract` in the same window after a Resolution redeploy.

## Acceptance criteria

- [x] Automated tests fail if the gap is reintroduced (`void_market` caller auth; settled-position parity; batch cap value/ordering).
- [x] Docs (AUTH_TABLE, events-reference, playbook, CEI audit) updated to match the new ABI.
- [x] No new instant admin mutators — `void_market` is a cross-contract callback, not an admin path; not timelocked because it is not admin-controlled.
- [x] No `panic!` / `todo!()` on shipped library paths.
- [ ] **CI cargo test paths green — NOT verified.** See below.
