### PR TITLE
fix: resolve #752-#755 — resolution audit getters, bond tests, finali…

### DIFF
--- a/AUTH_TABLE.md
+++ b/AUTH_TABLE.md
@@ -93,6 +93,47 @@ not an admin check. `propose_v2` (#701) is the V2-oracle counterpart of
 `propose`: same access model, verified via the market contract's
 `verify_signature_v2` instead of the legacy `verify_signature`.
 
+### #754 — `finalize` keeper model
+
+`finalize(finalizer, candidate_id)` uses the **open-caller / keeper model**:
+*any* address may call it once the challenge window has closed, not just the
+admin or factory. The caller must still provide a valid `require_auth()`
+authorization for their own address, but no additional role check is applied —
+the only effective guards are the challenge-window deadline and the
+`CandidateStatus::Proposed` state check. This is intentional: backend oracle
+services, off-chain keepers, or the proposer themselves can all trigger
+finalization; restricting finalize to a single admin address would create a
+single point of failure for market settlement. Regression tests in
+`test.rs::finalize_accepts_any_authenticated_caller` verify this invariant.
+
+### #753 — Bond denomination constants
+
+Both bond floors are `10_000_000 stroops` (1 XLM). Any caller may read the
+values via `crate::MIN_BOND_AMOUNT` / `crate::MIN_CHALLENGE_BOND_AMOUNT` (both
+`pub const`). The regression test `bond_constants_match_documented_minimum` in
+`test.rs` will fail CI if either constant is accidentally changed, preventing
+silent re-introduction of free-spam attacks.
+
+### #752 — Dedicated address getters
+
+`get_factory(env) -> Address`, `get_market_contract(env) -> Address`, and
+`get_admin(env) -> Address` are read-only getters that return individual fields
+from `ResolutionConfig`. They complement `get_config()` and allow backend
+oracle services to discover registered addresses without deserializing the full
+config struct. All three are out of scope for this auth table (no mutation,
+no auth required).
+
+### #755 — `market_id` type bridge (`u32` → `String`)
+
+The resolution contract stores `market_id` as `u32` internally (natural for
+an auto-increment counter keyed by `StorageKey::CandidateByMarket(u32)`). The
+market contract's `resolve_market` entrypoint takes `market_id: String`
+(forward-compatible with non-numeric IDs). The private `market_id_to_string`
+helper converts `u32 → base-10 decimal String` before the cross-contract call.
+Regression tests `finalize_passes_market_id_as_decimal_string_to_resolve_market`
+and `finalize_passes_market_id_zero_as_string` in `test.rs` assert the
+conversion is correct, locking in the ABI bridge against future refactors.
+
 ## Outcome-token contract (`contracts/outcome-token/src/lib.rs`)
 
 Not previously covered by this table at all — added by this pass.

--- a/contracts/resolution/src/lib.rs
+++ b/contracts/resolution/src/lib.rs
@@ -77,14 +77,14 @@ const MAX_APPEAL_ROUNDS: u32 = 3;
 /// Minimum bond a proposer must post (in the market's collateral token,
 /// stroops) when calling `propose`. Locked in this contract and refunded on
 /// successful finalize.
-const MIN_BOND_AMOUNT: i128 = 10_000_000;
+pub const MIN_BOND_AMOUNT: i128 = 10_000_000;
 
 /// Minimum bond a challenger must post (in the market's collateral token,
 /// stroops) when calling `challenge`. Locked in this contract alongside the
 /// proposer's bond. Requiring a bond (rather than a free challenge) is what
 /// makes griefing — repeatedly challenging to indefinitely delay resolution
 /// — economically costly instead of free.
-const MIN_CHALLENGE_BOND_AMOUNT: i128 = 10_000_000;
+pub const MIN_CHALLENGE_BOND_AMOUNT: i128 = 10_000_000;
 
 /// Delay, in seconds, that must elapse after a candidate's last challenge
 /// deadline before admin arbitration (`arbitrate_uphold_proposer`) or
@@ -192,6 +192,30 @@ impl ResolutionContract {
 
     pub fn get_config(env: Env) -> ResolutionConfig {
         storage::get_config(&env)
+    }
+
+    /// Return the registered factory address (#752).
+    ///
+    /// The factory is stored in `ResolutionConfig` at `initialize` time and
+    /// may later be rotated via the `propose_factory` / `execute_factory`
+    /// timelock. Backend oracle services need a direct getter rather than
+    /// deserializing the full `ResolutionConfig` struct, both for
+    /// convenience and because the full config type may grow over time.
+    pub fn get_factory(env: Env) -> Address {
+        storage::get_config(&env).factory
+    }
+
+    /// Return the registered market contract address.
+    ///
+    /// Symmetric to [`get_factory`] — backend services that manage the
+    /// resolution→market relationship need both addresses independently.
+    pub fn get_market_contract(env: Env) -> Address {
+        storage::get_config(&env).market_contract
+    }
+
+    /// Return the registered admin address.
+    pub fn get_admin(env: Env) -> Address {
+        storage::get_config(&env).admin
     }
 
     pub const ADDRESS_TIMELOCK_SECONDS: u64 = 172_800;

--- a/contracts/resolution/src/test.rs
+++ b/contracts/resolution/src/test.rs
@@ -1277,3 +1277,466 @@ fn appeal_rejects_v2_candidate() {
         .unwrap();
     assert_eq!(err, ContractError::Unauthorized);
 }
+
+// ── #752: get_factory / get_market_contract / get_admin getters ───────────
+
+/// `get_factory` returns the factory address registered at `initialize`.
+/// Regression: if the getter were removed or accidentally pointed at
+/// `config.market_contract`, this test would catch it.
+#[test]
+fn get_factory_returns_registered_factory() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ResolutionContract, ());
+    let client = ResolutionContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let factory = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    use mock_market::{MockMarket, MockMarketClient};
+    let market_id_contract = env.register(MockMarket, ());
+    MockMarketClient::new(&env, &market_id_contract).init(&token);
+
+    client.initialize(&admin, &factory, &market_id_contract, &300u64);
+
+    // The factory returned by the dedicated getter must match what was passed
+    // to initialize.
+    assert_eq!(client.get_factory(), factory);
+    // The market contract getter must also match.
+    assert_eq!(client.get_market_contract(), market_id_contract);
+    // The admin getter must match.
+    assert_eq!(client.get_admin(), admin);
+}
+
+/// After `execute_factory` rotates the factory address, `get_factory` must
+/// return the new address — confirming the getter always reads live storage.
+#[test]
+fn get_factory_reflects_update_after_execute_factory() {
+    let env = Env::default();
+    let (client, admin, _, _) = setup(&env);
+    set_time(&env, 1_000);
+
+    let new_factory = Address::generate(&env);
+
+    // Propose a factory rotation (admin must authorize).
+    client.propose_factory(&admin, &new_factory);
+
+    // Advance time past the 48 h timelock.
+    set_time(&env, 1_000 + 172_800 + 1);
+
+    // Execute the pending rotation — no auth required once time has elapsed.
+    let returned = client.execute_factory();
+    assert_eq!(returned, new_factory);
+
+    // get_factory must now return the newly registered address.
+    assert_eq!(client.get_factory(), new_factory);
+}
+
+// ── #753: Challenge bond denomination and minimum amount tests ────────────
+
+/// `propose` with bond exactly at `MIN_BOND_AMOUNT` succeeds.
+/// This locks the specific constant value into the test so any accidental
+/// increase or decrease to the constant causes a test failure.
+#[test]
+fn propose_bond_at_exact_minimum_succeeds() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    // Fund exactly the minimum — any less and the propose must fail.
+    fund(&env, &token, &proposer, BOND);
+
+    let candidate_id = client.propose(
+        &proposer,
+        &1u32,
+        &true,
+        &signature(&env),
+        &(env.ledger().timestamp() + 600),
+        &evidence(&env),
+        &300u64,
+        &BOND,
+    );
+    assert!(candidate_id >= 1);
+}
+
+/// `propose` with bond one stroop below `MIN_BOND_AMOUNT` is rejected with
+/// `InsufficientBond`. Zero-bond proposals must be impossible — they would
+/// make griefing resolution free.
+#[test]
+fn propose_bond_below_minimum_rejected() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+
+    let err = client
+        .try_propose(
+            &proposer,
+            &1u32,
+            &true,
+            &signature(&env),
+            &(env.ledger().timestamp() + 600),
+            &evidence(&env),
+            &300u64,
+            &(BOND - 1),
+        )
+        .unwrap_err()
+        .unwrap();
+    use crate::ContractError;
+    assert_eq!(err, ContractError::InsufficientBond);
+}
+
+/// `propose` with a zero bond is rejected with `InsufficientBond`.
+/// Free proposals would let anyone spam resolution with unresolvable
+/// candidates at no cost.
+#[test]
+fn propose_zero_bond_rejected() {
+    let env = Env::default();
+    let (client, _, _, _token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    // No funding needed — the bond check fires before any token transfer.
+
+    let err = client
+        .try_propose(
+            &proposer,
+            &1u32,
+            &true,
+            &signature(&env),
+            &(env.ledger().timestamp() + 600),
+            &evidence(&env),
+            &300u64,
+            &0i128,
+        )
+        .unwrap_err()
+        .unwrap();
+    use crate::ContractError;
+    assert_eq!(err, ContractError::InsufficientBond);
+}
+
+/// `challenge` with bond exactly at `MIN_CHALLENGE_BOND_AMOUNT` succeeds.
+#[test]
+fn challenge_bond_at_exact_minimum_succeeds() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer,
+        &1u32,
+        &true,
+        &signature(&env),
+        &(env.ledger().timestamp() + 600),
+        &evidence(&env),
+        &300u64,
+        &BOND,
+    );
+
+    let challenger = Address::generate(&env);
+    // Fund exactly the minimum challenge bond.
+    fund(&env, &token, &challenger, BOND);
+
+    // Should succeed — exact minimum bond is accepted.
+    client.challenge(&challenger, &candidate_id, &evidence(&env), &BOND);
+
+    let candidate = client.get_candidate(&candidate_id).unwrap();
+    use crate::types::CandidateStatus;
+    assert_eq!(candidate.status, CandidateStatus::Challenged);
+}
+
+/// `challenge` with bond one stroop below `MIN_CHALLENGE_BOND_AMOUNT` is
+/// rejected with `InsufficientChallengeBond`. Zero-bond challenges must be
+/// impossible — they would make spam challenges free.
+#[test]
+fn challenge_bond_below_minimum_rejected() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer,
+        &1u32,
+        &true,
+        &signature(&env),
+        &(env.ledger().timestamp() + 600),
+        &evidence(&env),
+        &300u64,
+        &BOND,
+    );
+
+    let challenger = Address::generate(&env);
+    fund(&env, &token, &challenger, BOND);
+
+    let err = client
+        .try_challenge(&challenger, &candidate_id, &evidence(&env), &(BOND - 1))
+        .unwrap_err()
+        .unwrap();
+    use crate::ContractError;
+    assert_eq!(err, ContractError::InsufficientChallengeBond);
+}
+
+/// `challenge` with a zero bond is rejected with `InsufficientChallengeBond`.
+#[test]
+fn challenge_zero_bond_rejected() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer,
+        &1u32,
+        &true,
+        &signature(&env),
+        &(env.ledger().timestamp() + 600),
+        &evidence(&env),
+        &300u64,
+        &BOND,
+    );
+
+    let challenger = Address::generate(&env);
+
+    let err = client
+        .try_challenge(&challenger, &candidate_id, &evidence(&env), &0i128)
+        .unwrap_err()
+        .unwrap();
+    use crate::ContractError;
+    assert_eq!(err, ContractError::InsufficientChallengeBond);
+}
+
+/// Bond denomination regression: `MIN_BOND_AMOUNT` and
+/// `MIN_CHALLENGE_BOND_AMOUNT` must both equal 10_000_000 stroops (the
+/// documented minimum). Any accidental reduction to these constants would
+/// be caught here before it reaches mainnet, re-enabling free-spam attacks.
+#[test]
+fn bond_constants_match_documented_minimum() {
+    // 10_000_000 stroops == 1 XLM. This is the absolute floor documented
+    // in the contract spec. If either constant is changed, this test fails
+    // and forces an explicit, conscious decision rather than a silent drift.
+    assert_eq!(
+        crate::MIN_BOND_AMOUNT, 10_000_000,
+        "MIN_BOND_AMOUNT must be 10_000_000 stroops (1 XLM)"
+    );
+    assert_eq!(
+        crate::MIN_CHALLENGE_BOND_AMOUNT, 10_000_000,
+        "MIN_CHALLENGE_BOND_AMOUNT must be 10_000_000 stroops (1 XLM)"
+    );
+}
+
+// ── #754: finalize open-caller model regression tests ────────────────────
+
+/// `finalize` accepts *any* authenticated address as the `finalizer` —
+/// it is not restricted to admin or factory. This "keeper" model means any
+/// external service can trigger finalization once the challenge window
+/// closes; the bond/window conditions are the access control, not caller
+/// identity. This test documents and locks in that behavior so a future
+/// auth hardening pass does not accidentally break third-party keeper bots.
+#[test]
+fn finalize_accepts_any_authenticated_caller() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer,
+        &1u32,
+        &true,
+        &signature(&env),
+        &(env.ledger().timestamp() + 10_000),
+        &evidence(&env),
+        &DEFAULT_WINDOW,
+        &BOND,
+    );
+
+    // Advance past the challenge window.
+    set_time(&env, 1_000 + DEFAULT_WINDOW + 1);
+
+    // A completely unrelated address — not admin, not factory, not proposer
+    // — should be able to call finalize once the window closes.
+    let random_keeper = Address::generate(&env);
+    let finalized = client.finalize(&random_keeper, &candidate_id);
+    use crate::types::CandidateStatus;
+    assert_eq!(finalized.status, CandidateStatus::Finalized);
+}
+
+/// `finalize` is still protected by `require_auth` on the finalizer: a
+/// second call to `finalize` on the same candidate fails with
+/// `CandidateAlreadyFinalized`, confirming the exactly-once guarantee.
+#[test]
+fn finalize_rejects_double_finalize() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer,
+        &1u32,
+        &true,
+        &signature(&env),
+        &(env.ledger().timestamp() + 10_000),
+        &evidence(&env),
+        &DEFAULT_WINDOW,
+        &BOND,
+    );
+
+    set_time(&env, 1_000 + DEFAULT_WINDOW + 1);
+
+    let keeper = Address::generate(&env);
+    client.finalize(&keeper, &candidate_id);
+
+    // Second finalize on the already-settled candidate must fail.
+    let err = client
+        .try_finalize(&keeper, &candidate_id)
+        .unwrap_err()
+        .unwrap();
+    use crate::ContractError;
+    assert_eq!(err, ContractError::CandidateAlreadyFinalized);
+}
+
+/// `finalize` called while the challenge window is still open must fail
+/// with `ChallengeWindowOpen` regardless of who the caller is.
+#[test]
+fn finalize_rejected_before_window_closes() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+    let candidate_id = client.propose(
+        &proposer,
+        &1u32,
+        &true,
+        &signature(&env),
+        &(env.ledger().timestamp() + 10_000),
+        &evidence(&env),
+        &DEFAULT_WINDOW,
+        &BOND,
+    );
+
+    // Still inside the window — finalize must be rejected.
+    set_time(&env, 1_000 + DEFAULT_WINDOW - 1);
+
+    let keeper = Address::generate(&env);
+    let err = client
+        .try_finalize(&keeper, &candidate_id)
+        .unwrap_err()
+        .unwrap();
+    use crate::ContractError;
+    assert_eq!(err, ContractError::ChallengeWindowOpen);
+}
+
+// ── #755: market_id type consistency documentation test ──────────────────
+
+/// `finalize` must pass `market_id` as a base-10 decimal `String` to
+/// `resolve_market`, not as a raw `u32`. The `market_id_to_string` helper
+/// (internal to `lib.rs`) converts the resolution contract's `u32`
+/// `market_id` to the `String` that `Market::resolve_market` expects.
+///
+/// This is the documented ABI mismatch (#683, #755): the resolution
+/// contract stores `market_id` as `u32` (natural for a counter) while the
+/// market contract's `resolve_market` entrypoint takes `market_id: String`
+/// (to allow non-numeric IDs in the future). The bridge is
+/// `market_id_to_string` — this test proves it works correctly by
+/// asserting that the mock market's `LastResolvedCall.market_id` field
+/// equals the decimal string of the numeric ID passed to `propose`.
+#[test]
+fn finalize_passes_market_id_as_decimal_string_to_resolve_market() {
+    let env = Env::default();
+    let (client, _, market_contract_addr, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+
+    // Use a non-trivial market_id so "42" → "42" conversion is meaningful.
+    let numeric_market_id: u32 = 42;
+    let candidate_id = client.propose(
+        &proposer,
+        &numeric_market_id,
+        &true,
+        &signature(&env),
+        &(env.ledger().timestamp() + 10_000),
+        &evidence(&env),
+        &DEFAULT_WINDOW,
+        &BOND,
+    );
+
+    set_time(&env, 1_000 + DEFAULT_WINDOW + 1);
+
+    let keeper = Address::generate(&env);
+    client.finalize(&keeper, &candidate_id);
+
+    // Query the mock market to confirm what resolve_market received.
+    let last = mock_market::MockMarketClient::new(&env, &market_contract_addr)
+        .get_last_resolved()
+        .expect("resolve_market should have been called");
+
+    // The market_id must have arrived as the decimal string "42", not as a
+    // raw u32 (which would be a different Soroban ScVal type and would fail
+    // the real market contract's `parse_market_id` validation).
+    assert_eq!(
+        last.market_id,
+        soroban_sdk::String::from_str(&env, "42"),
+        "finalize must pass market_id as decimal string to resolve_market"
+    );
+    assert_eq!(last.outcome, true);
+    assert_eq!(last.is_v2, false);
+}
+
+/// `market_id_to_string` edge case: market_id == 0 must produce "0", not
+/// an empty string. This prevents an edge-case panic or silent mismatch
+/// if market 0 is ever used.
+#[test]
+fn finalize_passes_market_id_zero_as_string() {
+    let env = Env::default();
+    let (client, _, market_contract_addr, token) = setup(&env);
+    set_time(&env, 1_000);
+
+    let proposer = Address::generate(&env);
+    fund(&env, &token, &proposer, BOND);
+
+    let candidate_id = client.propose(
+        &proposer,
+        &0u32,
+        &true,
+        &signature(&env),
+        &(env.ledger().timestamp() + 10_000),
+        &evidence(&env),
+        &DEFAULT_WINDOW,
+        &BOND,
+    );
+
+    set_time(&env, 1_000 + DEFAULT_WINDOW + 1);
+
+    let keeper = Address::generate(&env);
+    client.finalize(&keeper, &candidate_id);
+
+    let last = mock_market::MockMarketClient::new(&env, &market_contract_addr)
+        .get_last_resolved()
+        .expect("resolve_market should have been called");
+
+    assert_eq!(
+        last.market_id,
+        soroban_sdk::String::from_str(&env, "0"),
+        "market_id 0 must be passed as string \"0\""
+    );
+}

--- a/docs/events-reference.md
+++ b/docs/events-reference.md
@@ -87,6 +87,33 @@ events additionally carry a `version: u32 (topic)` field
 | `emergency_mode_changed` | `new_mode: EmergencyMode (topic)`, `admin: Address`, `changed_at: u64` | Admin changes the mirrored emergency mode (`set_emergency_mode`), coordinated with the Market and Treasury contracts (#662, wired up for resolution by #701) |
 | `market_voided` | `candidate_id: u32 (topic)`, `market_id: u32 (topic)`, `voided_at: u64` | Resolution `void_market` runs: the proposer's bond is split/slashed, challengers are refunded, and the market contract's `void_market` is invoked to move the market to `Canceled` (Issue #708). The market contract emits its own `market_voided` for the status transition. |
 
+### Resolution ABI notes for off-chain indexers
+
+- **#752 — Address getters**: `get_factory()`, `get_market_contract()`, and
+  `get_admin()` are read-only view functions added as dedicated address getters
+  (Issue #752). They complement `get_config()` for backends that need a single
+  field without deserializing the full `ResolutionConfig` struct. No events are
+  emitted by these calls.
+
+- **#754 — `finalize` caller model**: `finalize(finalizer, candidate_id)` is an
+  **open-caller / keeper** entrypoint. Any address may trigger finalization once
+  the challenge window closes. The `finalizer` address is authenticated via
+  `require_auth()` but is not checked against admin or factory — keepers,
+  off-chain bots, the proposer, or any other party may call it. The
+  `candidate_finalized` event does not include a `finalizer` field; if you need
+  to track who triggered finalization, index the authorizing signer from the
+  Soroban transaction envelope.
+
+- **#755 — `market_id` type bridge**: The resolution contract stores
+  `market_id` as `u32` internally (auto-increment counter). When calling
+  `resolve_market` on the market contract, the value is converted to its
+  base-10 decimal `String` representation (e.g., `42u32` → `"42"`) via the
+  internal `market_id_to_string` helper. The `candidate_proposed` and
+  `candidate_finalized` events carry `market_id: u32` (the resolution
+  contract's native representation), while the market contract's
+  `market_resolved` event carries `market_id: u32` (the market contract's own
+  storage key, decoded from the string). Both are numerically equal.
+
 ## Outcome Token (`contracts/outcome-token/src/events.rs`)
 
 | Event/Topic | Fields (name: type) | Emitted When |

--- a/docs/reentrancy-cei-audit.md
+++ b/docs/reentrancy-cei-audit.md
@@ -78,3 +78,30 @@
 
 ### `collect_fee` (`treasury/src/lib.rs`) — No violation
 `collect_fee` never makes an external token call itself; the actual token movement happens on the caller's side (a market contract's fee-routing code, already covered by the `withdraw_unused_collateral` entry above) before it invokes `collect_fee` to record the accounting entry. There is nothing to reorder within this function.
+
+---
+
+## Issues #752–#755 — Resolution audit additions (no new CEI concerns)
+
+The following changes introduced by Issues #752–#755 carry no new reentrancy or
+CEI implications:
+
+- **#752 — `get_factory` / `get_market_contract` / `get_admin` getters**: Pure
+  storage reads; no external calls, no state writes, no CEI ordering concern.
+
+- **#753 — Bond constant visibility (`MIN_BOND_AMOUNT`, `MIN_CHALLENGE_BOND_AMOUNT`)**: The
+  constants were changed from `const` to `pub const`. No CEI impact. The bond
+  transfer in `propose` / `challenge` was already ordered after all state writes
+  (see §6 and §7 above); making the floor constants visible for testing does not
+  alter the ordering.
+
+- **#754 — `finalize` open-caller documentation**: No code change to `finalize`
+  itself. The existing implementation already uses the keeper model and is
+  already CEI-compliant (see table row above: "Already CEI-compliant — status
+  persisted and bond settlement computed before every external transfer").
+
+- **#755 — `market_id_to_string` ABI bridge documentation**: No code change.
+  The `market_id_to_string` helper is a pure string-formatting function with no
+  external calls or state writes. The cross-contract call to `resolve_market`
+  that consumes its output already runs after all state writes in `finalize`
+  and `arbitrate_uphold_proposer` (see CEI table above).

--- a/scripts/upgrade/UPGRADE_PLAYBOOK.md
+++ b/scripts/upgrade/UPGRADE_PLAYBOOK.md
@@ -146,6 +146,16 @@ new `<name>StorageVersion` alongside the others it's compatible with, in
 the same PR — exactly like the existing `STORAGE_MIGRATION_GUIDE.md`
 "Version History" convention.
 
+**Issues #752–#755 (Resolution audit additions):** These changes add
+`get_factory()`, `get_market_contract()`, and `get_admin()` read-only
+view getters to the Resolution contract; make `MIN_BOND_AMOUNT` /
+`MIN_CHALLENGE_BOND_AMOUNT` constants `pub` for test visibility; and add
+regression tests. **No storage layout change — `STORAGE_VERSION` stays
+at `1`** and the `version-matrix.json` entry is unaffected. The new
+getters are purely additive to the ABI; no existing callers need
+updating. The `expected-hashes.json` WASM hash for the Resolution contract
+must be updated after the next deployment with these changes.
+
 ## Dual-read migration for the next storage bump
 
 The next time market or treasury's `STORAGE_VERSION` needs to move forward


### PR DESCRIPTION
…ze docs, market_id type

#752 — Add get_factory(), get_market_contract(), get_admin() dedicated getters to ResolutionContract. Backend oracle services need these individually rather than deserializing the full ResolutionConfig struct. Tests:
  - get_factory_returns_registered_factory
  - get_factory_reflects_update_after_execute_factory

#753 — Make MIN_BOND_AMOUNT / MIN_CHALLENGE_BOND_AMOUNT pub const so tests can assert their values directly, and add regression tests that lock in 10_000_000 stroops as the floor for both proposer and challenger bonds. Zero-bond or sub-minimum proposals/challenges are rejected with InsufficientBond / InsufficientChallengeBond. Tests:
  - propose_bond_at_exact_minimum_succeeds
  - propose_bond_below_minimum_rejected
  - propose_zero_bond_rejected
  - challenge_bond_at_exact_minimum_succeeds
  - challenge_bond_below_minimum_rejected
  - challenge_zero_bond_rejected
  - bond_constants_match_documented_minimum

#754 — Document the finalize open-caller / keeper model in AUTH_TABLE.md: any authenticated address may trigger finalize once the challenge window closes; no admin/factory restriction. Regression tests:
  - finalize_accepts_any_authenticated_caller
  - finalize_rejects_double_finalize
  - finalize_rejected_before_window_closes

#755 — Document and test the u32->String market_id type bridge (market_id_to_string helper in lib.rs converts before the resolve_market cross-contract call). Tests assert the mock market receives '42' (not raw u32) and '0' is handled correctly:
  - finalize_passes_market_id_as_decimal_string_to_resolve_market
  - finalize_passes_market_id_zero_as_string

Docs updated: AUTH_TABLE.md, docs/events-reference.md, docs/reentrancy-cei-audit.md, scripts/upgrade/UPGRADE_PLAYBOOK.md. No storage layout change — STORAGE_VERSION stays at 1.
Close #755 
Closes #754 
Closes #753 
Closes #752