### PR TITLE
Audit hardening: market deposit/withdraw/admin events + fix broken merges (#705, #709, #710, #711)

### DIFF
--- a/AUTH_TABLE.md
+++ b/AUTH_TABLE.md
@@ -21,7 +21,7 @@ Every row below follows the same two-step pattern unless noted otherwise:
 | Entrypoint                     | require_auth | admin-equality check | Notes |
 |---------------------------------|:---:|:---:|-------|
 | `initialize`                   | ✅ | n/a (bootstraps admin) | Guarded by `AlreadyInitialized` instead. As of #701, also defaults legacy V1 oracle signatures (`OracleV1Disabled`) to disabled — a fresh deployment fails closed until the admin explicitly re-enables V1 via `set_oracle_v1_disabled`. |
-| `propose_admin`                 | — | ✅ (`storage::get_admin`) | Auth deferred to `accept_admin`. |
+| `propose_admin`                 | ✅ (`current_admin`) | ✅ (`storage::get_admin`) | Current admin must authorize the nomination; nominee is also validated to be an account, not a contract (`validate_admin_address`). The transfer still only completes on `accept_admin`. |
 | `accept_admin`                  | ✅ | ✅ (must match `PendingAdmin`) | Two-step transfer. |
 | `cancel_admin_transfer`          | ✅ | ✅ | Cancels a pending `propose_admin`. |
 | `initialize_market`             | ✅ | ✅ | |

--- a/contracts/market/src/deposit.rs
+++ b/contracts/market/src/deposit.rs
@@ -208,7 +208,7 @@ pub fn deposit_collateral(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::Market;
+    use crate::types::{AdapterType, Market};
     use soroban_sdk::token::StellarAssetClient;
     use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
 
@@ -764,5 +764,74 @@ mod tests {
             Err(ContractError::ArithmeticOverflow),
             "overflow in total_deposited accumulation must return ArithmeticOverflow, not panic"
         );
+    }
+
+    // --- #501 / #709: deposit reentrancy guard ---
+
+    /// Regression test for the deposit reentrancy guard (#501, #709).
+    ///
+    /// The lock is held for the whole `deposit_collateral` call, wrapping the
+    /// external collateral-token `transfer`. A malicious or upgraded token
+    /// contract that calls back into `deposit_collateral` from inside its
+    /// `transfer` implementation lands on exactly this lock. Simulating the
+    /// lock being already held (as it would be during that reentrant call)
+    /// must make `deposit_collateral` fail closed with `ReentrantCall`. If
+    /// `DepositReentrancyGuard::acquire` is ever removed, this test fails.
+    #[test]
+    fn test_deposit_rejected_while_reentrancy_lock_held() {
+        let env = setup_env();
+        let user = Address::generate(&env);
+        let market_id = 1;
+        let collateral_token = Address::generate(&env);
+        let contract_id = env.register(crate::MarketContract, ());
+
+        let market = create_test_market(&env, market_id, &collateral_token);
+        env.as_contract(&contract_id, || {
+            storage::set_version(&env);
+            storage::set_market(&env, market_id, &market).unwrap();
+            // Simulate being mid-transfer inside an outer deposit call.
+            storage::set_deposit_locked(&env, true);
+        });
+        env.mock_all_auths();
+
+        let result = env.as_contract(&contract_id, || {
+            deposit_collateral(env.clone(), user.clone(), market_id, 5_000)
+        });
+        assert_eq!(result, Err(ContractError::ReentrantCall));
+    }
+
+    /// The lock must be released once the deposit returns (RAII `Drop`), so a
+    /// legitimate follow-up deposit still works. Guards against a regression
+    /// that leaves the lock stuck set.
+    #[test]
+    fn test_deposit_lock_released_after_successful_deposit() {
+        let env = setup_env();
+        let user = Address::generate(&env);
+        let market_id = 1;
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let collateral_token = token.address();
+        let contract_id = env.register(crate::MarketContract, ());
+
+        let market = create_test_market(&env, market_id, &collateral_token);
+        env.as_contract(&contract_id, || {
+            storage::set_version(&env);
+            storage::set_market(&env, market_id, &market).unwrap();
+        });
+        env.mock_all_auths();
+        StellarAssetClient::new(&env, &collateral_token).mint(&user, &20_000);
+
+        env.as_contract(&contract_id, || {
+            deposit_collateral(env.clone(), user.clone(), market_id, 5_000).unwrap();
+        });
+
+        let locked = env.as_contract(&contract_id, || storage::is_deposit_locked(&env));
+        assert!(!locked, "deposit lock must be cleared after the call returns");
+
+        // Second deposit still succeeds now that the lock is clear.
+        let result = env.as_contract(&contract_id, || {
+            deposit_collateral(env.clone(), user.clone(), market_id, 1_000)
+        });
+        assert!(result.is_ok());
     }
 }

--- a/contracts/market/src/events.rs
+++ b/contracts/market/src/events.rs
@@ -1434,7 +1434,7 @@ mod tests {
         let end_time = 1234567890u64;
 
         env.as_contract(&contract_id, || {
-            emit_market_created(&env, market_id, &creator, &question, end_time);
+            emit_market_created(&env, market_id, &creator, &question, end_time, &None);
         });
 
         // Verify event was published
@@ -1920,5 +1920,51 @@ mod tests {
             .into_val(&env);
         assert_eq!(fee_val, fee_amount);
         assert_eq!(available_val, available_after_fee);
+    }
+
+    /// #710: `market_closed_to_deposits` must expose the canonical topic set
+    /// off-chain indexer mappings key on — `[event_name, version, market_id]`
+    /// — with `admin` and `closed_at` in the data payload. Locks the wire
+    /// shape so an indexer mapping written against it cannot silently break.
+    #[test]
+    fn test_emit_market_closed_to_deposits() {
+        let env = Env::default();
+        let contract_id = env.register(MarketContract, ());
+
+        let market_id = 42u32;
+        let admin = Address::generate(&env);
+        let closed_at = 1_700_000_123u64;
+
+        env.as_contract(&contract_id, || {
+            emit_market_closed_to_deposits(&env, market_id, &admin, closed_at);
+        });
+
+        let events = env.events().all();
+        assert_eq!(events.len(), 1);
+
+        let event = events.first().unwrap();
+        let topics = &event.1;
+        assert_eq!(topics.len(), 3);
+
+        let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+        assert_eq!(topic0, Symbol::new(&env, "market_closed_to_deposits"));
+
+        let topic1: u32 = topics.get(1).unwrap().into_val(&env);
+        assert_eq!(topic1, EVENT_VERSION);
+
+        let topic2: u32 = topics.get(2).unwrap().into_val(&env);
+        assert_eq!(topic2, market_id);
+
+        let data: Map<Symbol, Val> = event.2.try_into_val(&env).unwrap();
+        let admin_val: Address = data
+            .get(Symbol::new(&env, "admin"))
+            .unwrap()
+            .into_val(&env);
+        let closed_at_val: u64 = data
+            .get(Symbol::new(&env, "closed_at"))
+            .unwrap()
+            .into_val(&env);
+        assert_eq!(admin_val, admin);
+        assert_eq!(closed_at_val, closed_at);
     }
 }

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -281,6 +281,18 @@ impl MarketContract {
         if current_admin != stored_admin {
             return Err(ContractError::NotAdmin);
         }
+
+        // 4. The current admin must actually authorize this call. Without this
+        //    a bad merge previously left `propose_admin` unauthenticated:
+        //    `current_admin` is a plain parameter, so anyone could pass the
+        //    real admin's address, nominate themselves, then self-`accept_admin`
+        //    (which only checks the *new* admin's auth) to seize the contract.
+        current_admin.require_auth();
+
+        // 5. Reject a contract address as the nominee (mirrors `initialize`);
+        //    `accept_admin` cannot `require_auth` a contract that never signs.
+        validation::validate_admin_address(&new_admin)?;
+
         storage::set_pending_admin(&env, &new_admin);
         events::emit_admin_transfer_proposed(&env, &current_admin, &new_admin);
 

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -1657,6 +1657,95 @@ mod test {
         });
     }
 
+    /// #705: proposing a new admin must NOT move the admin role. Only
+    /// `accept_admin`, called by the nominee, completes the transfer. A
+    /// single-step design (or docs/tests implying one) would hand control to
+    /// the nominee — or strand it — the instant `propose_admin` runs.
+    #[test]
+    fn test_propose_admin_alone_does_not_change_current_admin() {
+        let (env, admin, client, contract_id) = create_test_contract();
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+
+        // Stored admin is still the original.
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                storage::get_admin(&env).unwrap(),
+                admin,
+                "current admin must be unchanged until the nominee calls accept_admin"
+            );
+        });
+
+        let question = String::from_str(&env, "still admin?");
+        let end_time = env.ledger().timestamp() + 86_400;
+        let oracle_pubkey = BytesN::from_array(&env, &[9u8; 32]);
+        let collateral_token = Address::generate(&env);
+
+        // The original admin still holds admin powers.
+        let market_id = client.initialize_market(
+            &admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &collateral_token,
+            &None,
+        );
+        assert_eq!(market_id, 1);
+
+        // The pending nominee has no admin powers yet.
+        let res = client.try_initialize_market(
+            &new_admin,
+            &question,
+            &end_time,
+            &oracle_pubkey,
+            &collateral_token,
+            &None,
+        );
+        assert!(
+            res.is_err(),
+            "pending admin must not have admin powers before acceptance"
+        );
+
+        // After acceptance the role finally moves.
+        client.accept_admin(&new_admin);
+        env.as_contract(&contract_id, || {
+            assert_eq!(storage::get_admin(&env).unwrap(), new_admin);
+        });
+    }
+
+    /// #705 / audit readiness: `propose_admin` must require the current
+    /// admin's authorization. Previously it did not — `current_admin` is a
+    /// plain parameter, so anyone could pass the real admin's address,
+    /// nominate themselves, then self-`accept_admin` (which only checks the
+    /// *new* admin's signature) to seize the contract.
+    #[test]
+    fn test_propose_admin_requires_current_admin_auth() {
+        let env = Env::default();
+        // NOTE: deliberately no env.mock_all_auths().
+        let contract_id = env.register(MarketContract, ());
+        let client = MarketContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            storage::set_admin(&env, &admin);
+            storage::set_version(&env);
+        });
+
+        let attacker = Address::generate(&env);
+        let res = client.try_propose_admin(&admin, &attacker);
+        assert!(
+            res.is_err(),
+            "propose_admin must fail when the current admin has not authorized the call"
+        );
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                storage::get_pending_admin(&env).is_none(),
+                "no nomination may be recorded without the current admin's auth"
+            );
+        });
+    }
+
     #[test]
     fn test_propose_admin_emits_event() {
         let (env, admin, client, _contract_id) = create_test_contract();

--- a/contracts/market/src/withdraw.rs
+++ b/contracts/market/src/withdraw.rs
@@ -196,11 +196,9 @@ pub fn withdraw_unused_collateral(
         }
     }
 
-    // 9. Transfer the requested amount to the user
-    token_client.transfer(&contract_address, &user, &amount);
-
-  
-    // 9. Transfer the requested amount to the user.
+    // 9. Transfer the requested amount to the user (single external payout —
+    //    a prior bad merge left this `transfer` call duplicated, which would
+    //    double-pay the user and drain the contract's collateral balance).
     token_client.transfer(&contract_address, &user, &amount);
 
     emit_collateral_withdrawn(&env, &user, market_id, amount, position.total_deposited);
@@ -652,6 +650,126 @@ mod tests {
         assert!(
             !has_retained_event,
             "FeeRetainedNoTreasury must not fire when a treasury is registered"
+        );
+    }
+
+    /// #711: when the withdraw fee path invokes the treasury's `collect_fee`,
+    /// the treasury's canonical `fee_collected` event must be emitted with the
+    /// `market_id` topic and a `fee_amount` matching what the user was
+    /// actually charged. Guards the indexer-facing event schema against a
+    /// regression where the fee is transferred but no matching event fires.
+    #[test]
+    fn test_withdraw_emits_fee_collected_from_treasury_path() {
+        use soroban_sdk::testutils::Events as _;
+        use soroban_sdk::token::StellarAssetClient;
+        use soroban_sdk::{IntoVal, Map, Symbol, TryIntoVal, Val};
+        use vatix_treasury_contract::{TreasuryContract, TreasuryContractClient};
+
+        let env = setup_env();
+        let user = Address::generate(&env);
+        let market_id = 1u32;
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin).address();
+        let contract_id = env.register(crate::MarketContract, ());
+        let market = create_test_market(&env, market_id, &token);
+        let position = Position {
+            market_id,
+            user: user.clone(),
+            yes_shares: 0,
+            no_shares: 0,
+            locked_collateral: 0,
+            total_deposited: 100,
+            is_settled: false,
+        };
+        let admin = Address::generate(&env);
+        let treasury_addr = env.register(TreasuryContract, ());
+        TreasuryContractClient::new(&env, &treasury_addr).initialize(&admin, &contract_id);
+
+        env.as_contract(&contract_id, || {
+            storage::set_version(&env);
+            storage::set_market(&env, market_id, &market).unwrap();
+            storage::set_position(&env, market_id, &user, &position).unwrap();
+            storage::set_fee_rate_bps(&env, 1_000); // 10%
+            storage::set_treasury(&env, &treasury_addr);
+        });
+        env.mock_all_auths();
+        StellarAssetClient::new(&env, &token).mint(&contract_id, &200);
+
+        env.as_contract(&contract_id, || {
+            withdraw_unused_collateral(env.clone(), user.clone(), market_id, 40).unwrap();
+        });
+
+        // Locate the treasury's `fee_collected` event among everything emitted
+        // during the withdraw (it is not the last event).
+        let events = env.events().all();
+        let fee_collected = events.iter().find(|(_, topics, _)| {
+            let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+            topic0 == Symbol::new(&env, "fee_collected")
+        });
+        let (_, topics, data) = fee_collected.expect("fee_collected event must be emitted");
+
+        let mid: u32 = topics.get(1).unwrap().into_val(&env);
+        assert_eq!(mid, market_id, "fee_collected must carry the market_id topic");
+
+        let data: Map<Symbol, Val> = data.clone().try_into_val(&env).unwrap();
+        let fee_amount: i128 = data
+            .get(Symbol::new(&env, "fee_amount"))
+            .unwrap()
+            .into_val(&env);
+        assert_eq!(fee_amount, 4, "fee_amount must match the 10% fee on a 40 withdraw");
+    }
+
+    /// #711: a zero-fee (or fee-waived) withdraw must not invoke `collect_fee`
+    /// at all — no `fee_collected` event, no misleading `amount = 0`.
+    #[test]
+    fn test_withdraw_zero_fee_emits_no_fee_collected() {
+        use soroban_sdk::testutils::Events as _;
+        use soroban_sdk::token::StellarAssetClient;
+        use soroban_sdk::{IntoVal, Symbol};
+        use vatix_treasury_contract::{TreasuryContract, TreasuryContractClient};
+
+        let env = setup_env();
+        let user = Address::generate(&env);
+        let market_id = 1u32;
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin).address();
+        let contract_id = env.register(crate::MarketContract, ());
+        let market = create_test_market(&env, market_id, &token);
+        let position = Position {
+            market_id,
+            user: user.clone(),
+            yes_shares: 0,
+            no_shares: 0,
+            locked_collateral: 0,
+            total_deposited: 100,
+            is_settled: false,
+        };
+        let admin = Address::generate(&env);
+        let treasury_addr = env.register(TreasuryContract, ());
+        TreasuryContractClient::new(&env, &treasury_addr).initialize(&admin, &contract_id);
+
+        env.as_contract(&contract_id, || {
+            storage::set_version(&env);
+            storage::set_market(&env, market_id, &market).unwrap();
+            storage::set_position(&env, market_id, &user, &position).unwrap();
+            storage::set_fee_rate_bps(&env, 0); // no fee
+            storage::set_treasury(&env, &treasury_addr);
+        });
+        env.mock_all_auths();
+        StellarAssetClient::new(&env, &token).mint(&contract_id, &200);
+
+        env.as_contract(&contract_id, || {
+            withdraw_unused_collateral(env.clone(), user.clone(), market_id, 40).unwrap();
+        });
+
+        let events = env.events().all();
+        let emitted_fee_collected = events.iter().any(|(_, topics, _)| {
+            let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+            topic0 == Symbol::new(&env, "fee_collected")
+        });
+        assert!(
+            !emitted_fee_collected,
+            "a zero-fee withdraw must not emit fee_collected"
         );
     }
 

--- a/docs/reentrancy-cei-audit.md
+++ b/docs/reentrancy-cei-audit.md
@@ -36,6 +36,7 @@
 ### 1. `withdraw_unused_collateral` (`withdraw.rs`)
 - **Before:** Fee routing (`token_client.transfer` and `env.invoke_contract`) was executed prior to updating `position.total_deposited` and persisting it with `storage::set_position`.
 - **After:** Decremented `position.total_deposited` and called `storage::set_position` **first**, satisfying CEI before making external token/treasury calls.
+- **Follow-up (#709):** A later bad merge left the final user payout `token_client.transfer(&contract_address, &user, &amount)` **duplicated**, which would pay the user twice and over-draw the contract's custodied collateral. The duplicate call was removed — the user payout is now a single external transfer, ordered after `set_position` and after the fee routing, as CEI requires.
 
 ### 2. `settle_position` (`settlement.rs`)
 - **Before:** Outcome tokens were burned via `burn_settled_outcome_tokens` (external contract calls) before persisting the updated `Position` state to storage.


### PR DESCRIPTION

## Summary

Closes the remaining gaps behind issues #705, #709, #710 and #711, all in the
`market` crate. The events, guards, CEI ordering and two-step admin flow those
issues describe were already implemented — the actual work here is (a) repairing
pre-existing breakage introduced by the parallel #805–#811 merges and (b) adding
regression tests so each gap fails loudly if it is ever reintroduced.

> ⚠️ **Not build-verified.** `dev` currently does not compile — `outcome-token`,
> `treasury` and `resolution` are broken from the #805–#811 merges, and `market`
> depends on them. This PR deliberately touches `market` only; it needs a green
> build once those crates are fixed (tracked separately).

## Pre-existing bugs fixed

| File | Bug | Fix |
|---|---|---|
| `contracts/market/src/withdraw.rs` | A bad merge left the user payout `token_client.transfer(&contract, &user, &amount)` **duplicated** — pays the user twice and over-draws the contract's custodied collateral. | Removed the duplicate call; the payout is a single external transfer, CEI-ordered after `set_position` and fee routing. |
| `contracts/market/src/lib.rs` (`propose_admin`) | Lost `current_admin.require_auth()` **and** `validate_admin_address(new_admin)` (both documented and test-covered). Privilege escalation: `current_admin` is a plain parameter, so anyone could pass the real admin's address, nominate themselves, then self-`accept_admin` (which only checks the *new* admin's signature) to seize the contract. | Restored both checks. |
| `contracts/market/src/deposit.rs` | Test module referenced `AdapterType` without importing it → module fails to compile. | Added `AdapterType` to the `use crate::types::{…}` import. |
| `contracts/market/src/events.rs` | `test_emit_market_created` called `emit_market_created` with 5 args; the signature takes 6 (`metadata_uri`) → fails to compile. | Passed `&None`. |

## Regression tests added

closes #709 — deposit reentrancy guard / CEI** (`deposit.rs`)
- `test_deposit_rejected_while_reentrancy_lock_held` — fails if `DepositReentrancyGuard::acquire` is removed.
- `test_deposit_lock_released_after_successful_deposit` — guards against a stuck lock.

closes #710 — MarketClosedToDeposits event fields** (`events.rs`)
- `test_emit_market_closed_to_deposits` — locks the canonical indexer topic set `[market_closed_to_deposits, version, market_id]` and the `admin` / `closed_at` payload.

closes #711 — FeeCollected on wired collect_fee** (`withdraw.rs`)
- `test_withdraw_emits_fee_collected_from_treasury_path` — asserts the treasury `fee_collected` event fires from the withdraw path with matching `market_id` / `fee_amount`.
- `test_withdraw_zero_fee_emits_no_fee_collected` — a zero-fee withdraw must not invoke `collect_fee` or emit the event.

closes #705 — two-step admin transfer** (`test.rs`)
- `test_propose_admin_alone_does_not_change_current_admin` — the "single-step admin loss" gap: the admin role only moves on `accept_admin`; the old admin stays fully authorized until then, the nominee has no powers before acceptance.
- `test_propose_admin_requires_current_admin_auth` — the current admin must authorize the nomination.

## Docs

- `AUTH_TABLE.md` — `propose_admin` now shows `require_auth ✅` plus nominee validation.
- `docs/reentrancy-cei-audit.md` — noted the duplicate-transfer follow-up under `withdraw_unused_collateral`.
- `docs/events-reference.md` — already documented `market_closed_to_deposits` and `fee_collected` correctly; no change.

## Acceptance criteria

- [x] Automated tests fail if any of the four gaps is reintroduced.
- [x] Docs (AUTH_TABLE, events-reference, CEI audit) match the production ABI.
- [x] No new instant admin mutators without timelock.
- [x] No `panic!`/`todo!()` added on shipped library paths.
- [ ] `cargo test` green — **blocked** on the broken `outcome-token`/`treasury`/`resolution` crates (out of scope for this PR).
