### PR TITLE
fix(treasury): restore stakeholder test compilation, fix double-payou…

### DIFF
--- a/AUTH_TABLE.md
+++ b/AUTH_TABLE.md
@@ -65,8 +65,8 @@ are out of scope for this table.
 | `propose_market_contract` / `execute_market_contract` / `cancel_market_contract` | propose ✅, execute —, cancel ✅ | propose ✅, cancel ✅, execute n/a | Timelocked market-contract rotation. |
 | `pause` / `unpause`    | ✅ | ✅ | |
 | `set_emergency_mode`   | ✅ | ✅ | Mirrors the Market/Resolution coordinated mode (#662). |
-| `set_stakeholders`     | ✅ | ✅ | Share weights must sum to exactly 10,000 bps. |
-| `distribute_fees`      | ✅ | ✅ | |
+| `propose_stakeholders` / `execute_stakeholders` / `cancel_stakeholders` | propose ✅, execute —, cancel ✅ | propose ✅, cancel ✅, execute n/a | Timelocked (#689) stakeholder revenue-share list. `propose_stakeholders` rejects an empty list or shares not summing to exactly 10,000 bps with `InvalidStakeholderWeights` (#721). Table entry was still named `set_stakeholders` (its pre-#689 name) until this pass — kept in sync now. |
+| `distribute_fees`      | ✅ | ✅ | Rejects with `NoStakeholdersConfigured` if `propose_stakeholders`/`execute_stakeholders` has never installed a list. **Fixed by #721**: the payout loop pushed each stakeholder's transfer onto the payout list twice, so every stakeholder was paid double the intended amount while the treasury's own ledger (`distributed`/`remaining`) only accounted for a single payment — found via the `test.rs`/`distribute_proptest.rs` fallout from the `set_stakeholders` → `propose_stakeholders` rename (#689), which had left those test files referencing a removed client method and unable to compile at all, masking the bug. |
 
 `collect_fee` requires auth from `caller` but intentionally checks
 *registered-market* membership (`is_authorized_market`) rather than admin

--- a/contracts/treasury/src/distribute_proptest.rs
+++ b/contracts/treasury/src/distribute_proptest.rs
@@ -9,7 +9,7 @@
 
 use proptest::prelude::*;
 use soroban_sdk::{
-    testutils::Address as _,
+    testutils::{Address as _, Ledger as _},
     token::{Client as TokenClient, StellarAssetClient},
     Address, Env,
 };
@@ -53,11 +53,19 @@ fn fund_and_collect(s: &Setup, amount: i128) {
     s.client.collect_fee(&s.market, &s.token, &1u32, &amount);
 }
 
+fn propose_and_execute_stakeholders(s: &Setup, stakeholders: &soroban_sdk::Vec<(Address, u32)>) {
+    s.client.propose_stakeholders(&s.admin, stakeholders);
+    s.env.ledger().with_mut(|li| {
+        li.timestamp += crate::ADDRESS_TIMELOCK_SECONDS + 1;
+    });
+    s.client.execute_stakeholders();
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(300))]
 
     /// Invariant: for a 3-way stakeholder split (shares summing to exactly
-    /// `BPS_DENOMINATOR`, matching `set_stakeholders`' validation) and any
+    /// `BPS_DENOMINATOR`, matching `propose_stakeholders`' validation) and any
     /// realistic fee balance, the sum of every stakeholder payout plus the
     /// remaining treasury balance equals the pre-distribution balance
     /// exactly — no value is created or silently dropped.
@@ -68,7 +76,7 @@ proptest! {
         share_b_raw in 1u32..=9_998u32,
     ) {
         // Derive three non-zero shares that sum to exactly BPS_DENOMINATOR
-        // (the same invariant `set_stakeholders` enforces).
+        // (the same invariant `propose_stakeholders` enforces).
         let remaining_after_a = BPS_DENOMINATOR - share_a;
         prop_assume!(remaining_after_a >= 2);
         let share_b = 1 + (share_b_raw % (remaining_after_a - 1));
@@ -85,7 +93,7 @@ proptest! {
         stakeholders.push_back((stakeholder_a.clone(), share_a));
         stakeholders.push_back((stakeholder_b.clone(), share_b));
         stakeholders.push_back((stakeholder_c.clone(), share_c));
-        s.client.set_stakeholders(&s.admin, &stakeholders);
+        propose_and_execute_stakeholders(&s, &stakeholders);
 
         s.client.distribute_fees(&s.admin, &s.token);
 
@@ -134,7 +142,7 @@ proptest! {
         let mut stakeholders = soroban_sdk::Vec::new(&s.env);
         stakeholders.push_back((stakeholder_a.clone(), share_a));
         stakeholders.push_back((stakeholder_b.clone(), share_b));
-        s.client.set_stakeholders(&s.admin, &stakeholders);
+        propose_and_execute_stakeholders(&s, &stakeholders);
 
         s.client.distribute_fees(&s.admin, &s.token);
 
@@ -160,7 +168,7 @@ proptest! {
         let stakeholder = Address::generate(&s.env);
         let mut stakeholders = soroban_sdk::Vec::new(&s.env);
         stakeholders.push_back((stakeholder.clone(), BPS_DENOMINATOR));
-        s.client.set_stakeholders(&s.admin, &stakeholders);
+        propose_and_execute_stakeholders(&s, &stakeholders);
 
         s.client.distribute_fees(&s.admin, &s.token);
 

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -16,8 +16,8 @@
 //! | `collect_fee`                      | registered market contract|
 //! | `withdraw_fees`                    | admin                     |
 //! | `add_market` / `remove_market`     | admin                     |
-//! | `set_market_contract`              | admin                     |
-//! | `set_stakeholders`                 | admin                     |
+//! | `propose_market_contract` / `execute_market_contract` | admin (propose), timelock (execute) |
+//! | `propose_stakeholders` / `execute_stakeholders` | admin (propose), timelock (execute) |
 //! | `distribute_fees`                  | admin                     |
 //! | Getters                            | anyone                    |
 //!
@@ -581,8 +581,8 @@ impl TreasuryContract {
     /// - [`TreasuryError::NotInitialized`] – treasury not initialized.
     /// - [`TreasuryError::ContractPaused`] – treasury is paused.
     /// - [`TreasuryError::Unauthorized`] – caller is not the admin.
-    /// - [`TreasuryError::NoStakeholdersConfigured`] – `set_stakeholders` has
-    ///   never been called.
+    /// - [`TreasuryError::NoStakeholdersConfigured`] – `propose_stakeholders`
+    ///   / `execute_stakeholders` has never installed a list.
     /// - [`TreasuryError::InsufficientBalance`] – the current `token` balance is zero.
     pub fn distribute_fees(env: Env, caller: Address, token: Address) -> Result<(), TreasuryError> {
         caller.require_auth();
@@ -624,6 +624,11 @@ impl TreasuryContract {
         // every transfer had already gone out — a reentrant call back into
         // a balance-reading entry point mid-loop would have observed the
         // stale, not-yet-decremented balance.
+        // Each stakeholder must appear exactly once in `payouts` — a second
+        // push here would double the real token transfer below while
+        // `distributed`/`remaining` still accounted for only one, silently
+        // overpaying every stakeholder by 2x relative to the treasury's own
+        // ledger (#721).
         let mut payouts: Vec<(Address, i128)> = Vec::new(&env);
         let mut distributed: i128 = 0;
         for (stakeholder, share_bps) in stakeholders.iter() {
@@ -636,7 +641,6 @@ impl TreasuryContract {
                 distributed = distributed
                     .checked_add(amount)
                     .ok_or(TreasuryError::ArithmeticOverflow)?;
-                payouts.push_back((stakeholder, amount));
             }
         }
 

--- a/contracts/treasury/src/test.rs
+++ b/contracts/treasury/src/test.rs
@@ -734,7 +734,7 @@ fn collect_fee_resumes_after_unpause() {
 // ── stakeholder fee distribution (#485) ───────────────────────────────────────
 
 #[test]
-fn set_stakeholders_rejects_weights_not_summing_to_10000() {
+fn propose_stakeholders_rejects_weights_not_summing_to_10000() {
     let s = setup();
     let a = Address::generate(&s.env);
     let b = Address::generate(&s.env);
@@ -744,14 +744,31 @@ fn set_stakeholders_rejects_weights_not_summing_to_10000() {
 
     let err = s
         .client
-        .try_set_stakeholders(&s.admin, &stakeholders)
+        .try_propose_stakeholders(&s.admin, &stakeholders)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, TreasuryError::InvalidStakeholderWeights);
+}
+
+/// Regression for #721: an empty stakeholder list must be rejected at
+/// `propose_stakeholders` with a typed error, not silently accepted (which
+/// would let `execute_stakeholders` install an empty list and leave
+/// `distribute_fees` to reject later, or worse, not reject at all).
+#[test]
+fn propose_stakeholders_rejects_empty_list() {
+    let s = setup();
+    let empty: soroban_sdk::Vec<(Address, u32)> = soroban_sdk::Vec::new(&s.env);
+
+    let err = s
+        .client
+        .try_propose_stakeholders(&s.admin, &empty)
         .unwrap_err()
         .unwrap();
     assert_eq!(err, TreasuryError::InvalidStakeholderWeights);
 }
 
 #[test]
-fn set_stakeholders_rejects_non_admin() {
+fn propose_stakeholders_rejects_non_admin() {
     let s = setup();
     let rando = Address::generate(&s.env);
     let a = Address::generate(&s.env);
@@ -760,10 +777,18 @@ fn set_stakeholders_rejects_non_admin() {
 
     let err = s
         .client
-        .try_set_stakeholders(&rando, &stakeholders)
+        .try_propose_stakeholders(&rando, &stakeholders)
         .unwrap_err()
         .unwrap();
     assert_eq!(err, TreasuryError::Unauthorized);
+}
+
+fn propose_and_execute_stakeholders(s: &Setup, stakeholders: &soroban_sdk::Vec<(Address, u32)>) {
+    s.client.propose_stakeholders(&s.admin, stakeholders);
+    s.env.ledger().with_mut(|li| {
+        li.timestamp += crate::ADDRESS_TIMELOCK_SECONDS + 1;
+    });
+    s.client.execute_stakeholders();
 }
 
 #[test]
@@ -777,7 +802,7 @@ fn distribute_fees_pays_out_by_share() {
     let mut stakeholders = soroban_sdk::Vec::new(&s.env);
     stakeholders.push_back((stakeholder_a.clone(), 7_000u32));
     stakeholders.push_back((stakeholder_b.clone(), 3_000u32));
-    s.client.set_stakeholders(&s.admin, &stakeholders);
+    propose_and_execute_stakeholders(&s, &stakeholders);
 
     s.client.distribute_fees(&s.admin, &s.token);
 
@@ -786,6 +811,34 @@ fn distribute_fees_pays_out_by_share() {
     assert_eq!(s.client.token_balance(&s.token), 0);
     // Cumulative fees stay monotone — distribution only moves the live balance.
     assert_eq!(s.client.get_cumulative_fees(&s.token), 1_000_000);
+}
+
+/// Regression for #721: the payout loop used to push each stakeholder onto
+/// the transfer list twice, doubling every real token transfer while the
+/// treasury's own ledger (`distributed`/`remaining`) accounted for only one
+/// payment. A single-stakeholder, 100%-share distribution makes the bug
+/// unmistakable: with the bug, the second `token_client.transfer` for the
+/// same stakeholder would attempt to move funds already fully paid out
+/// (panicking on insufficient real balance once the treasury's actual token
+/// balance is exhausted), and any surviving distribution would leave the
+/// stakeholder short by exactly what they were shorted elsewhere or would
+/// double what they're due — either way, the exact-value assertion below
+/// only holds without the bug.
+#[test]
+fn distribute_fees_pays_exact_share_not_double() {
+    let s = setup();
+    fund_treasury(&s, 250_000);
+    s.client.collect_fee(&s.market, &s.token, &1u32, &250_000i128);
+
+    let stakeholder = Address::generate(&s.env);
+    let mut stakeholders = soroban_sdk::Vec::new(&s.env);
+    stakeholders.push_back((stakeholder.clone(), 10_000u32));
+    propose_and_execute_stakeholders(&s, &stakeholders);
+
+    s.client.distribute_fees(&s.admin, &s.token);
+
+    assert_eq!(TokenClient::new(&s.env, &s.token).balance(&stakeholder), 250_000);
+    assert_eq!(s.client.token_balance(&s.token), 0);
 }
 
 #[test]
@@ -800,6 +853,8 @@ fn distribute_fees_rejects_without_stakeholders_configured() {
         .unwrap_err()
         .unwrap();
     assert_eq!(err, TreasuryError::NoStakeholdersConfigured);
+    // A rejected distribution must move no funds.
+    assert_eq!(s.client.token_balance(&s.token), 500_000);
 }
 
 #[test]
@@ -808,7 +863,7 @@ fn distribute_fees_rejects_zero_balance() {
     let stakeholder = Address::generate(&s.env);
     let mut stakeholders = soroban_sdk::Vec::new(&s.env);
     stakeholders.push_back((stakeholder, 10_000u32));
-    s.client.set_stakeholders(&s.admin, &stakeholders);
+    propose_and_execute_stakeholders(&s, &stakeholders);
 
     let err = s
         .client
@@ -826,7 +881,7 @@ fn distribute_fees_rejects_non_admin() {
     let stakeholder = Address::generate(&s.env);
     let mut stakeholders = soroban_sdk::Vec::new(&s.env);
     stakeholders.push_back((stakeholder, 10_000u32));
-    s.client.set_stakeholders(&s.admin, &stakeholders);
+    propose_and_execute_stakeholders(&s, &stakeholders);
 
     let rando = Address::generate(&s.env);
     let err = s
@@ -845,7 +900,7 @@ fn distribute_fees_blocked_while_paused() {
     let stakeholder = Address::generate(&s.env);
     let mut stakeholders = soroban_sdk::Vec::new(&s.env);
     stakeholders.push_back((stakeholder, 10_000u32));
-    s.client.set_stakeholders(&s.admin, &stakeholders);
+    propose_and_execute_stakeholders(&s, &stakeholders);
 
     s.client.pause(&s.admin);
     let err = s

--- a/docs/treasury-storage.md
+++ b/docs/treasury-storage.md
@@ -20,13 +20,13 @@
 | Key | Storage tier | Value type | Description |
 |-----|-------------|-----------|-------------|
 | `StorageVersion` | `instance` | `u32` | Written by `initialize`; guards against stale or uninitialized deployments. Every accessor calls `assert_version` before reading data. |
-| `Admin` | `instance` | `Address` | The address that may call `withdraw_fees` and other admin-only operations. Set once at initialization; transferable via `transfer_admin`. |
+| `Admin` | `instance` | `Address` | The address that may call `withdraw_fees` and other admin-only operations. Set once at initialization; transferable via the timelocked `propose_admin` / `execute_admin` / `cancel_admin` (#658). |
 | `AuthorizedMarkets` | `instance` | `Vec<Address>` | The set of market contract addresses allowed to call `collect_fee`. Managed via `add_market` / `remove_market`. Returns an empty list when unset (not an error). |
 | `TokenBalance(Address)` | `persistent` | `i128` | Current custodied balance for a specific collateral token. Increases on `collect_fee`, decreases on `withdraw_fees` / `distribute_fees`. Key parameter: token mint address. |
 | `CumulativeFees(Address)` | `persistent` | `i128` | Monotonically increasing historical total of all fees ever collected for a token. Never decreases — useful for off-chain accounting and audit trails. Key parameter: token mint address. |
 | `TotalCollected` | `instance` | `i128` | Global monotone counter: sum of all fees ever collected across every token. Never decreases. |
 | `Paused` | `instance` | `bool` | When `true`, `collect_fee` and `withdraw_fees` are blocked until an admin calls `unpause`. Defaults to `false` when unset. |
-| `Stakeholders` | `instance` | `Vec<(Address, u32)>` | Ordered list of `(stakeholder_address, share_bps)` pairs used by `distribute_fees` (#485). All `share_bps` values must sum to exactly `10_000`. Empty list when `set_stakeholders` has never been called. |
+| `Stakeholders` | `instance` | `Vec<(Address, u32)>` | Ordered list of `(stakeholder_address, share_bps)` pairs used by `distribute_fees` (#485). All `share_bps` values must sum to exactly `10_000`; an empty or non-summing list is rejected at `propose_stakeholders` time with `InvalidStakeholderWeights` (#721). Set via the timelocked `propose_stakeholders` / `execute_stakeholders` / `cancel_stakeholders` (#689). Empty list when no stakeholder change has ever executed — `distribute_fees` rejects with `NoStakeholdersConfigured` in that case. |
 | `FeeTokens` | `instance` | `Vec<Address>` | Registry of every distinct token mint that has ever had a fee routed through `collect_fee` (#484). Lets callers enumerate which tokens hold a balance without prior knowledge of token addresses. Append-only and idempotent — re-registering an already-known token is a no-op. |
 
 ---


### PR DESCRIPTION
…t bug

The set_stakeholders -> propose_stakeholders/execute_stakeholders timelock rename (#689) never updated test.rs or distribute_proptest.rs, which still called the removed client method. The treasury crate's test target has not compiled since that commit, so none of its unit tests or the distribute_fees proptests have run in CI.

Restoring compilation exposes a real bug in distribute_fees: the payout loop pushed each stakeholder's transfer onto the payout list twice, so every stakeholder was paid double the intended amount while the treasury's own ledger (distributed/remaining) accounted for only one payment. Fixed by removing the duplicate push.

Adds a regression test isolating the exact-share invariant, plus coverage for propose_stakeholders rejecting an empty list (#721's "Empty stakeholders + distribute should typed-error" -- already correctly typed-errors via InvalidStakeholderWeights at propose time and NoStakeholdersConfigured at distribute time; this just adds explicit test coverage now that the crate compiles again).

Updates AUTH_TABLE.md, the treasury module's own auth-model docstring, and docs/treasury-storage.md, all of which still referenced the pre-#689 set_stakeholders/set_market_contract/transfer_admin names.

Fixes #721
closes #721 