### PR TITLE
fix(treasury): stop execute_market_contract from wiping AuthorizedMar…

### DIFF
--- a/AUTH_TABLE.md
+++ b/AUTH_TABLE.md
@@ -62,7 +62,7 @@ are out of scope for this table.
 | `propose_admin` / `execute_admin` / `cancel_admin` | propose ✅, execute —, cancel ✅ | propose ✅, cancel ✅, execute n/a | 48h timelock (`ADDRESS_TIMELOCK_SECONDS`) admin rotation. |
 | `add_market`           | ✅ | ✅ | |
 | `remove_market`        | ✅ | ✅ | |
-| `propose_market_contract` / `execute_market_contract` / `cancel_market_contract` | propose ✅, execute —, cancel ✅ | propose ✅, cancel ✅, execute n/a | Timelocked market-contract rotation. |
+| `propose_market_contract` / `execute_market_contract` / `cancel_market_contract` | propose ✅, execute —, cancel ✅ | propose ✅, cancel ✅, execute n/a | Timelocked market-contract rotation. **Fixed by #720**: `execute_market_contract` used to overwrite the entire `AuthorizedMarkets` registry with a single-element vec, silently deregistering every market previously added via `add_market` (no `market_removed` event, no error) — registry drift between the two entrypoints that both mutate `AuthorizedMarkets`. It now appends idempotently, matching `add_market`. |
 | `pause` / `unpause`    | ✅ | ✅ | |
 | `set_emergency_mode`   | ✅ | ✅ | Mirrors the Market/Resolution coordinated mode (#662). |
 | `set_stakeholders`     | ✅ | ✅ | Share weights must sum to exactly 10,000 bps. |

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -365,8 +365,19 @@ impl TreasuryContract {
             return Err(TreasuryError::Unauthorized);
         }
 
-        let markets = soroban_sdk::vec![&env, pending.new_address.clone()];
-        storage::set_authorized_markets(&env, &markets);
+        // Append rather than replace (#720): this entrypoint and
+        // `add_market`/`remove_market` both mutate the single
+        // `AuthorizedMarkets` registry. Overwriting it with a fresh
+        // single-element vec here used to silently deregister every other
+        // market added via `add_market` — including markets still live and
+        // routing fees through this treasury — with no `market_removed`
+        // event to signal the drop. Matching `add_market`'s idempotent
+        // append keeps the two entrypoints consistent with one registry.
+        let mut markets = storage::get_authorized_markets(&env);
+        if !markets.contains(&pending.new_address) {
+            markets.push_back(pending.new_address.clone());
+            storage::set_authorized_markets(&env, &markets);
+        }
         storage::clear_pending_market_contract(&env);
 
         events::emit_market_contract_set(&env, &pending.new_address);

--- a/contracts/treasury/src/test.rs
+++ b/contracts/treasury/src/test.rs
@@ -495,6 +495,90 @@ fn multiple_markets_can_each_collect_fees() {
     assert_eq!(s.client.get_cumulative_fees(&s.token), 300);
 }
 
+// ── propose_market_contract / execute_market_contract (timelocked, #720) ──────
+
+#[test]
+fn execute_market_contract_preserves_previously_added_markets() {
+    // Regression for #720: `execute_market_contract` used to overwrite the
+    // whole `AuthorizedMarkets` registry with a single-element vec, silently
+    // deregistering every market added via `add_market`. It must now append,
+    // just like `add_market` does, so the two entrypoints agree on one
+    // registry instead of drifting apart.
+    let s = setup();
+    let market2 = Address::generate(&s.env);
+    let market3 = Address::generate(&s.env);
+    s.client.add_market(&s.admin, &market2);
+
+    s.client.propose_market_contract(&s.admin, &market3);
+    s.env.ledger().with_mut(|li| {
+        li.timestamp += crate::ADDRESS_TIMELOCK_SECONDS + 1;
+    });
+    s.client.execute_market_contract();
+
+    assert!(s.client.is_authorized_market(&s.market));
+    assert!(s.client.is_authorized_market(&market2));
+    assert!(s.client.is_authorized_market(&market3));
+    assert_eq!(s.client.list_markets().len(), 3);
+
+    // The originally-registered market must still be able to collect fees —
+    // this is the concrete symptom the drift caused: a live market silently
+    // losing `collect_fee` access with no `remove_market` call or event.
+    s.client.collect_fee(&s.market, &s.token, &1u32, &1_000i128);
+    assert_eq!(s.client.token_balance(&s.token), 1_000i128);
+}
+
+#[test]
+fn execute_market_contract_is_idempotent_for_already_authorized_market() {
+    let s = setup();
+    s.client.propose_market_contract(&s.admin, &s.market);
+    s.env.ledger().with_mut(|li| {
+        li.timestamp += crate::ADDRESS_TIMELOCK_SECONDS + 1;
+    });
+    s.client.execute_market_contract();
+
+    assert_eq!(s.client.list_markets().len(), 1);
+    assert!(s.client.is_authorized_market(&s.market));
+}
+
+#[test]
+fn execute_market_contract_rejects_before_timelock_elapses() {
+    let s = setup();
+    let market2 = Address::generate(&s.env);
+    s.client.propose_market_contract(&s.admin, &market2);
+
+    let err = s.client.try_execute_market_contract().unwrap_err().unwrap();
+    assert_eq!(err, TreasuryError::Unauthorized);
+    assert!(!s.client.is_authorized_market(&market2));
+}
+
+#[test]
+fn propose_market_contract_rejects_non_admin() {
+    let s = setup();
+    let rando = Address::generate(&s.env);
+    let market2 = Address::generate(&s.env);
+    let err = s
+        .client
+        .try_propose_market_contract(&rando, &market2)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, TreasuryError::Unauthorized);
+}
+
+#[test]
+fn cancel_market_contract_clears_pending_change() {
+    let s = setup();
+    let market2 = Address::generate(&s.env);
+    s.client.propose_market_contract(&s.admin, &market2);
+    s.client.cancel_market_contract(&s.admin);
+
+    s.env.ledger().with_mut(|li| {
+        li.timestamp += crate::ADDRESS_TIMELOCK_SECONDS + 1;
+    });
+    let err = s.client.try_execute_market_contract().unwrap_err().unwrap();
+    assert_eq!(err, TreasuryError::Unauthorized);
+    assert!(!s.client.is_authorized_market(&market2));
+}
+
 // ── propose_admin / execute_admin (timelocked, #658) ───────────────────────────
 
 #[test]


### PR DESCRIPTION
…kets

execute_market_contract (the timelocked market-contract rotation path) overwrote the whole AuthorizedMarkets registry with a fresh single-element vec, silently deregistering every market previously added via add_market -- with no market_removed event and no error. The two entrypoints mutate the same storage key but disagreed on whether it's a single value or an incremental set, causing registry drift: a legitimate, still-live market could lose collect_fee access with no trace.

execute_market_contract now appends idempotently instead, matching add_market's semantics, so both entrypoints agree on one registry.

Adds regression coverage reproducing the wipe, plus baseline propose/execute/cancel_market_contract tests that had no coverage at all before this change.

Fixes #720
closes #720 