### PR TITLE
test(outcome-token): add set_metadata admin require_auth tests

### DIFF
--- a/contracts/outcome-token/src/error.rs
+++ b/contracts/outcome-token/src/error.rs
@@ -21,4 +21,14 @@ pub enum ContractError {
     /// `mint`/`burn`/`transfer` against a stale on-chain layout after a
     /// partial cross-contract upgrade instead of silently corrupting balances.
     UpgradeRequired = 8,
+    /// `execute_market_contract` was called but no pending rotation exists.
+    NoPendingMarketContractChange = 9,
+    /// The timelock delay for a pending `market_contract` rotation has not
+    /// elapsed yet.
+    TimelockNotElapsed = 10,
+    /// A peer-to-peer `transfer` was attempted after the market resolved.
+    /// Post-resolution transfers are blocked because settlement pays out
+    /// against the original depositor's position record, not the current
+    /// token holder (Issue #690).
+    TransferBlockedAfterResolve = 11,
 }

--- a/contracts/outcome-token/src/events.rs
+++ b/contracts/outcome-token/src/events.rs
@@ -100,6 +100,7 @@ pub fn emit_market_contract_set(env: &Env, market_contract: &Address) {
 
 #[contractevent]
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub struct TokenTransferred {
     #[topic]
     pub market_id: u32,
@@ -110,6 +111,7 @@ pub struct TokenTransferred {
     pub amount: i128,
 }
 
+#[allow(dead_code)]
 pub fn emit_token_transferred(
     env: &Env,
     market_id: u32,

--- a/contracts/outcome-token/src/lib.rs
+++ b/contracts/outcome-token/src/lib.rs
@@ -83,7 +83,7 @@ impl OutcomeTokenContract {
     ) -> Result<(), ContractError> {
         admin.require_auth();
         storage::assert_version(&env)?;
-        let mut config = storage::get_config(&env);
+        let config = storage::get_config(&env);
         if admin != config.admin {
             return Err(ContractError::Unauthorized);
         }
@@ -260,8 +260,8 @@ impl OutcomeTokenContract {
         env: Env,
         market_id: u32,
         from: Address,
-        to: Address,
-        kind: TokenKind,
+        _to: Address,
+        _kind: TokenKind,
         amount: i128,
     ) -> Result<(), ContractError> {
         if amount <= 0 {

--- a/contracts/outcome-token/src/storage.rs
+++ b/contracts/outcome-token/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::error::ContractError;
-use crate::types::{OutcomeTokenConfig, TokenKind};
+use crate::types::{OutcomeTokenConfig, PendingAddressChange, TokenKind};
 use soroban_sdk::{contracttype, Address, Env};
 
 /// Bump this constant whenever the outcome-token storage layout changes in a

--- a/contracts/outcome-token/src/test.rs
+++ b/contracts/outcome-token/src/test.rs
@@ -1,7 +1,7 @@
 use crate::types::TokenKind;
 use crate::{ContractError, OutcomeTokenContract, OutcomeTokenContractClient};
 use soroban_sdk::{
-    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
     Address, Env, IntoVal, String,
 };
 
@@ -79,6 +79,104 @@ fn non_admin_cannot_update_metadata() {
     let s = String::from_str(&env, "BAD");
     assert_eq!(
         client.try_set_metadata(&stranger, &n, &s),
+        Err(Ok(ContractError::Unauthorized))
+    );
+}
+
+// ── set_metadata require_auth (#729) ─────────────────────────────────────────
+//
+// The tests above run under `mock_all_auths()`, so `admin.require_auth()`
+// inside `set_metadata` always succeeds unconditionally — they don't verify
+// the auth gate itself. The tests below build their own environment without
+// blanket auth mocking so the gate is genuinely exercised.
+
+fn setup_unmocked_metadata(
+    env: &Env,
+) -> (OutcomeTokenContractClient<'_>, Address, Address, Address) {
+    let contract_id = env.register(OutcomeTokenContract, ());
+    let client = OutcomeTokenContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let market_contract = Address::generate(env);
+    let name = String::from_str(env, "Vatix YES Token");
+    let symbol = String::from_str(env, "vYES");
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "initialize",
+            args: (&admin, &market_contract, &name, &symbol).into_val(env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.initialize(&admin, &market_contract, &name, &symbol);
+
+    (client, admin, market_contract, contract_id)
+}
+
+/// `set_metadata` must succeed when called with a valid authorization from
+/// the registered admin address.
+#[test]
+fn set_metadata_succeeds_when_authorized_by_admin() {
+    let env = Env::default();
+    let (client, admin, _market, contract_id) = setup_unmocked_metadata(&env);
+
+    let new_name = String::from_str(&env, "Vatix NO Token");
+    let new_symbol = String::from_str(&env, "vNO");
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "set_metadata",
+            args: (&admin, &new_name, &new_symbol).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.set_metadata(&admin, &new_name, &new_symbol);
+
+    assert_eq!(client.name(), new_name);
+    assert_eq!(client.symbol(), new_symbol);
+}
+
+/// `set_metadata` must panic when called without any authorization — no
+/// address has been mocked, so `admin.require_auth()` cannot be satisfied.
+/// This is the "external EOA cannot update metadata" acceptance criterion.
+#[test]
+#[should_panic]
+fn set_metadata_panics_without_admin_authorization() {
+    let env = Env::default();
+    let (client, admin, _market, _contract_id) = setup_unmocked_metadata(&env);
+
+    let new_name = String::from_str(&env, "Hack");
+    let new_symbol = String::from_str(&env, "HCK");
+
+    // No auths are mocked — `admin.require_auth()` inside `set_metadata`
+    // has nothing to satisfy it with, so this must panic.
+    client.set_metadata(&admin, &new_name, &new_symbol);
+}
+
+/// A non-admin address passing its own auth cannot update metadata — the
+/// contract checks `admin != config.admin` after `require_auth()`.
+#[test]
+fn set_metadata_rejects_non_admin_with_own_auth() {
+    let env = Env::default();
+    let (client, _admin, _market, contract_id) = setup_unmocked_metadata(&env);
+    let stranger = Address::generate(&env);
+    let new_name = String::from_str(&env, "Bad");
+    let new_symbol = String::from_str(&env, "BAD");
+
+    env.mock_auths(&[MockAuth {
+        address: &stranger,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "set_metadata",
+            args: (&stranger, &new_name, &new_symbol).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    assert_eq!(
+        client.try_set_metadata(&stranger, &new_name, &new_symbol),
         Err(Ok(ContractError::Unauthorized))
     );
 }
@@ -328,26 +426,34 @@ fn balances_are_isolated_across_markets() {
     assert_eq!(client.total_supply(&2, &TokenKind::Yes), 200);
 }
 
-// ── set_market_contract ─────────────────────────────────────────────────────
+// ── propose/execute market_contract (timelock) ──────────────────────────────
 
 #[test]
-fn admin_can_update_market_contract() {
+fn admin_can_propose_and_execute_market_contract() {
     let env = Env::default();
+    env.mock_all_auths();
     let (client, admin, _old_market) = setup(&env);
     let new_market = Address::generate(&env);
 
-    client.set_market_contract(&admin, &new_market);
+    client.propose_market_contract(&admin, &new_market);
+
+    // Advance time past the timelock.
+    env.ledger()
+        .set_timestamp(OutcomeTokenContract::MARKET_CONTRACT_TIMELOCK_SECONDS + 1);
+
+    let applied = client.execute_market_contract();
+    assert_eq!(applied, new_market);
     assert_eq!(client.get_config().market_contract, new_market);
 }
 
 #[test]
-fn non_admin_cannot_update_market_contract() {
+fn non_admin_cannot_propose_market_contract() {
     let env = Env::default();
     let (client, _admin, _market) = setup(&env);
     let stranger = Address::generate(&env);
     let new_market = Address::generate(&env);
     assert_eq!(
-        client.try_set_market_contract(&stranger, &new_market),
+        client.try_propose_market_contract(&stranger, &new_market),
         Err(Ok(ContractError::Unauthorized))
     );
 }


### PR DESCRIPTION
## Summary

Add unmocked authorization tests for `set_metadata` that genuinely exercise the `admin.require_auth()` gate — existing tests used `mock_all_auths()` which bypasses auth checks.

**New tests added:**
- `set_metadata_succeeds_when_authorized_by_admin` — scoped `MockAuth` for the admin; asserts name/symbol update
- `set_metadata_panics_without_admin_authorization` — no mocked auth; asserts `#[should_panic]`
- `set_metadata_rejects_non_admin_with_own_auth` — stranger with own auth returns `ContractError::Unauthorized`

**Pre-existing compilation fixes (required to compile):**
- Add missing `ContractError` variants: `NoPendingMarketContractChange`, `TimelockNotElapsed`, `TransferBlockedAfterResolve`
- Fix `PendingAddressChange` import in `storage.rs`
- Replace broken `set_market_contract` test refs with timelock API
- Suppress dead_code on `TokenTransferred`, fix clippy warnings

## Validation

`cargo test -p vatix-outcome-token-contract`: 27 passed, 0 failed
`cargo clippy -p vatix-outcome-token-contract -- -D warnings`: clean

Closes #729