### PR TITLE
test(outcome-token): add decimals=7 SAC compatibility tests

### DIFF
--- a/contracts/outcome-token/src/error.rs
+++ b/contracts/outcome-token/src/error.rs
@@ -21,4 +21,14 @@ pub enum ContractError {
     /// `mint`/`burn`/`transfer` against a stale on-chain layout after a
     /// partial cross-contract upgrade instead of silently corrupting balances.
     UpgradeRequired = 8,
+    /// `execute_market_contract` was called but no pending rotation exists.
+    NoPendingMarketContractChange = 9,
+    /// The timelock delay for a pending `market_contract` rotation has not
+    /// elapsed yet.
+    TimelockNotElapsed = 10,
+    /// A peer-to-peer `transfer` was attempted after the market resolved.
+    /// Post-resolution transfers are blocked because settlement pays out
+    /// against the original depositor's position record, not the current
+    /// token holder (Issue #690).
+    TransferBlockedAfterResolve = 11,
 }

--- a/contracts/outcome-token/src/events.rs
+++ b/contracts/outcome-token/src/events.rs
@@ -100,6 +100,7 @@ pub fn emit_market_contract_set(env: &Env, market_contract: &Address) {
 
 #[contractevent]
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub struct TokenTransferred {
     #[topic]
     pub market_id: u32,
@@ -110,6 +111,7 @@ pub struct TokenTransferred {
     pub amount: i128,
 }
 
+#[allow(dead_code)]
 pub fn emit_token_transferred(
     env: &Env,
     market_id: u32,

--- a/contracts/outcome-token/src/lib.rs
+++ b/contracts/outcome-token/src/lib.rs
@@ -83,7 +83,7 @@ impl OutcomeTokenContract {
     ) -> Result<(), ContractError> {
         admin.require_auth();
         storage::assert_version(&env)?;
-        let mut config = storage::get_config(&env);
+        let config = storage::get_config(&env);
         if admin != config.admin {
             return Err(ContractError::Unauthorized);
         }
@@ -260,8 +260,8 @@ impl OutcomeTokenContract {
         env: Env,
         market_id: u32,
         from: Address,
-        to: Address,
-        kind: TokenKind,
+        _to: Address,
+        _kind: TokenKind,
         amount: i128,
     ) -> Result<(), ContractError> {
         if amount <= 0 {

--- a/contracts/outcome-token/src/storage.rs
+++ b/contracts/outcome-token/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::error::ContractError;
-use crate::types::{OutcomeTokenConfig, TokenKind};
+use crate::types::{OutcomeTokenConfig, PendingAddressChange, TokenKind};
 use soroban_sdk::{contracttype, Address, Env};
 
 /// Bump this constant whenever the outcome-token storage layout changes in a

--- a/contracts/outcome-token/src/test.rs
+++ b/contracts/outcome-token/src/test.rs
@@ -1,7 +1,7 @@
 use crate::types::TokenKind;
 use crate::{ContractError, OutcomeTokenContract, OutcomeTokenContractClient};
 use soroban_sdk::{
-    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
     Address, Env, IntoVal, String,
 };
 
@@ -328,26 +328,119 @@ fn balances_are_isolated_across_markets() {
     assert_eq!(client.total_supply(&2, &TokenKind::Yes), 200);
 }
 
-// ── set_market_contract ─────────────────────────────────────────────────────
+// ── propose/execute market_contract (timelock) ──────────────────────────────
 
 #[test]
-fn admin_can_update_market_contract() {
+fn admin_can_propose_and_execute_market_contract() {
     let env = Env::default();
+    env.mock_all_auths();
     let (client, admin, _old_market) = setup(&env);
     let new_market = Address::generate(&env);
 
-    client.set_market_contract(&admin, &new_market);
+    client.propose_market_contract(&admin, &new_market);
+
+    // Advance time past the timelock.
+    env.ledger()
+        .set_timestamp(OutcomeTokenContract::MARKET_CONTRACT_TIMELOCK_SECONDS + 1);
+
+    let applied = client.execute_market_contract();
+    assert_eq!(applied, new_market);
     assert_eq!(client.get_config().market_contract, new_market);
 }
 
 #[test]
-fn non_admin_cannot_update_market_contract() {
+fn non_admin_cannot_propose_market_contract() {
     let env = Env::default();
     let (client, _admin, _market) = setup(&env);
     let stranger = Address::generate(&env);
     let new_market = Address::generate(&env);
     assert_eq!(
-        client.try_set_market_contract(&stranger, &new_market),
+        client.try_propose_market_contract(&stranger, &new_market),
         Err(Ok(ContractError::Unauthorized))
+    );
+}
+
+// ── decimals SAC compatibility (#728) ────────────────────────────────────────
+//
+// The Stellar Asset Contract (SAC) standard fixes decimals at 7. Outcome
+// tokens must match that constant so that mint/burn amounts are scaled
+// consistently with the collateral token. A mismatch — e.g. decimals = 6 or
+// 8 — would silently corrupt the ratio between collateral deposited and
+// tokens minted whenever the market contract converts between the two.
+
+/// `decimals()` is a compile-time constant; it must equal 7 to be SAC-
+/// compatible.
+#[test]
+fn decimals_is_seven_sac_standard() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    assert_eq!(
+        client.decimals(),
+        7u32,
+        "decimals must be 7 to match the SAC standard"
+    );
+}
+
+/// One whole token at 7-decimal SAC precision equals 10_000_000 base units.
+/// Minting exactly that amount must produce the correct balance, confirming
+/// the contract treats the unit consistently with the SAC scale.
+#[test]
+fn mint_one_whole_token_at_sac_decimals() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    let user = Address::generate(&env);
+
+    // 1 token = 10^7 stroops (SAC 7-decimal unit).
+    let one_token: i128 = 10_000_000;
+    client.mint(&1, &user, &TokenKind::Yes, &one_token);
+
+    assert_eq!(client.balance(&1, &user, &TokenKind::Yes), one_token);
+    assert_eq!(client.total_supply(&1, &TokenKind::Yes), one_token);
+}
+
+/// The total supply across a batch of mints must accumulate correctly using
+/// 7-decimal SAC amounts, ensuring no precision loss in integer arithmetic.
+#[test]
+fn total_supply_accumulates_correctly_with_sac_amounts() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+
+    // 0.5 tokens and 1.5 tokens, expressed in 7-decimal SAC units.
+    let half_token: i128 = 5_000_000;
+    let one_half_token: i128 = 15_000_000;
+
+    client.mint(&1, &user_a, &TokenKind::Yes, &half_token);
+    client.mint(&1, &user_b, &TokenKind::Yes, &one_half_token);
+
+    assert_eq!(
+        client.total_supply(&1, &TokenKind::Yes),
+        half_token + one_half_token,
+        "total supply must equal the sum of all SAC-scaled mint amounts"
+    );
+}
+
+/// Burning a SAC-scaled amount must decrease supply by exactly that amount,
+/// with no rounding error.
+#[test]
+fn burn_sac_amount_reduces_supply_exactly() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    let user = Address::generate(&env);
+
+    let two_tokens: i128 = 20_000_000; // 2 * 10^7
+    let half_token: i128 = 5_000_000; // 0.5 * 10^7
+
+    client.mint(&1, &user, &TokenKind::Yes, &two_tokens);
+    client.burn(&1, &user, &TokenKind::Yes, &half_token);
+
+    assert_eq!(
+        client.balance(&1, &user, &TokenKind::Yes),
+        two_tokens - half_token,
+    );
+    assert_eq!(
+        client.total_supply(&1, &TokenKind::Yes),
+        two_tokens - half_token,
     );
 }


### PR DESCRIPTION
## Summary

Add SAC-compatibility tests verifying that outcome token decimals are fixed at 7 and that mint/burn amounts work correctly at that scale.

**New tests added:**
- `decimals_is_seven_sac_standard` — asserts `decimals() == 7`
- `mint_one_whole_token_at_sac_decimals` — 1 token = 10_000_000 base units
- `total_supply_accumulates_correctly_with_sac_amounts` — batch mints at SAC scale
- `burn_sac_amount_reduces_supply_exactly` — burn precision at 7 decimals

**Pre-existing compilation fixes (required to compile):**
- Add missing `ContractError` variants: `NoPendingMarketContractChange`, `TimelockNotElapsed`, `TransferBlockedAfterResolve`
- Fix `PendingAddressChange` import in `storage.rs`
- Replace broken `set_market_contract` test refs with timelock API
- Suppress dead_code on `TokenTransferred` event (transfer is intentionally blocked)
- Fix unused `mut` and unused variables caught by clippy

## Validation

`cargo test -p vatix-outcome-token-contract`: 28 passed, 0 failed
`cargo clippy -p vatix-outcome-token-contract -- -D warnings`: clean

Closes #728