### PR TITLE
test(outcome-token): add mint/burn market-contract-only auth tests

### DIFF
--- a/contracts/outcome-token/src/error.rs
+++ b/contracts/outcome-token/src/error.rs
@@ -21,4 +21,14 @@ pub enum ContractError {
     /// `mint`/`burn`/`transfer` against a stale on-chain layout after a
     /// partial cross-contract upgrade instead of silently corrupting balances.
     UpgradeRequired = 8,
+    /// `execute_market_contract` was called but no pending rotation exists.
+    NoPendingMarketContractChange = 9,
+    /// The timelock delay for a pending `market_contract` rotation has not
+    /// elapsed yet.
+    TimelockNotElapsed = 10,
+    /// A peer-to-peer `transfer` was attempted after the market resolved.
+    /// Post-resolution transfers are blocked because settlement pays out
+    /// against the original depositor's position record, not the current
+    /// token holder (Issue #690).
+    TransferBlockedAfterResolve = 11,
 }

--- a/contracts/outcome-token/src/events.rs
+++ b/contracts/outcome-token/src/events.rs
@@ -100,6 +100,7 @@ pub fn emit_market_contract_set(env: &Env, market_contract: &Address) {
 
 #[contractevent]
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub struct TokenTransferred {
     #[topic]
     pub market_id: u32,
@@ -110,6 +111,7 @@ pub struct TokenTransferred {
     pub amount: i128,
 }
 
+#[allow(dead_code)]
 pub fn emit_token_transferred(
     env: &Env,
     market_id: u32,

--- a/contracts/outcome-token/src/lib.rs
+++ b/contracts/outcome-token/src/lib.rs
@@ -83,7 +83,7 @@ impl OutcomeTokenContract {
     ) -> Result<(), ContractError> {
         admin.require_auth();
         storage::assert_version(&env)?;
-        let mut config = storage::get_config(&env);
+        let config = storage::get_config(&env);
         if admin != config.admin {
             return Err(ContractError::Unauthorized);
         }
@@ -260,8 +260,8 @@ impl OutcomeTokenContract {
         env: Env,
         market_id: u32,
         from: Address,
-        to: Address,
-        kind: TokenKind,
+        _to: Address,
+        _kind: TokenKind,
         amount: i128,
     ) -> Result<(), ContractError> {
         if amount <= 0 {

--- a/contracts/outcome-token/src/storage.rs
+++ b/contracts/outcome-token/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::error::ContractError;
-use crate::types::{OutcomeTokenConfig, TokenKind};
+use crate::types::{OutcomeTokenConfig, PendingAddressChange, TokenKind};
 use soroban_sdk::{contracttype, Address, Env};
 
 /// Bump this constant whenever the outcome-token storage layout changes in a

--- a/contracts/outcome-token/src/test.rs
+++ b/contracts/outcome-token/src/test.rs
@@ -1,7 +1,7 @@
 use crate::types::TokenKind;
 use crate::{ContractError, OutcomeTokenContract, OutcomeTokenContractClient};
 use soroban_sdk::{
-    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
     Address, Env, IntoVal, String,
 };
 
@@ -328,26 +328,107 @@ fn balances_are_isolated_across_markets() {
     assert_eq!(client.total_supply(&2, &TokenKind::Yes), 200);
 }
 
-// ── set_market_contract ─────────────────────────────────────────────────────
+// ── propose/execute market_contract (timelock) ──────────────────────────────
 
 #[test]
-fn admin_can_update_market_contract() {
+fn admin_can_propose_and_execute_market_contract() {
     let env = Env::default();
+    env.mock_all_auths();
     let (client, admin, _old_market) = setup(&env);
     let new_market = Address::generate(&env);
 
-    client.set_market_contract(&admin, &new_market);
+    client.propose_market_contract(&admin, &new_market);
+
+    // Advance time past the timelock.
+    env.ledger()
+        .set_timestamp(OutcomeTokenContract::MARKET_CONTRACT_TIMELOCK_SECONDS + 1);
+
+    let applied = client.execute_market_contract();
+    assert_eq!(applied, new_market);
     assert_eq!(client.get_config().market_contract, new_market);
 }
 
 #[test]
-fn non_admin_cannot_update_market_contract() {
+fn non_admin_cannot_propose_market_contract() {
     let env = Env::default();
     let (client, _admin, _market) = setup(&env);
     let stranger = Address::generate(&env);
     let new_market = Address::generate(&env);
     assert_eq!(
-        client.try_set_market_contract(&stranger, &new_market),
+        client.try_propose_market_contract(&stranger, &new_market),
         Err(Ok(ContractError::Unauthorized))
     );
+}
+
+// ── mint/burn market_contract-only gate (#730) ───────────────────────────────
+//
+// The tests in the "mint/burn authorization" section above confirm that the
+// registered market_contract address can authorize mint/burn, and that
+// callers with no auth at all are rejected. The tests below extend coverage
+// to the "only the *registered* contract" requirement: an address that is not
+// the registered market_contract must be rejected even if it presents its
+// own valid authorization.
+
+/// A stranger address providing its own auth must be rejected by mint — only
+/// the registered market_contract address can satisfy the gate.
+#[test]
+fn mint_rejected_when_wrong_address_is_authorized() {
+    let env = Env::default();
+    let (client, _admin, _market_contract, contract_id) = setup_unmocked(&env);
+    let user = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    // The stranger presents valid auth for *itself* but is not the registered
+    // market contract — `config.market_contract.require_auth()` will fail.
+    env.mock_auths(&[MockAuth {
+        address: &stranger,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "mint",
+            args: (&1u32, &user, &TokenKind::Yes, &100i128).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    // try_mint must return an auth error, not succeed.
+    assert!(client
+        .try_mint(&1, &user, &TokenKind::Yes, &100)
+        .is_err());
+}
+
+/// A stranger address providing its own auth must be rejected by burn — only
+/// the registered market_contract can authorize burn operations.
+#[test]
+fn burn_rejected_when_wrong_address_is_authorized() {
+    let env = Env::default();
+    let (client, _admin, market_contract, contract_id) = setup_unmocked(&env);
+    let user = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    // Fund user via the legitimate market_contract.
+    env.mock_auths(&[MockAuth {
+        address: &market_contract,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "mint",
+            args: (&1u32, &user, &TokenKind::Yes, &500i128).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.mint(&1, &user, &TokenKind::Yes, &500);
+
+    // Stranger presents its own auth — must be rejected.
+    env.mock_auths(&[MockAuth {
+        address: &stranger,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "burn",
+            args: (&1u32, &user, &TokenKind::Yes, &100i128).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    assert!(client
+        .try_burn(&1, &user, &TokenKind::Yes, &100)
+        .is_err());
+    // Balance must be unchanged — the rejected burn must not have taken effect.
+    assert_eq!(client.balance(&1, &user, &TokenKind::Yes), 500);
 }


### PR DESCRIPTION
## Summary

Add unmocked authorization tests that verify mint and burn can only be called by the registered `market_contract` address — an external EOA or any other address is rejected even with valid self-authorization.

**New tests added:**
- `mint_rejected_when_wrong_address_is_authorized` — stranger with its own `MockAuth` is rejected; `try_mint` returns an error
- `burn_rejected_when_wrong_address_is_authorized` — same for burn; balance unchanged after rejection

The four core unmocked tests already in the file were not running due to pre-existing compilation errors. This PR also fixes those errors so all unmocked mint/burn auth coverage is now active:
- `mint_succeeds_when_authorized_by_market_contract`
- `mint_fails_without_market_contract_authorization`
- `burn_succeeds_when_authorized_by_market_contract`
- `burn_fails_without_market_contract_authorization`

**Pre-existing compilation fixes:**
- Add missing `ContractError` variants: `NoPendingMarketContractChange`, `TimelockNotElapsed`, `TransferBlockedAfterResolve`
- Fix `PendingAddressChange` import in `storage.rs`
- Replace broken `set_market_contract` test refs with timelock API
- Suppress dead_code on `TokenTransferred`, fix clippy warnings

## Validation

`cargo test -p vatix-outcome-token-contract`: 26 passed, 0 failed
`cargo clippy -p vatix-outcome-token-contract -- -D warnings`: clean

Closes #730